### PR TITLE
blocking out some ideas for repo hosting

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,8 @@ type EdgeConfig struct {
 	Debug       bool
 	Database    *dbConfig
 	BucketName  string
+	AccessKey   string
+	SecretKey   string
 }
 
 type dbConfig struct {
@@ -76,6 +78,8 @@ func Init() {
 		}
 
 		config.BucketName = clowder.ObjectBuckets[config.BucketName].RequestedName
+		config.AccessKey = *cfg.ObjectStore.AccessKey
+		config.SecretKey = *cfg.ObjectStore.SecretKey
 
 		config.Logging = &loggingConfig{
 			AccessKeyID:     cfg.Logging.Cloudwatch.AccessKeyId,
@@ -83,6 +87,7 @@ func Init() {
 			LogGroup:        cfg.Logging.Cloudwatch.LogGroup,
 			Region:          cfg.Logging.Cloudwatch.Region,
 		}
+
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -51,9 +51,18 @@ func main() {
 	}
 
 	r.Get("/", common.StatusOK)
+
+	var server repo.Server
+	server = &repo.FileServer{
+		BasePath: "/tmp",
+	}
+	if cfg.BucketName != "" {
+		server = repo.NewS3Proxy()
+	}
+
 	r.Route("/api/edge/v1", func(s chi.Router) {
 		s.Route("/commits", commits.MakeRouter)
-		s.Route("/repos", repo.MakeRouter)
+		s.Route("/repos", repo.MakeRouter(server))
 	})
 
 	mr := chi.NewRouter()

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/redhatinsights/edge-api/pkg/commits"
 	"github.com/redhatinsights/edge-api/pkg/common"
 	"github.com/redhatinsights/edge-api/pkg/db"
+	"github.com/redhatinsights/edge-api/pkg/repo"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
@@ -50,7 +51,10 @@ func main() {
 	}
 
 	r.Get("/", common.StatusOK)
-	r.Route("/api/edge/v1/commits", commits.MakeRouter)
+	r.Route("/api/edge/v1", func(s chi.Router) {
+		s.Route("/commits", commits.MakeRouter)
+		s.Route("/repos", repo.MakeRouter)
+	})
 
 	mr := chi.NewRouter()
 	mr.Get("/", common.StatusOK)

--- a/pkg/commits/commits.go
+++ b/pkg/commits/commits.go
@@ -3,7 +3,6 @@ package commits
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -14,10 +13,8 @@ import (
 
 	"github.com/go-chi/chi"
 
-	"github.com/redhatinsights/edge-api/config"
 	"github.com/redhatinsights/edge-api/pkg/common"
 	"github.com/redhatinsights/edge-api/pkg/db"
-	"github.com/redhatinsights/platform-go-middlewares/identity"
 	"gorm.io/gorm"
 )
 
@@ -72,7 +69,7 @@ const commitKey key = 0
 func CommitCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var commit Commit
-		account, err := getAccount(r)
+		account, err := common.GetAccount(r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -94,20 +91,6 @@ func CommitCtx(next http.Handler) http.Handler {
 	})
 }
 
-func getAccount(r *http.Request) (string, error) {
-
-	if config.Get().Debug {
-		return "0000000", nil
-	}
-
-	ident := identity.Get(r.Context())
-	if ident.Identity.AccountNumber != "" {
-		return ident.Identity.AccountNumber, nil
-	}
-	return "", fmt.Errorf("cannot find account number")
-
-}
-
 // Add a commit object to the database for an account
 func Add(w http.ResponseWriter, r *http.Request) {
 
@@ -117,7 +100,7 @@ func Add(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	commit.Account, err = getAccount(r)
+	commit.Account, err = common.GetAccount(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -129,7 +112,7 @@ func Add(w http.ResponseWriter, r *http.Request) {
 // GetAll commit objects from the database for an account
 func GetAll(w http.ResponseWriter, r *http.Request) {
 	var commits []Commit
-	account, err := getAccount(r)
+	account, err := common.GetAccount(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -2,11 +2,29 @@ package common
 
 import (
 	"archive/tar"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
+
+func GetAccount(r *http.Request) (string, error) {
+
+	if config.Get().Debug {
+		return "0000000", nil
+	}
+
+	ident := identity.Get(r.Context())
+	if ident.Identity.AccountNumber != "" {
+		return ident.Identity.AccountNumber, nil
+	}
+	return "", fmt.Errorf("cannot find account number")
+
+}
 
 // StatusOK returns a simple 200 status code
 func StatusOK(w http.ResponseWriter, r *http.Request) {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,11 +1,48 @@
 package common
 
 import (
+	"archive/tar"
+	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 )
 
 // StatusOK returns a simple 200 status code
 func StatusOK(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
+}
+
+func Untar(rc io.ReadCloser, dst string) error {
+	defer rc.Close()
+	tarReader := tar.NewReader(rc)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		path := filepath.Join(dst, header.Name)
+		info := header.FileInfo()
+		if info.IsDir() {
+			if err = os.MkdirAll(path, info.Mode()); err != nil {
+				return err
+			}
+			continue
+		}
+
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode())
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		_, err = io.Copy(file, tarReader)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -55,8 +55,8 @@ func CreateRepo(w http.ResponseWriter, r *http.Request) {
 
 	res := &createResponse{
 		RepoURL: filepath.Join(
-			chi.RouteContext(r.Context()).RoutePath,
-			path),
+			chi.RouteContext(r.Context()).RoutePattern(),
+			cr.Name),
 	}
 
 	w.WriteHeader(http.StatusCreated)

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -1,0 +1,81 @@
+package repo
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-chi/chi"
+	"github.com/redhatinsights/edge-api/pkg/common"
+)
+
+func MakeRouter(sub chi.Router) {
+	sub.Post("/", CreateRepo)
+	sub.Get("/", GetAll)
+	sub.Get("/{name}/*", ServeRepo)
+}
+
+type createRequest struct {
+	TarURL string
+	Name   string
+}
+
+type createResponse struct {
+	RepoURL string
+}
+
+func CreateRepo(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	var cr createRequest
+	err := json.NewDecoder(r.Body).Decode(&cr)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if cr.TarURL == "" {
+		http.Error(w, "tarUrl must be set", http.StatusBadRequest)
+		return
+	}
+
+	if cr.Name == "" {
+		cr.Name = "default" // should be randomized?
+	}
+
+	resp, err := http.Get(cr.TarURL)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	path := filepath.Join("/tmp", cr.Name)
+
+	common.Untar(resp.Body, path)
+
+	res := &createResponse{
+		RepoURL: filepath.Join(
+			chi.RouteContext(r.Context()).RoutePath,
+			path),
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(res)
+}
+
+func GetAll(w http.ResponseWriter, r *http.Request) {
+}
+
+func ServeRepo(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+	if name == "" {
+		http.Error(w, "repo name not provided", http.StatusBadRequest)
+		return
+	}
+	_r := strings.Index(r.URL.Path, name)
+	pathPrefix := string(r.URL.Path[:_r+len(name)])
+
+	path := filepath.Join("/tmp", name)
+	fs := http.StripPrefix(pathPrefix, http.FileServer(http.Dir(path)))
+	fs.ServeHTTP(w, r)
+}

--- a/pkg/repo/server.go
+++ b/pkg/repo/server.go
@@ -1,0 +1,87 @@
+package repo
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/go-chi/chi"
+	"github.com/redhatinsights/edge-api/config"
+)
+
+type Server interface {
+	ServeRepo(w http.ResponseWriter, r *http.Request)
+}
+
+func getNameAndPrefix(r *http.Request) (string, string, error) {
+	name := chi.URLParam(r, "name")
+	if name == "" {
+		return "", "", fmt.Errorf("repo name not provided")
+	}
+	_r := strings.Index(r.URL.Path, name)
+	pathPrefix := string(r.URL.Path[:_r+len(name)])
+	return name, pathPrefix, nil
+}
+
+type FileServer struct {
+	BasePath string
+}
+
+func (s *FileServer) ServeRepo(w http.ResponseWriter, r *http.Request) {
+	name, pathPrefix, err := getNameAndPrefix(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	path := filepath.Join(s.BasePath, name)
+	fs := http.StripPrefix(pathPrefix, http.FileServer(http.Dir(path)))
+	fs.ServeHTTP(w, r)
+}
+
+type S3Proxy struct {
+	Client *s3.S3
+	Bucket string
+}
+
+func NewS3Proxy() *S3Proxy {
+	cfg := config.Get()
+	sess := session.Must(session.NewSession())
+	client := s3.New(sess)
+	return &S3Proxy{
+		Client: client,
+		Bucket: cfg.BucketName,
+	}
+}
+
+func (p *S3Proxy) ServeRepo(w http.ResponseWriter, r *http.Request) {
+
+	_, pathPrefix, err := getNameAndPrefix(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	_r := strings.Index(r.URL.Path, pathPrefix)
+	realPath := string(r.URL.Path[_r+len(pathPrefix):])
+
+	o, err := p.Client.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(p.Bucket),
+		Key:    aws.String(realPath),
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	defer o.Body.Close()
+	_, err = io.Copy(w, o.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}


### PR DESCRIPTION
This PR introduces a new endpoint `/repos` that proxies repo content.  The idea is to separate commit data from actual repo data, and allow space for the repo to be constructed and served in distinct steps.