### PR TITLE
Add validation to images filter query

### DIFF
--- a/pkg/common/filters.go
+++ b/pkg/common/filters.go
@@ -34,18 +34,19 @@ func OneOfFilterHandler(name string) FilterFunc {
 	})
 }
 
-const layoutISO = "2006-01-02"
+// LayoutISO represent the date layout in the API query
+const LayoutISO = "2006-01-02"
 
 // CreatedAtFilterHandler handles the "created_at" filter
 func CreatedAtFilterHandler() FilterFunc {
 	return FilterFunc(func(r *http.Request, tx *gorm.DB) *gorm.DB {
 		if val := r.URL.Query().Get("created_at"); val != "" {
-			currentDay, err := time.Parse(layoutISO, val)
+			currentDay, err := time.Parse(LayoutISO, val)
 			if err != nil {
 				return tx
 			}
 			nextDay := currentDay.Add(time.Hour * 24)
-			tx = tx.Where("created_at BETWEEN ? AND ?", currentDay.Format(layoutISO), nextDay.Format(layoutISO))
+			tx = tx.Where("created_at BETWEEN ? AND ?", currentDay.Format(LayoutISO), nextDay.Format(LayoutISO))
 		}
 		return tx
 	})

--- a/pkg/common/filters_test.go
+++ b/pkg/common/filters_test.go
@@ -103,7 +103,7 @@ func TestOneOfFilterHandler(t *testing.T) {
 
 func TestCreatedAtFilterHandler(t *testing.T) {
 	filter := ComposeFilters(CreatedAtFilterHandler())
-	nowStr := time.Now().Format(layoutISO)
+	nowStr := time.Now().Format(LayoutISO)
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/images?created_at=%s", nowStr), nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %s", err)
@@ -112,8 +112,8 @@ func TestCreatedAtFilterHandler(t *testing.T) {
 	images := []models.Image{}
 	result.Find(&images)
 	for _, image := range images {
-		if image.CreatedAt.Format(layoutISO) != nowStr {
-			t.Errorf("Expected image created at will be %s but %s", nowStr, image.CreatedAt.Format(layoutISO))
+		if image.CreatedAt.Format(LayoutISO) != nowStr {
+			t.Errorf("Expected image created at will be %s but %s", nowStr, image.CreatedAt.Format(LayoutISO))
 		}
 	}
 }


### PR DESCRIPTION
I just realized that I didn't do any validation on the params that passed to filter images.
This fixes that and return an error message with a clear message.

For example, passing `status=INVALIDSTATUS` will return:

```json
[
  {
    "key": "status",
    "reason": "INVALIDSTATUS is not a valid status. Status must be CREATED or BUILDING or ERROR or SUCCESS"
  }
]
```
