### PR TITLE
Add test to untar method in common

### DIFF
--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -1,9 +1,12 @@
 package common
 
 import (
+	"archive/tar"
 	"context"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 )
 
@@ -66,4 +69,53 @@ func TestGetPagination(t *testing.T) {
 		}
 	}
 
+}
+
+func TestUntar(t *testing.T) {
+	//create tar file to be used as mock
+	tarPath := "mockTarFile.tar"
+	files := map[string]string{
+		"index.html":   `<body>Ansible!</body>`,
+		"lang.json":    `[{"code":"pt","name":"{Portuguese}"}]`,
+		"mock_txt.txt": `some content about red hat`,
+	}
+	tarWrite := func(data map[string]string) error {
+		tarFile, err := os.Create(tarPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer tarFile.Close()
+		tw := tar.NewWriter(tarFile)
+		defer tw.Close()
+		for name, content := range data {
+			hdr := &tar.Header{
+				Name: name,
+				Mode: 0600,
+				Size: int64(len(content)),
+			}
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+			if _, err := tw.Write([]byte(content)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := tarWrite(files); err != nil {
+		log.Fatal(err)
+	}
+	unTarFile, errOpenFile := os.Open(tarPath)
+	if errOpenFile != nil {
+		t.Error("Unable to open mock tar file before test")
+	}
+	Untar(unTarFile, `./`)
+	for name := range files {
+		// check if file exist after untar method calls
+		if _, err := os.Stat(name); os.IsNotExist(err) {
+			t.Fail()
+		}
+		os.Remove(name)
+	}
+	os.Remove(tarPath)
 }


### PR DESCRIPTION
### What is inside?
Add a new unit test to untar method in common package

### How is it done?

- Create a new test method
- create a mock tar file based in a files map structure
- call untar method from common package
- iterate over files map and check if all files are available after untar
- delete file to avoid generate files unecessary to project
