### PR TITLE
Fix extraction of tar files

### DIFF
--- a/pkg/commits/updates.go
+++ b/pkg/commits/updates.go
@@ -312,10 +312,10 @@ func DownloadExtractVersionRepo(c *models.Commit, dest string) error {
 	}
 	tarFile.Close()
 
-	// err = os.Remove(filepath.Join(dest, tarFileName))
-	// if err != nil {
-	// 	return err
-	// }
+	err = os.Remove(filepath.Join(dest, tarFileName))
+	if err != nil {
+		return err
+	}
 
 	// FIXME: The repo path is hard coded because this is how it comes from
 	//		  osbuild composer but we might want to revisit this later

--- a/pkg/commits/updates.go
+++ b/pkg/commits/updates.go
@@ -306,13 +306,16 @@ func DownloadExtractVersionRepo(c *models.Commit, dest string) error {
 	if err != nil {
 		return err
 	}
-	common.Untar(tarFile, filepath.Join(dest))
-	tarFile.Close()
-
-	err = os.Remove(filepath.Join(dest, tarFileName))
+	err = common.Untar(tarFile, filepath.Join(dest))
 	if err != nil {
 		return err
 	}
+	tarFile.Close()
+
+	// err = os.Remove(filepath.Join(dest, tarFileName))
+	// if err != nil {
+	// 	return err
+	// }
 
 	// FIXME: The repo path is hard coded because this is how it comes from
 	//		  osbuild composer but we might want to revisit this later

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -80,13 +80,13 @@ func Untar(rc io.ReadCloser, dst string) error {
 			}
 			continue
 		}
-
 		file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode())
 		if err != nil {
 			return err
 		}
 		_, err = io.Copy(file, tarReader)
 		if err != nil {
+			file.Close()
 			return err
 		}
 		file.Close()

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -85,11 +85,11 @@ func Untar(rc io.ReadCloser, dst string) error {
 		if err != nil {
 			return err
 		}
-		defer file.Close()
 		_, err = io.Copy(file, tarReader)
 		if err != nil {
 			return err
 		}
+		file.Close()
 	}
 	return nil
 }


### PR DESCRIPTION
This pull request fixes the extraction of tar files. I was getting too many open files and I think we ran across the problem described here on #2 
https://blog.learngoprogramming.com/gotchas-of-defer-in-go-1-8d070894cb01
