### PR TITLE
Add OSTreeRef and Arch field to Commit struct

### DIFF
--- a/pkg/commits/commits.go
+++ b/pkg/commits/commits.go
@@ -30,10 +30,12 @@ type Commit struct {
 	ImageBuildTarURL     string
 	OSTreeCommit         string
 	OSTreeParentCommit   string
+	OSTreeRef            string
 	BuildDate            string
 	BuildNumber          uint
 	BlueprintToml        string
 	NEVRAManifest        string
+	Arch                 string
 }
 
 func commitFromReadCloser(rc io.ReadCloser) (*Commit, error) {


### PR DESCRIPTION
We need to keep track of the ostree ref (such as rhel/x86_64/edge) which
will not change regardless of where the ostree remote is ultimately hosted.

Also we will need to keep track of the Arch to correlate a proper
candidate update image to a set of devices. This will also be useful for
ISO image creation.

Signed-off-by: Adam Miller <admiller@redhat.com>