### PR TITLE
update manager data model

### DIFF
--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -3,7 +3,6 @@ package main
 import (
 	"github.com/redhatinsights/edge-api/config"
 	l "github.com/redhatinsights/edge-api/logger"
-	"github.com/redhatinsights/edge-api/pkg/commits"
 	"github.com/redhatinsights/edge-api/pkg/db"
 	"github.com/redhatinsights/edge-api/pkg/models"
 	log "github.com/sirupsen/logrus"
@@ -23,7 +22,7 @@ func main() {
 		"BucketName":  cfg.BucketName,
 	}).Info("Configuration Values:")
 	db.InitDB()
-	err := db.DB.AutoMigrate(&models.Commit{}, &commits.UpdateRecord{}, &models.Package{}, &models.Image{})
+	err := db.DB.AutoMigrate(&models.Commit{}, &models.UpdateRecord{}, &models.Package{}, &models.Image{})
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/redhatinsights/edge-api/config"
-	"github.com/redhatinsights/edge-api/pkg/commits"
 	"github.com/redhatinsights/edge-api/pkg/db"
 	"github.com/redhatinsights/edge-api/pkg/imagebuilder"
 	"github.com/redhatinsights/edge-api/pkg/models"
@@ -24,7 +23,7 @@ func setUp() {
 	config.Init()
 	config.Get().Debug = true
 	db.InitDB()
-	db.DB.AutoMigrate(&models.Commit{}, &commits.UpdateRecord{}, &models.Package{}, &models.Image{})
+	db.DB.AutoMigrate(&models.Commit{}, &models.UpdateRecord{}, &models.Package{}, &models.Image{})
 	tx = db.DB.Begin()
 }
 

--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -1,0 +1,67 @@
+package models
+
+import (
+	"errors"
+
+	"gorm.io/gorm"
+)
+
+/*
+Device
+
+	A record of Edge Devices referenced by their UUID as per the
+	cloud.redhat.com Inventory.
+
+	ConnectionState refers to the devices Cloud Connector state, 0 is unavailable
+	and 1 is reachable.
+*/
+type Device struct {
+	gorm.Model
+	UUID            string
+	ConnectionState int `gorm:"default:1"`
+}
+
+/*
+UpdateRecord
+
+	Reporesents the combination of an OSTree commit and a set of Inventory
+	hosts that need to have the commit deployed to them
+
+	This will ultimately kick off a transaction where the old version(s) of
+	OSTree commit that are currently deployed onto those devices are combined
+	with the new commit into a new OSTree repo, static deltas are computed, and
+	then the result is stored in a way that can be served(proxied) by a
+	Server (pkg/repo/server.go).
+*/
+type UpdateRecord struct {
+	gorm.Model
+	UpdateCommitID uint
+	Account        string
+	OldCommitIDs   string
+	InventoryHosts []Device `gorm:"many2many:updaterecord_devices;"`
+	Status         string
+	UpdateRepoURL  string
+}
+
+const (
+	// Errors
+	UpdatCommitIDCantBeNilMessage    = "update commit id can't be empty"
+	AccountCantBeEmptyMessage        = "account can't be empty"
+	InventoryHostsCantBeEmptyMessage = "inventory hosts can not be empty"
+
+	// Status
+	UpdateStatusCreated  = "CREATED"
+	UpdateStatusBuilding = "BUILDING"
+	UpdateStatusError    = "ERROR"
+	UpdateStatusSuccess  = "SUCCESS"
+)
+
+func (ur *UpdateRecord) ValidateRequest() error {
+	if ur.UpdateCommitID == 0 {
+		return errors.New(UpdatCommitIDCantBeNilMessage)
+	}
+	if ur.InventoryHosts == nil || len(ur.InventoryHosts) == 0 {
+		return errors.New(InventoryHostsCantBeEmptyMessage)
+	}
+	return nil
+}

--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -24,7 +24,7 @@ type Device struct {
 /*
 UpdateRecord
 
-	Reporesents the combination of an OSTree commit and a set of Inventory
+	Represents the combination of an OSTree commit and a set of Inventory
 	hosts that need to have the commit deployed to them
 
 	This will ultimately kick off a transaction where the old version(s) of

--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -45,7 +45,7 @@ type UpdateRecord struct {
 
 const (
 	// Errors
-	UpdatCommitIDCantBeNilMessage    = "update commit id can't be empty"
+	UpdateCommitIDCantBeNilMessage    = "update commit id can't be empty"
 	AccountCantBeEmptyMessage        = "account can't be empty"
 	InventoryHostsCantBeEmptyMessage = "inventory hosts can not be empty"
 

--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -45,7 +45,7 @@ type UpdateRecord struct {
 
 const (
 	// Errors
-	UpdateCommitIDCantBeNilMessage    = "update commit id can't be empty"
+	UpdateCommitIDCantBeNilMessage   = "update commit id can't be empty"
 	AccountCantBeEmptyMessage        = "account can't be empty"
 	InventoryHostsCantBeEmptyMessage = "inventory hosts can not be empty"
 
@@ -58,7 +58,7 @@ const (
 
 func (ur *UpdateRecord) ValidateRequest() error {
 	if ur.UpdateCommitID == 0 {
-		return errors.New(UpdatCommitIDCantBeNilMessage)
+		return errors.New(UpdateCommitIDCantBeNilMessage)
 	}
 	if ur.InventoryHosts == nil || len(ur.InventoryHosts) == 0 {
 		return errors.New(InventoryHostsCantBeEmptyMessage)


### PR DESCRIPTION
If a device is not actively reachable or "online" via Cloud Connector, then
Playbook Dispatcher will 404 error when trying to schedule work for the device.
This behavior is the same for "offline" devices as well as invalid
device UUIDs, this means that we are going to have to manage the update
transaction. This change provides the basic data model for the update
transaction.

Signed-off-by: Adam Miller <admiller@redhat.com>