### PR TITLE
Feat: Get status from img builder

### DIFF
--- a/pkg/errors/api.go
+++ b/pkg/errors/api.go
@@ -35,3 +35,15 @@ func NewBadRequest(message string) *BadRequest {
 	err.Status = http.StatusBadRequest
 	return err
 }
+
+type NotFound struct {
+	APIError
+}
+
+func NewNotFound(message string) *NotFound {
+	err := new(NotFound)
+	err.Code = "NOT_FOUND"
+	err.Title = message
+	err.Status = http.StatusNotFound
+	return err
+}

--- a/pkg/imagebuilder/client.go
+++ b/pkg/imagebuilder/client.go
@@ -72,15 +72,15 @@ const (
 
 type UploadStatus struct {
 	Options S3UploadStatus `json:"options"`
-	Status  string            `json:"status"`
-	Type    UploadTypes       `json:"type"`
+	Status  string         `json:"status"`
+	Type    UploadTypes    `json:"type"`
 }
 type ComposeResult struct {
 	Id string `json:"id"`
 }
 
 type S3UploadStatus struct {
-	Url string `json:"url"`
+	URL string `json:"url"`
 }
 type ImageBuilderClientInterface interface {
 	Compose(image *models.Image) (*models.Image, error)
@@ -172,7 +172,7 @@ func (c *ImageBuilderClient) GetStatus(image *models.Image) (*models.Image, erro
 	defer res.Body.Close()
 	if cs.ImageStatus.Status == imageStatusSuccess {
 		image.Status = models.ImageStatusSuccess
-		image.Commit.ImageBuildTarURL = cs.ImageStatus.UploadStatus.Options.Url
+		image.Commit.ImageBuildTarURL = cs.ImageStatus.UploadStatus.Options.URL
 		// TODO: What to do if it's an installer?
 	} else if cs.ImageStatus.Status == imageStatusFailure {
 		image.Status = models.ImageStatusError

--- a/pkg/imagebuilder/client.go
+++ b/pkg/imagebuilder/client.go
@@ -70,14 +70,17 @@ const (
 )
 
 type UploadStatus struct {
-	Options interface{} `json:"options"`
-	Status  string      `json:"status"`
-	Type    UploadTypes `json:"type"`
+	Options AWSS3UploadStatus `json:"options"`
+	Status  string            `json:"status"`
+	Type    UploadTypes       `json:"type"`
 }
 type ComposeResult struct {
 	Id string `json:"id"`
 }
 
+type AWSS3UploadStatus struct {
+	Url string `json:"url"`
+}
 type ImageBuilderClientInterface interface {
 	Compose(image *models.Image) (*models.Image, error)
 	GetStatus(image *models.Image) (*models.Image, error)
@@ -162,9 +165,10 @@ func (c *ImageBuilderClient) GetStatus(image *models.Image) (*models.Image, erro
 	defer res.Body.Close()
 	if cs.ImageStatus.Status == imageStatusSuccess {
 		image.Status = models.ImageStatusSuccess
+		image.Commit.ImageBuildTarURL = cs.ImageStatus.UploadStatus.Options.Url
+		// TODO: What to do if it's an installer?
 	} else if cs.ImageStatus.Status == imageStatusFailure {
 		image.Status = models.ImageStatusError
 	}
-	// TODO: We might wanna update db here
 	return image, nil
 }

--- a/pkg/imagebuilder/client.go
+++ b/pkg/imagebuilder/client.go
@@ -141,7 +141,7 @@ func (c *ImageBuilderClient) Compose(image *models.Image) (*models.Image, error)
 func (c *ImageBuilderClient) GetStatus(image *models.Image) (*models.Image, error) {
 	cs := &ComposeStatus{}
 	cfg := config.Get()
-	url := fmt.Sprintf("%s/composes/%s", cfg.ImageBuilderConfig.Url, image.ComposeJobID)
+	url := fmt.Sprintf("%s/composes/%s", cfg.ImageBuilderConfig.URL, image.ComposeJobID)
 	req, _ := http.NewRequest("GET", url, nil)
 
 	client := &http.Client{}

--- a/pkg/imagebuilder/client.go
+++ b/pkg/imagebuilder/client.go
@@ -54,20 +54,19 @@ type ComposeStatus struct {
 	ImageStatus ImageStatus `json:"image_status"`
 }
 type ImageStatus struct {
-	Status       ImageStatusValue `json:"status"`
+	Status       imageStatusValue `json:"status"`
 	UploadStatus *UploadStatus    `json:"upload_status,omitempty"`
 }
 
-type ImageStatusValue string
+type imageStatusValue string
 
-// List of ImageStatusValue
 const (
-	ImageStatusValue_building    ImageStatusValue = "building"
-	ImageStatusValue_failure     ImageStatusValue = "failure"
-	ImageStatusValue_pending     ImageStatusValue = "pending"
-	ImageStatusValue_registering ImageStatusValue = "registering"
-	ImageStatusValue_success     ImageStatusValue = "success"
-	ImageStatusValue_uploading   ImageStatusValue = "uploading"
+	imageStatusBulding     imageStatusValue = "building"
+	imageStatusFailure     imageStatusValue = "failure"
+	imageStatusPending     imageStatusValue = "pending"
+	imageStatusRegistering imageStatusValue = "registering"
+	imageStatusSuccess     imageStatusValue = "success"
+	imageStatusUploading   imageStatusValue = "uploading"
 )
 
 type UploadStatus struct {
@@ -161,9 +160,9 @@ func (c *ImageBuilderClient) GetStatus(image *models.Image) (*models.Image, erro
 	}
 
 	defer res.Body.Close()
-	if cs.ImageStatus.Status == ImageStatusValue_success {
+	if cs.ImageStatus.Status == imageStatusSuccess {
 		image.Status = models.ImageStatusSuccess
-	} else if cs.ImageStatus.Status == ImageStatusValue_failure {
+	} else if cs.ImageStatus.Status == imageStatusFailure {
 		image.Status = models.ImageStatusError
 	}
 	// TODO: We might wanna update db here

--- a/pkg/imagebuilder/client.go
+++ b/pkg/imagebuilder/client.go
@@ -3,6 +3,7 @@ package imagebuilder
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -123,6 +124,9 @@ func (c *ImageBuilderClient) Compose(image *models.Image) (*models.Image, error)
 		return nil, err
 	}
 
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.New("error requesting image builder")
+	}
 	respBody, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
@@ -152,6 +156,9 @@ func (c *ImageBuilderClient) GetStatus(image *models.Image) (*models.Image, erro
 		return nil, err
 	}
 
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.New("error requesting image builder")
+	}
 	respBody, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, err

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -32,7 +32,7 @@ func MakeRouter(sub chi.Router) {
 // rationale.
 type key int
 
-const imageKey key = 0
+const imageKey key = 1
 
 // ImageCtx is a handler for Commit requests
 func ImageCtx(next http.Handler) http.Handler {

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -100,7 +100,9 @@ func TestGetStatus(t *testing.T) {
 		Account:      "0000000",
 		ComposeJobID: "123",
 		Status:       models.ImageStatusBuilding,
+		Commit:       &models.Commit{},
 	}
+	db.DB.Create(&image)
 	ctx := context.WithValue(req.Context(), imageKey, &image)
 	handler := http.HandlerFunc(GetStatusByID)
 	handler.ServeHTTP(rr, req.WithContext(ctx))

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -2,6 +2,9 @@ package images
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -35,6 +38,10 @@ type MockImageBuilderClient struct{}
 func (c *MockImageBuilderClient) Compose(image *models.Image) (*models.Image, error) {
 	return image, nil
 }
+func (c *MockImageBuilderClient) GetStatus(image *models.Image) (*models.Image, error) {
+	image.Status = models.ImageStatusError
+	return image, nil
+}
 
 func TestCreateWasCalledWithAccountNotSet(t *testing.T) {
 	imagebuilder.Client = &MockImageBuilderClient{}
@@ -55,7 +62,6 @@ func TestCreateWasCalledWithAccountNotSet(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-	// TODO: We need to discuss all-things testing against databases and setup, teardown and test suites
 	config.Init()
 	config.Get().Debug = true
 	db.InitDB()
@@ -75,5 +81,51 @@ func TestCreate(t *testing.T) {
 	if status := rr.Code; status != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v want %v",
 			status, http.StatusOK)
+	}
+}
+func TestGetStatus(t *testing.T) {
+	config.Init()
+	config.Get().Debug = true
+	db.InitDB()
+	db.DB.AutoMigrate(&models.Commit{}, &commits.UpdateRecord{}, &models.Package{}, &models.Image{})
+
+	imagebuilder.Client = &MockImageBuilderClient{}
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+
+	var image = models.Image{
+		Account:      "0000000",
+		ComposeJobID: "123",
+		Status:       models.ImageStatusBuilding,
+	}
+	ctx := context.WithValue(req.Context(), imageKey, &image)
+	handler := http.HandlerFunc(GetStatusByID)
+	handler.ServeHTTP(rr, req.WithContext(ctx))
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+		return
+	}
+
+	var ir struct {
+		Status string
+	}
+	respBody, err := ioutil.ReadAll(rr.Body)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	err = json.Unmarshal(respBody, &ir)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if ir.Status != models.ImageStatusError { // comes from the mock above
+		t.Errorf("wrong image status: got %v want %v",
+			ir.Status, models.ImageStatusError)
 	}
 }

--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -23,9 +23,16 @@ type Image struct {
 }
 
 const (
+	// Errors
 	DistributionCantBeNilMessage   = "distribution can't be empty"
 	ArchitectureCantBeEmptyMessage = "architecture can't be empty"
 	OnlyTarAcceptedMessage         = "only tar architecture supported for now"
+
+	// Status
+	ImageStatusCreated  = "created"
+	ImageStatusBuilding = "building"
+	ImageStatusError    = "error"
+	ImageStatusSuccess  = "success"
 )
 
 func (i *Image) ValidateRequest() error {

--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -29,10 +29,10 @@ const (
 	OnlyTarAcceptedMessage         = "only tar architecture supported for now"
 
 	// Status
-	ImageStatusCreated  = "created"
-	ImageStatusBuilding = "building"
-	ImageStatusError    = "error"
-	ImageStatusSuccess  = "success"
+	ImageStatusCreated  = "CREATED"
+	ImageStatusBuilding = "BUILDING"
+	ImageStatusError    = "ERROR"
+	ImageStatusSuccess  = "SUCCESS"
 )
 
 func (i *Image) ValidateRequest() error {

--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -13,7 +13,7 @@ type Image struct {
 	gorm.Model
 	Name         string
 	Account      string
-	Distribution string // rhel-8
+	Distribution string
 	Description  string
 	OutputType   string
 	Status       string


### PR DESCRIPTION
`curl -v -X GET -H "Content-Type: application/json" http://localhost:3000/api/edge/v1/images/<image-id>/status`

response:

`{ "Status" : "SUCCESS"}`
`{ "Status" : "BUILDING"}`
`{ "Status" : "ERROR"}`

This PR adds an endpoint that returns the status of an image.
If still building, it makes a request to image builder's API, gets the updated image status and saves the URL returned from them in our database.