### PR TITLE
Feat: Build RHEL for Edge Installer

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -74,7 +74,7 @@ func Init() {
 		ImageBuilderConfig: &imageBuilderConfig{
 			URL: options.GetString("ImageBuilderUrl"),
 		},
-		S3ProxyURL: options.GetString("S3_PROXY_URL"),
+		S3ProxyURL: options.GetString("S3ProxyURL"),
 	}
 
 	if clowder.IsClowderEnabled() {

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ type EdgeConfig struct {
 	SecretKey          string
 	UpdateTempPath     string
 	ImageBuilderConfig *imageBuilderConfig
+	S3ProxyURL         string
 }
 
 type dbConfig struct {
@@ -73,6 +74,7 @@ func Init() {
 		ImageBuilderConfig: &imageBuilderConfig{
 			URL: options.GetString("ImageBuilderUrl"),
 		},
+		S3ProxyURL: options.GetString("S3_PROXY_URL"),
 	}
 
 	if clowder.IsClowderEnabled() {

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ func initDependencies() {
 	l.InitLogger()
 	db.InitDB()
 	imagebuilder.InitClient()
+	commits.InitRepoBuilder()
 }
 
 func main() {

--- a/pkg/commits/updates.go
+++ b/pkg/commits/updates.go
@@ -26,6 +26,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var RepoBuilderInstance RepoBuilderInterface
+
+// InitRepoBuilder initializes the repository builder in this package
+func InitRepoBuilder() {
+	RepoBuilderInstance = &RepoBuilder{}
+}
+
 func getCommitFromDB(commitID uint) (*models.Commit, error) {
 	var commit models.Commit
 	result := db.DB.First(&commit, commitID)
@@ -128,7 +135,7 @@ func UpdatesAdd(w http.ResponseWriter, r *http.Request) {
 
 	db.DB.Create(&update)
 
-	go RepoBuilder(update)
+	go RepoBuilderInstance.BuildRepo(update)
 }
 
 // UpdatesGetAll update objects from the database for an account
@@ -187,9 +194,17 @@ func getUpdate(w http.ResponseWriter, r *http.Request) *models.UpdateRecord {
 	return update
 }
 
-// RepoBuilder build an update repo with the set of commits all merged into a single repo
+// RepoBuilderInterface defines the interface of a repository builder
+type RepoBuilderInterface interface {
+	BuildRepo(ur *models.UpdateRecord) error
+}
+
+// RepoBuilder is the implementation of a RepoBuilderInterface
+type RepoBuilder struct{}
+
+// BuildRepo build an update repo with the set of commits all merged into a single repo
 // with static deltas generated between them all
-func RepoBuilder(ur *models.UpdateRecord) error {
+func (rb *RepoBuilder) BuildRepo(ur *models.UpdateRecord) error {
 	cfg := config.Get()
 
 	var updaterec models.UpdateRecord

--- a/pkg/commits/updates.go
+++ b/pkg/commits/updates.go
@@ -128,7 +128,7 @@ func UpdatesAdd(w http.ResponseWriter, r *http.Request) {
 
 	db.DB.Create(&update)
 
-	go RepoBuilder(update, r)
+	go RepoBuilder(update)
 }
 
 // UpdatesGetAll update objects from the database for an account
@@ -189,7 +189,7 @@ func getUpdate(w http.ResponseWriter, r *http.Request) *models.UpdateRecord {
 
 // RepoBuilder build an update repo with the set of commits all merged into a single repo
 // with static deltas generated between them all
-func RepoBuilder(ur *models.UpdateRecord, r *http.Request) error {
+func RepoBuilder(ur *models.UpdateRecord) error {
 	cfg := config.Get()
 
 	var updaterec models.UpdateRecord
@@ -261,13 +261,9 @@ func RepoBuilder(ur *models.UpdateRecord, r *http.Request) error {
 		uploader = NewS3Uploader()
 	}
 	// FIXME: Need to actually do something with the return string for Server
-	account, err := common.GetAccount(r)
-	if err != nil {
-		return err
-	}
 
 	// NOTE: This relies on the file path being cfg.UpdateTempPath/models.UpdateRecord.ID
-	repoURL, err := uploader.UploadRepo(filepath.Join(path, "repo"), account)
+	repoURL, err := uploader.UploadRepo(filepath.Join(path, "repo"), ur.Account)
 	if err != nil {
 		return err
 	}

--- a/pkg/common/filters_test.go
+++ b/pkg/common/filters_test.go
@@ -22,28 +22,24 @@ func setUp() {
 		{
 			Name:         "Motion Sensor 1",
 			Distribution: "rhel-8",
-			ImageType:    "rhel-edge-installer",
 			Status:       models.ImageStatusError,
 			Commit:       &models.Commit{Arch: "arm7"},
 		},
 		{
 			Name:         "Pressure Sensor 1",
 			Distribution: "fedora-33",
-			ImageType:    "rhel-edge-commit",
 			Status:       models.ImageStatusSuccess,
 			Commit:       &models.Commit{Arch: "x86_64"},
 		},
 		{
 			Name:         "Pressure Sensor 2",
 			Distribution: "rhel-8",
-			ImageType:    "rhel-edge-commit",
 			Status:       models.ImageStatusCreated,
 			Commit:       &models.Commit{Arch: "x86_64"},
 		},
 		{
 			Name:         "Motion Sensor 2",
 			Distribution: "rhel-8",
-			ImageType:    "rhel-edge-installer",
 			Status:       models.ImageStatusBuilding,
 			Commit:       &models.Commit{Arch: "arm7"},
 		},

--- a/pkg/imagebuilder/client.go
+++ b/pkg/imagebuilder/client.go
@@ -145,6 +145,7 @@ func (c *ImageBuilderClient) Compose(image *models.Image, headers map[string]str
 	defer res.Body.Close()
 	image.Commit.ComposeJobID = cr.Id
 	image.Commit.Status = models.ImageStatusBuilding
+	image.Status = models.ImageStatusBuilding
 
 	return image, nil
 }
@@ -183,9 +184,11 @@ func (c *ImageBuilderClient) GetStatus(image *models.Image, headers map[string]s
 	log.Info(fmt.Sprintf("Got image status %s", cs.ImageStatus.Status))
 	if cs.ImageStatus.Status == imageStatusSuccess {
 		image.Status = models.ImageStatusSuccess
+		image.Commit.Status = models.ImageStatusSuccess
 		image.Commit.ImageBuildTarURL = cs.ImageStatus.UploadStatus.Options.URL
 		// TODO: What to do if it's an installer?
 	} else if cs.ImageStatus.Status == imageStatusFailure {
+		image.Commit.Status = models.ImageStatusError
 		image.Status = models.ImageStatusError
 	}
 	return image, nil

--- a/pkg/imagebuilder/client.go
+++ b/pkg/imagebuilder/client.go
@@ -20,7 +20,9 @@ var Client ImageBuilderClientInterface
 
 // InitClient initializes the client for Image Builder in this package
 func InitClient() {
-	Client = new(ImageBuilderClient)
+	Client = &ImageBuilderClient{
+		RepoURL: config.Get().S3ProxyURL,
+	}
 }
 
 // A lot of this code comes from https://github.com/osbuild/osbuild-composer
@@ -108,7 +110,9 @@ type ImageBuilderClientInterface interface {
 }
 
 // ImageBuilderClient is the implementation of an ImageBuilderClientInterface
-type ImageBuilderClient struct{}
+type ImageBuilderClient struct {
+	RepoURL string
+}
 
 func compose(composeReq *ComposeRequest, headers map[string]string) (*ComposeResult, error) {
 	payloadBuf := new(bytes.Buffer)
@@ -202,7 +206,7 @@ func (c *ImageBuilderClient) ComposeInstaller(updateRecord *models.UpdateRecord,
 				ImageType:    models.ImageTypeInstaller,
 				Ostree: &OSTree{
 					Ref: "rhel/8/x86_64/edge", //image.Commit.OSTreeRef,
-					URL: fmt.Sprintf("http://s3httpproxy-env.eba-zswvuamp.us-east-2.elasticbeanstalk.com/%s/%d/repo", updateRecord.Account, updateRecord.ID),
+					URL: fmt.Sprintf("%s/%s/%d/repo", c.RepoURL, updateRecord.Account, updateRecord.ID),
 				},
 				UploadRequest: &UploadRequest{
 					Options: make(map[string]string),

--- a/pkg/imagebuilder/client.go
+++ b/pkg/imagebuilder/client.go
@@ -32,7 +32,7 @@ type OSTree struct {
 
 // Customizations is made of the packages that are baked into an image
 type Customizations struct {
-	Packages *[]string `json:"packages,omitempty"`
+	Packages *[]string `json:"packages"`
 }
 
 // UploadRequests is the upload options accepted by Image Builder API
@@ -54,7 +54,7 @@ type ImageRequest struct {
 
 // ComposeRequest is the request to Compose one or more Images
 type ComposeRequest struct {
-	Customizations *Customizations `json:"customizations,omitempty"`
+	Customizations *Customizations `json:"customizations"`
 	Distribution   string          `json:"distribution"`
 	ImageRequests  []ImageRequest  `json:"image_requests"`
 }
@@ -114,7 +114,7 @@ func compose(composeReq *ComposeRequest, headers map[string]string) (*ComposeRes
 	json.NewEncoder(payloadBuf).Encode(composeReq)
 	cfg := config.Get()
 	url := fmt.Sprintf("%s/v1/compose", cfg.ImageBuilderConfig.URL)
-	log.Infof("Requesting url: %s", url)
+	log.Infof("Requesting url: %s with payloadBuf %s", url, payloadBuf.String())
 	req, _ := http.NewRequest("POST", url, payloadBuf)
 	for key, value := range headers {
 		req.Header.Add(key, value)
@@ -188,7 +188,7 @@ func (c *ImageBuilderClient) ComposeCommit(image *models.Image, headers map[stri
 
 // ComposeInstaller composes a Installer on ImageBuilder
 func (c *ImageBuilderClient) ComposeInstaller(updateRecord *models.UpdateRecord, image *models.Image, headers map[string]string) (*models.Image, error) {
-	var pkgs []string
+	pkgs := make([]string, 0)
 	req := &ComposeRequest{
 		Customizations: &Customizations{
 			Packages: &pkgs,
@@ -200,7 +200,7 @@ func (c *ImageBuilderClient) ComposeInstaller(updateRecord *models.UpdateRecord,
 				Architecture: image.Commit.Arch,
 				ImageType:    models.ImageTypeInstaller,
 				Ostree: &OSTree{
-					Ref: image.Commit.OSTreeRef,
+					Ref: "rhel/8/x86_64/edge", //image.Commit.OSTreeRef,
 					URL: fmt.Sprintf("http://s3httpproxy-env.eba-zswvuamp.us-east-2.elasticbeanstalk.com/%s/%d/repo", updateRecord.Account, updateRecord.ID),
 				},
 				UploadRequest: &UploadRequest{

--- a/pkg/imagebuilder/client.go
+++ b/pkg/imagebuilder/client.go
@@ -137,16 +137,25 @@ func (c *ImageBuilderClient) ComposeCommit(image *models.Image, headers map[stri
 			{
 				Architecture: image.Commit.Arch,
 				ImageType:    models.ImageTypeCommit,
-				Ostree: &OSTree{
-					Ref: image.Commit.OSTreeRef,
-					URL: image.Commit.OSTreeParentCommit,
-				},
 				UploadRequest: &UploadRequest{
 					Options: make(map[string]string),
 					Type:    "aws.s3",
 				},
 			}},
 	}
+	if image.Commit.OSTreeRef != "" {
+		if req.ImageRequests[0].Ostree == nil {
+			req.ImageRequests[0].Ostree = &OSTree{}
+		}
+		req.ImageRequests[0].Ostree.Ref = image.Commit.OSTreeRef
+	}
+	if image.Commit.OSTreeRef != "" {
+		if req.ImageRequests[0].Ostree == nil {
+			req.ImageRequests[0].Ostree = &OSTree{}
+		}
+		req.ImageRequests[0].Ostree.URL = image.Commit.OSTreeParentCommit
+	}
+
 	cr, err := compose(req, headers)
 	if err != nil {
 		return nil, err
@@ -198,7 +207,7 @@ func getComposeStatus(jobId string, headers map[string]string) (*ComposeStatus, 
 		req.Header.Add(key, value)
 	}
 	req.Header.Add("Content-Type", "application/json")
-
+	log.Infof("Requesting url: %s", url)
 	client := &http.Client{}
 	res, err := client.Do(req)
 	if err != nil {

--- a/pkg/imagebuilder/client.go
+++ b/pkg/imagebuilder/client.go
@@ -18,6 +18,7 @@ import (
 // This makes it easy to mock API calls to the Image Builder API
 var Client ImageBuilderClientInterface
 
+// InitClient initializes the client for Image Builder in this package
 func InitClient() {
 	Client = new(ImageBuilderClient)
 }
@@ -35,7 +36,7 @@ type Customizations struct {
 	Packages *[]string `json:"packages"`
 }
 
-// UploadRequests is the upload options accepted by Image Builder API
+// UploadRequest is the upload options accepted by Image Builder API
 type UploadRequest struct {
 	Options interface{} `json:"options"`
 	Type    string      `json:"type"`
@@ -88,9 +89,9 @@ type UploadStatus struct {
 	Type    UploadTypes    `json:"type"`
 }
 
-// ComposeResult has the Id of a ComposeRequest
+// ComposeResult has the ID of a ComposeRequest
 type ComposeResult struct {
-	Id string `json:"id"`
+	ID string `json:"id"`
 }
 
 // S3UploadStatus contains the URL to the S3 Bucket
@@ -180,7 +181,7 @@ func (c *ImageBuilderClient) ComposeCommit(image *models.Image, headers map[stri
 	if err != nil {
 		return nil, err
 	}
-	image.Commit.ComposeJobID = cr.Id
+	image.Commit.ComposeJobID = cr.ID
 	image.Commit.Status = models.ImageStatusBuilding
 	image.Status = models.ImageStatusBuilding
 	return image, nil
@@ -213,16 +214,16 @@ func (c *ImageBuilderClient) ComposeInstaller(updateRecord *models.UpdateRecord,
 	if err != nil {
 		return nil, err
 	}
-	image.Installer.ComposeJobID = cr.Id
+	image.Installer.ComposeJobID = cr.ID
 	image.Installer.Status = models.ImageStatusBuilding
 	image.Status = models.ImageStatusBuilding
 	return image, nil
 }
 
-func getComposeStatus(jobId string, headers map[string]string) (*ComposeStatus, error) {
+func getComposeStatus(jobID string, headers map[string]string) (*ComposeStatus, error) {
 	cs := &ComposeStatus{}
 	cfg := config.Get()
-	url := fmt.Sprintf("%s/v1/composes/%s", cfg.ImageBuilderConfig.URL, jobId)
+	url := fmt.Sprintf("%s/v1/composes/%s", cfg.ImageBuilderConfig.URL, jobID)
 	req, _ := http.NewRequest("GET", url, nil)
 	for key, value := range headers {
 		req.Header.Add(key, value)

--- a/pkg/imagebuilder/client.go
+++ b/pkg/imagebuilder/client.go
@@ -143,8 +143,8 @@ func (c *ImageBuilderClient) Compose(image *models.Image, headers map[string]str
 	}
 
 	defer res.Body.Close()
-	image.ComposeJobID = cr.Id
-	image.Status = models.ImageStatusBuilding
+	image.Commit.ComposeJobID = cr.Id
+	image.Commit.Status = models.ImageStatusBuilding
 
 	return image, nil
 }
@@ -152,7 +152,7 @@ func (c *ImageBuilderClient) Compose(image *models.Image, headers map[string]str
 func (c *ImageBuilderClient) GetStatus(image *models.Image, headers map[string]string) (*models.Image, error) {
 	cs := &ComposeStatus{}
 	cfg := config.Get()
-	url := fmt.Sprintf("%s/v1/composes/%s", cfg.ImageBuilderConfig.URL, image.ComposeJobID)
+	url := fmt.Sprintf("%s/v1/composes/%s", cfg.ImageBuilderConfig.URL, image.Commit.ComposeJobID)
 	req, _ := http.NewRequest("GET", url, nil)
 	for key, value := range headers {
 		req.Header.Add(key, value)

--- a/pkg/imagebuilder/client_test.go
+++ b/pkg/imagebuilder/client_test.go
@@ -4,12 +4,28 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/redhatinsights/edge-api/config"
 	"github.com/redhatinsights/edge-api/pkg/models"
 )
 
+func setUp() {
+	config.Init()
+	config.Get().Debug = true
+}
+
+func tearDown() {
+
+}
+
+func TestMain(m *testing.M) {
+	setUp()
+	retCode := m.Run()
+	tearDown()
+	os.Exit(retCode)
+}
 func TestInitClient(t *testing.T) {
 	InitClient()
 	if Client == nil {
@@ -31,26 +47,26 @@ func TestComposeImage(t *testing.T) {
 	config.Get().ImageBuilderConfig.URL = ts.URL
 
 	pkgs := []models.Package{
-		models.Package{
+		{
 			Name: "vim",
 		},
-		models.Package{
+		{
 			Name: "ansible",
 		},
 	}
-	img := &models.Image{Distribution: "rhel-8", ImageType: models.ImageTypeInstaller, Commit: &models.Commit{
+	img := &models.Image{Distribution: "rhel-8", Commit: &models.Commit{
 		Arch:     "x86_64",
 		Packages: pkgs,
 	}}
 	headers := make(map[string]string)
-	img, err := Client.Compose(img, headers)
+	img, err := Client.ComposeCommit(img, headers)
 	if err != nil {
 		t.Errorf("Shouldnt throw error")
 	}
 	if img == nil {
 		t.Errorf("Image shouldnt be nil")
 	}
-	if img != nil && img.ComposeJobID != "compose-job-id-returned-from-image-builder" {
+	if img != nil && img.Commit.ComposeJobID != "compose-job-id-returned-from-image-builder" {
 		t.Error("Compose job is not correct")
 	}
 }

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -156,7 +156,6 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		db.DB.Joins("Commit").First(&i, id)
 		fmt.Println("Compose job id", i.Commit.ComposeJobID)
 		for {
-			time.Sleep(1 * time.Minute)
 			i, err := updateImageStatus(i, r)
 			if err != nil {
 				panic(err)
@@ -164,8 +163,9 @@ func Create(w http.ResponseWriter, r *http.Request) {
 			if i.Commit.Status != models.ImageStatusBuilding {
 				break
 			}
+			time.Sleep(1 * time.Minute)
 		}
-		log.Info("Commit %d for Image %d is ready. Creating OSTree repo.", image.Commit.ID, image.ID)
+		log.Infof("Commit %d for Image %d is ready. Creating OSTree repo.", image.Commit.ID, image.ID)
 		update := &models.UpdateRecord{
 			UpdateCommitID: image.Commit.ID,
 			Account:        image.Account,
@@ -202,13 +202,6 @@ func validateGetAllSearchParams(next http.Handler) http.Handler {
 			for _, status := range statuses {
 				if status != models.ImageStatusCreated && status != models.ImageStatusBuilding && status != models.ImageStatusError && status != models.ImageStatusSuccess {
 					errs = append(errs, validationError{Key: "status", Reason: fmt.Sprintf("%s is not a valid status. Status must be %s", status, strings.Join(validStatuses, " or "))})
-				}
-			}
-		}
-		if imageTypes, ok := r.URL.Query()["image_type"]; ok {
-			for _, imageType := range imageTypes {
-				if imageType != models.ImageTypeCommit && imageType != models.ImageTypeInstaller {
-					errs = append(errs, validationError{Key: "image_type", Reason: fmt.Sprintf("%s is not a valid image_type. %s", imageType, models.ImageTypeNotAccepted)})
 				}
 			}
 		}
@@ -273,7 +266,7 @@ func getImage(w http.ResponseWriter, r *http.Request) *models.Image {
 }
 
 func updateImageStatus(image *models.Image, r *http.Request) (*models.Image, error) {
-	log.Info("Requesting image status on image builder")
+	log.Info("Requesting image status on image builder aa")
 	headers := common.GetOutgoingHeaders(r)
 	if image.Commit.Status == models.ImageStatusBuilding {
 		image, err := imagebuilder.Client.GetCommitStatus(image, headers)
@@ -409,7 +402,6 @@ func CreateInstallerForImage(w http.ResponseWriter, r *http.Request) {
 		var i *models.Image
 		db.DB.Joins("Commit").Joins("Installer").First(&i, id)
 		for {
-			time.Sleep(1 * time.Minute)
 			i, err := updateImageStatus(i, r)
 			if err != nil {
 				panic(err)
@@ -417,6 +409,7 @@ func CreateInstallerForImage(w http.ResponseWriter, r *http.Request) {
 			if i.Installer.Status != models.ImageStatusBuilding {
 				break
 			}
+			time.Sleep(1 * time.Minute)
 		}
 	}(image.ID)
 

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -156,7 +156,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		db.DB.Joins("Commit").First(&i, id)
 		fmt.Println("Compose job id", i.Commit.ComposeJobID)
 		for {
-			time.Sleep(1 * time.Second)
+			time.Sleep(1 * time.Minute)
 			i, err := updateImageStatus(i, r)
 			if err != nil {
 				panic(err)

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -130,7 +130,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(&err)
 		return
 	}
-	image.Status = models.ImageStatusBuilding
+	image.Commit.Status = models.ImageStatusBuilding
 	tx = db.DB.Save(&image)
 	if tx.Error != nil {
 		log.Error(err)
@@ -148,7 +148,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				panic(err)
 			}
-			if i.Status != models.ImageStatusBuilding {
+			if i.Commit.Status != models.ImageStatusBuilding {
 				break
 			}
 		}

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -273,7 +273,7 @@ func updateImageStatus(image *models.Image, r *http.Request) (*models.Image, err
 		}
 	}
 	if image.Installer != nil {
-		image, err = imagebuilder.Client.GetCommitStatus(image, headers)
+		image, err = imagebuilder.Client.GetInstallerStatus(image, headers)
 		if err != nil {
 			return image, err
 		}

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -26,7 +26,7 @@ func MakeRouter(sub chi.Router) {
 		r.Use(ImageCtx)
 		r.Get("/", GetByID)
 		r.Get("/status", GetStatusByID)
-		r.Get("/installer", CreateInstallerForImage)
+		r.Post("/installer", CreateInstallerForImage)
 	})
 }
 
@@ -333,7 +333,9 @@ func GetByID(w http.ResponseWriter, r *http.Request) {
 // It requires a created image and an update for the commit
 func CreateInstallerForImage(w http.ResponseWriter, r *http.Request) {
 	image := getImage(w, r)
-	image.Installer.Status = models.ImageStatusCreated
+	image.Installer = &models.Installer{
+		Status: models.ImageStatusCreated,
+	}
 	tx := db.DB.Save(&image)
 	if tx.Error != nil {
 		log.Error(tx.Error)

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -340,7 +340,8 @@ func GetByID(w http.ResponseWriter, r *http.Request) {
 func CreateInstallerForImage(w http.ResponseWriter, r *http.Request) {
 	image := getImage(w, r)
 	image.Installer = &models.Installer{
-		Status: models.ImageStatusCreated,
+		Status:  models.ImageStatusCreated,
+		Account: image.Account,
 	}
 	tx := db.DB.Save(&image)
 	if tx.Error != nil {

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -171,7 +171,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 			Account:        image.Account,
 		}
 		db.DB.Create(&update)
-		commits.RepoBuilder(update)
+		commits.RepoBuilderInstance.BuildRepo(update)
 
 		// TODO: This is also where we need to get the metadata from image builder
 		// in a separate goroutine

--- a/pkg/models/commits.go
+++ b/pkg/models/commits.go
@@ -5,7 +5,7 @@ import "gorm.io/gorm"
 // Commit represents an OSTree commit from image builder
 type Commit struct {
 	gorm.Model
-	Name                 string    `json:"Name"`
+	Name                 string
 	Account              string    `json:"Account"`
 	ImageBuildHash       string    `json:"ImageBuildHash"`
 	ImageBuildParentHash string    `json:"ImageBuildParentHash"`
@@ -18,6 +18,8 @@ type Commit struct {
 	BlueprintToml        string    `json:"BlueprintToml"`
 	Arch                 string    `json:"Arch"`
 	Packages             []Package `json:"Packages" gorm:"many2many:commit_packages;"`
+	ComposeJobID         string    `json:"ComposeJobID"`
+	Status               string    `json:"Status"`
 }
 
 type Package struct {

--- a/pkg/models/commits.go
+++ b/pkg/models/commits.go
@@ -22,6 +22,7 @@ type Commit struct {
 	Status               string    `json:"Status"`
 }
 
+// Package represents the packages a Commit can have
 type Package struct {
 	gorm.Model
 	Name string `json:"Name"`
@@ -36,6 +37,7 @@ var requiredPackages = [6]string{
 	"insights-client",
 }
 
+// GetPackagesList returns the packages in a user-friendly list containing their names
 func (c *Commit) GetPackagesList() *[]string {
 	l := len(requiredPackages)
 	pkgs := make([]string, len(c.Packages)+l)

--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -14,12 +14,12 @@ type Image struct {
 	Distribution string
 	Description  string
 	ImageType    string
-	// Status       string
-	Version     int `gorm:"default:1"`
-	CommitID    int
-	Commit      *Commit
-	InstallerID int
-	Installer   *Installer
+	Status       string
+	Version      int `gorm:"default:1"`
+	CommitID     int
+	Commit       *Commit
+	InstallerID  int
+	Installer    *Installer
 }
 
 const (

--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -15,10 +15,11 @@ type Image struct {
 	Description  string
 	ImageType    string
 	Status       string
-	ComposeJobID string
-	CommitID     int
 	Version      int `gorm:"default:1"`
+	CommitID     int
 	Commit       *Commit
+	InstallerID  int
+	Installer    *Installer
 }
 
 const (

--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -22,19 +22,16 @@ type Image struct {
 }
 
 const (
-	// Errors
 	// DistributionCantBeNilMessage is the error message when a distribution is nil
 	DistributionCantBeNilMessage = "distribution can't be empty"
 	// ArchitectureCantBeEmptyMessage is the error message when the architecture is empty
 	ArchitectureCantBeEmptyMessage = "architecture can't be empty"
 
-	// ImageTypes
 	// ImageTypeInstaller is the installer image type on Image Builder
 	ImageTypeInstaller = "rhel-edge-installer"
 	// ImageTypeCommit is the installer image type on Image Builder
 	ImageTypeCommit = "rhel-edge-commit"
 
-	// Status
 	// ImageStatusCreated is for when a image is created
 	ImageStatusCreated = "CREATED"
 	// ImageStatusBuilding is for when a image is building

--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -13,7 +13,6 @@ type Image struct {
 	Account      string
 	Distribution string
 	Description  string
-	ImageType    string
 	Status       string
 	Version      int `gorm:"default:1"`
 	CommitID     int
@@ -45,9 +44,6 @@ func (i *Image) ValidateRequest() error {
 	}
 	if i.Commit == nil || i.Commit.Arch == "" {
 		return errors.New(ArchitectureCantBeEmptyMessage)
-	}
-	if i.ImageType != ImageTypeCommit && i.ImageType != ImageTypeInstaller {
-		return errors.New(ImageTypeNotAccepted)
 	}
 	return nil
 }

--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -23,21 +23,29 @@ type Image struct {
 
 const (
 	// Errors
-	DistributionCantBeNilMessage   = "distribution can't be empty"
+	// DistributionCantBeNilMessage is the error message when a distribution is nil
+	DistributionCantBeNilMessage = "distribution can't be empty"
+	// ArchitectureCantBeEmptyMessage is the error message when the architecture is empty
 	ArchitectureCantBeEmptyMessage = "architecture can't be empty"
-	ImageTypeNotAccepted           = "Image type must be rhel-edge-installer or rhel-edge-commit"
 
 	// ImageTypes
+	// ImageTypeInstaller is the installer image type on Image Builder
 	ImageTypeInstaller = "rhel-edge-installer"
-	ImageTypeCommit    = "rhel-edge-commit"
+	// ImageTypeCommit is the installer image type on Image Builder
+	ImageTypeCommit = "rhel-edge-commit"
 
 	// Status
-	ImageStatusCreated  = "CREATED"
+	// ImageStatusCreated is for when a image is created
+	ImageStatusCreated = "CREATED"
+	// ImageStatusBuilding is for when a image is building
 	ImageStatusBuilding = "BUILDING"
-	ImageStatusError    = "ERROR"
-	ImageStatusSuccess  = "SUCCESS"
+	// ImageStatusError is for when a image is on a error state
+	ImageStatusError = "ERROR"
+	// ImageStatusSuccess is for when a image is available to the user
+	ImageStatusSuccess = "SUCCESS"
 )
 
+// ValidateRequest validates an Image Request
 func (i *Image) ValidateRequest() error {
 	if i.Distribution == "" {
 		return errors.New(DistributionCantBeNilMessage)

--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -14,12 +14,12 @@ type Image struct {
 	Distribution string
 	Description  string
 	ImageType    string
-	Status       string
-	Version      int `gorm:"default:1"`
-	CommitID     int
-	Commit       *Commit
-	InstallerID  int
-	Installer    *Installer
+	// Status       string
+	Version     int `gorm:"default:1"`
+	CommitID    int
+	Commit      *Commit
+	InstallerID int
+	Installer   *Installer
 }
 
 const (

--- a/pkg/models/images_test.go
+++ b/pkg/models/images_test.go
@@ -34,7 +34,6 @@ func TestValidateRequestWithEdgeInstallerOutputType(t *testing.T) {
 	img := &Image{
 		Distribution: "rhel-8",
 		Commit:       &Commit{Arch: "x86_64"},
-		ImageType:    ImageTypeInstaller,
 	}
 
 	err := img.ValidateRequest()
@@ -46,7 +45,6 @@ func TestValidateRequestWithEdgeCommitImageType(t *testing.T) {
 	img := &Image{
 		Distribution: "rhel-8",
 		Commit:       &Commit{Arch: "x86_64"},
-		ImageType:    ImageTypeCommit,
 	}
 
 	err := img.ValidateRequest()
@@ -54,24 +52,11 @@ func TestValidateRequestWithEdgeCommitImageType(t *testing.T) {
 		t.Errorf("Error not expected")
 	}
 }
-func TestValidateRequestWithWrongImageType(t *testing.T) {
-	img := &Image{
-		Distribution: "rhel-8",
-		Commit:       &Commit{Arch: "x86_64"},
-		ImageType:    "wrong image type",
-	}
-
-	err := img.ValidateRequest()
-	if err == nil {
-		t.Errorf("Error expected")
-	}
-}
 
 func TestValidateRequest(t *testing.T) {
 	img := &Image{
 		Distribution: "rhel-8",
 		Commit:       &Commit{Arch: "x86_64"},
-		ImageType:    ImageTypeCommit,
 	}
 
 	err := img.ValidateRequest()

--- a/pkg/models/installers.go
+++ b/pkg/models/installers.go
@@ -1,0 +1,12 @@
+package models
+
+import "gorm.io/gorm"
+
+// Installer defines the model for a ISO installer
+type Installer struct {
+	gorm.Model
+	Account          string `json:"Account"`
+	ImageBuildISOURL string `json:"ImageBuildISOURL"`
+	ComposeJobID     string `json:"ComposeJobID"`
+	Status           string `json:"Status"`
+}

--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -44,13 +44,11 @@ type UpdateRecord struct {
 }
 
 const (
-	// Errors
 	// UpdateCommitIDCantBeNilMessage is the error message when a update commit is nil
 	UpdateCommitIDCantBeNilMessage = "update commit id can't be empty"
 	// InventoryHostsCantBeEmptyMessage is the error message when the hosts are empty
 	InventoryHostsCantBeEmptyMessage = "inventory hosts can not be empty"
 
-	// Status
 	// UpdateStatusCreated is for when a update is created
 	UpdateStatusCreated = "CREATED"
 	// UpdateStatusBuilding is for when a update is building

--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -45,17 +45,23 @@ type UpdateRecord struct {
 
 const (
 	// Errors
-	UpdateCommitIDCantBeNilMessage   = "update commit id can't be empty"
-	AccountCantBeEmptyMessage        = "account can't be empty"
+	// UpdateCommitIDCantBeNilMessage is the error message when a update commit is nil
+	UpdateCommitIDCantBeNilMessage = "update commit id can't be empty"
+	// InventoryHostsCantBeEmptyMessage is the error message when the hosts are empty
 	InventoryHostsCantBeEmptyMessage = "inventory hosts can not be empty"
 
 	// Status
-	UpdateStatusCreated  = "CREATED"
+	// UpdateStatusCreated is for when a update is created
+	UpdateStatusCreated = "CREATED"
+	// UpdateStatusBuilding is for when a update is building
 	UpdateStatusBuilding = "BUILDING"
-	UpdateStatusError    = "ERROR"
-	UpdateStatusSuccess  = "SUCCESS"
+	// UpdateStatusError is for when a update is on a error state
+	UpdateStatusError = "ERROR"
+	// UpdateStatusSuccess is for when a update is available to the user
+	UpdateStatusSuccess = "SUCCESS"
 )
 
+// ValidateRequest validates a Update Record Request
 func (ur *UpdateRecord) ValidateRequest() error {
 	if ur.UpdateCommitID == 0 {
 		return errors.New(UpdateCommitIDCantBeNilMessage)


### PR DESCRIPTION
This workflow still needs to be organized in a way that it's gonna be good for the frontend to use, but this is the code to have it as a 2-step process and the way that I did it, we can either have:

Image with a Commit (v1)
Image with a Installer (v2) with a Parent Commit (v1)
Image with a Commit (v1) and a Installer (v1)

So we can do the flow the way that it suits us better.

This endpoint allows to create a installer for a existent image (shortest path). It doesn't upgrade the version. It need to have a image already built and being served by our ostree repo.