### PR TITLE
Test with race detector enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ CONTAINER_TAG="quay.io/cloudservices/edge-api"
 
 KUBECTL=kubectl
 NAMESPACE=default
+TEST_OPTIONS="-race"
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"


### PR DESCRIPTION
I'm proposing this so we can test with race detection enabled in case we run into any issues while adding more unit tests to the project.

I was able to test creating a race example in a `_test.go` file.

```
func TestRace(t *testing.T) {
	start := time.Now()
	var tm *time.Timer
	tm = time.AfterFunc(randomDuration(), func() {
		fmt.Println(time.Now().Sub(start))
		tm.Reset(randomDuration())
	})
	time.Sleep(5 * time.Second)
}

func randomDuration() time.Duration {
	return time.Duration(rand.Int63n(1e9))
}
```

Further reading on race detection in Go for those interested: https://blog.golang.org/race-detector