### PR TITLE
Add pagination to GetAll endpoints

### DIFF
--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -26,4 +27,43 @@ func TestStatusOK(t *testing.T) {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expected)
 	}
+}
+
+func TestGetPagination(t *testing.T) {
+
+	tt := []struct {
+		name     string
+		expected Pagination
+		passed   *Pagination
+	}{
+		{
+			name:     "No pagination set in context should use default pagination",
+			expected: Pagination{Offset: defaultOffset, Limit: defaultLimit},
+			passed:   nil,
+		},
+		{
+			name:     "Passing pagination to context",
+			expected: Pagination{Offset: 10, Limit: 10},
+			passed:   &Pagination{Offset: 10, Limit: 10},
+		},
+	}
+
+	for _, te := range tt {
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		if err != nil {
+			t.Errorf("Test %q: failed create test request: %s", te.name, err)
+		}
+		if te.passed != nil {
+			ctx := context.WithValue(req.Context(), PaginationKey, *te.passed)
+			req = req.WithContext(ctx)
+		}
+		res := GetPagination(req)
+		if res.Offset != te.expected.Offset {
+			t.Errorf("Test %q: expected pagination offset to be %d but got %d", te.name, te.expected.Offset, res.Offset)
+		}
+		if res.Limit != te.expected.Limit {
+			t.Errorf("Test %q: expected pagination offset to be %d but got %d", te.name, te.expected.Limit, res.Limit)
+		}
+	}
+
 }

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -17,7 +17,7 @@ import (
 
 // MakeRouter adds support for operations on images
 func MakeRouter(sub chi.Router) {
-	sub.Get("/", GetAll)
+	sub.With(common.Paginate).Get("/", GetAll)
 	sub.Post("/", Create)
 	sub.Route("/{imageId}", func(r chi.Router) {
 		r.Use(ImageCtx)
@@ -155,6 +155,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 // GetAll image objects from the database for an account
 func GetAll(w http.ResponseWriter, r *http.Request) {
 	var images []models.Image
+	pagination := common.GetPagination(r)
 	account, err := common.GetAccount(r)
 	if err != nil {
 		log.Info(err)
@@ -163,7 +164,7 @@ func GetAll(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(&err)
 		return
 	}
-	result := db.DB.Where("account = ?", account).Find(&images)
+	result := db.DB.Limit(pagination.Limit).Offset(pagination.Offset).Where("account = ?", account).Find(&images)
 	if result.Error != nil {
 		log.Error(err)
 		err := errors.NewInternalServerError()


### PR DESCRIPTION
This patch adds pagination to the necessary endpoints in order to have small size responses when fetching all items from backend.