### PR TITLE
Adapt request to pass headers to image builder

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -28,6 +28,17 @@ func GetAccount(r *http.Request) (string, error) {
 
 }
 
+func GetOutgoingHeaders(r *http.Request) map[string]string {
+	out := make(map[string]string)
+	headers := []string{"x-rh-identity", "x-rh-insights-request-id"}
+	for _, key := range headers {
+		if value := r.Header.Get(key); value != "" {
+			out[key] = value
+		}
+	}
+	return out
+}
+
 // StatusOK returns a simple 200 status code
 func StatusOK(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")

--- a/pkg/imagebuilder/client.go
+++ b/pkg/imagebuilder/client.go
@@ -3,7 +3,6 @@ package imagebuilder
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -83,19 +82,19 @@ type S3UploadStatus struct {
 	URL string `json:"url"`
 }
 type ImageBuilderClientInterface interface {
-	Compose(image *models.Image) (*models.Image, error)
-	GetStatus(image *models.Image) (*models.Image, error)
+	Compose(image *models.Image, headers map[string]string) (*models.Image, error)
+	GetStatus(image *models.Image, headers map[string]string) (*models.Image, error)
 }
 
 type ImageBuilderClient struct{}
 
-func (c *ImageBuilderClient) Compose(image *models.Image) (*models.Image, error) {
+func (c *ImageBuilderClient) Compose(image *models.Image, headers map[string]string) (*models.Image, error) {
 	cr := &ComposeResult{}
 	imgReq := ImageRequest{
 		Architecture: image.Commit.Arch,
 		ImageType:    image.ImageType,
 		UploadRequest: &UploadRequest{
-			Options: nil,
+			Options: make(map[string]string),
 			Type:    "aws.s3",
 		},
 	}
@@ -114,9 +113,13 @@ func (c *ImageBuilderClient) Compose(image *models.Image) (*models.Image, error)
 	payloadBuf := new(bytes.Buffer)
 	json.NewEncoder(payloadBuf).Encode(reqBody)
 	cfg := config.Get()
-	url := fmt.Sprintf("%s/compose", cfg.ImageBuilderConfig.URL)
+	url := fmt.Sprintf("%s/v1/compose", cfg.ImageBuilderConfig.URL)
 	log.Infof("Requesting url: %s", url)
 	req, _ := http.NewRequest("POST", url, payloadBuf)
+	for key, value := range headers {
+		req.Header.Add(key, value)
+	}
+	req.Header.Add("Content-Type", "application/json")
 
 	client := &http.Client{}
 	res, err := client.Do(req)
@@ -124,8 +127,9 @@ func (c *ImageBuilderClient) Compose(image *models.Image) (*models.Image, error)
 		return nil, err
 	}
 
-	if res.StatusCode != http.StatusOK {
-		return nil, errors.New("error requesting image builder")
+	if res.StatusCode != http.StatusCreated {
+		body, _ := ioutil.ReadAll(res.Body)
+		return nil, fmt.Errorf("error requesting image builder, got status code %d and body %s", res.StatusCode, body)
 	}
 	respBody, err := ioutil.ReadAll(res.Body)
 	if err != nil {
@@ -144,11 +148,15 @@ func (c *ImageBuilderClient) Compose(image *models.Image) (*models.Image, error)
 	return image, nil
 }
 
-func (c *ImageBuilderClient) GetStatus(image *models.Image) (*models.Image, error) {
+func (c *ImageBuilderClient) GetStatus(image *models.Image, headers map[string]string) (*models.Image, error) {
 	cs := &ComposeStatus{}
 	cfg := config.Get()
-	url := fmt.Sprintf("%s/composes/%s", cfg.ImageBuilderConfig.URL, image.ComposeJobID)
+	url := fmt.Sprintf("%s/v1/composes/%s", cfg.ImageBuilderConfig.URL, image.ComposeJobID)
 	req, _ := http.NewRequest("GET", url, nil)
+	for key, value := range headers {
+		req.Header.Add(key, value)
+	}
+	req.Header.Add("Content-Type", "application/json")
 
 	client := &http.Client{}
 	res, err := client.Do(req)
@@ -157,7 +165,8 @@ func (c *ImageBuilderClient) GetStatus(image *models.Image) (*models.Image, erro
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return nil, errors.New("error requesting image builder")
+		body, _ := ioutil.ReadAll(res.Body)
+		return nil, fmt.Errorf("error requesting image builder, got status code %d and body %s", res.StatusCode, body)
 	}
 	respBody, err := ioutil.ReadAll(res.Body)
 	if err != nil {

--- a/pkg/imagebuilder/client_test.go
+++ b/pkg/imagebuilder/client_test.go
@@ -24,6 +24,7 @@ func TestComposeImage(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
 		fmt.Fprintln(w, `{"id": "compose-job-id-returned-from-image-builder"}`)
 	}))
 	defer ts.Close()
@@ -41,7 +42,8 @@ func TestComposeImage(t *testing.T) {
 		Arch:     "x86_64",
 		Packages: pkgs,
 	}}
-	img, err := Client.Compose(img)
+	headers := make(map[string]string)
+	img, err := Client.Compose(img, headers)
 	if err != nil {
 		t.Errorf("Shouldnt throw error")
 	}

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -131,7 +131,8 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(&err)
 		return
 	}
-	image, err = imagebuilder.Client.Compose(image)
+	headers := common.GetOutgoingHeaders(r)
+	image, err = imagebuilder.Client.Compose(image, headers)
 	if err != nil {
 		log.Error(err)
 		err := errors.NewInternalServerError()
@@ -192,7 +193,8 @@ func GetStatusByID(w http.ResponseWriter, r *http.Request) {
 	if image := getImage(w, r); image != nil {
 		if image.Status == models.ImageStatusBuilding {
 			var err error
-			image, err = imagebuilder.Client.GetStatus(image)
+			headers := common.GetOutgoingHeaders(r)
+			image, err = imagebuilder.Client.GetStatus(image, headers)
 			if err != nil {
 				log.Error(err)
 				err := errors.NewInternalServerError()

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -35,10 +35,10 @@ func TestCreateWasCalledWithWrongBody(t *testing.T) {
 
 type MockImageBuilderClient struct{}
 
-func (c *MockImageBuilderClient) Compose(image *models.Image) (*models.Image, error) {
+func (c *MockImageBuilderClient) Compose(image *models.Image, headers map[string]string) (*models.Image, error) {
 	return image, nil
 }
-func (c *MockImageBuilderClient) GetStatus(image *models.Image) (*models.Image, error) {
+func (c *MockImageBuilderClient) GetStatus(image *models.Image, headers map[string]string) (*models.Image, error) {
 	image.Status = models.ImageStatusError
 	return image, nil
 }


### PR DESCRIPTION
I was finally able to integrate with an actual instance of hosted image builder instead of a mock, so I had to fix some stuff.

Image builder also only works with auth on, so I started passing auth headers to image builder API.