### PR TITLE
Make InstallerID nullable on a image

### DIFF
--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -17,7 +17,7 @@ type Image struct {
 	Version      int `gorm:"default:1"`
 	CommitID     int
 	Commit       *Commit
-	InstallerID  int
+	InstallerID  *int
 	Installer    *Installer
 }
 


### PR DESCRIPTION
Did not have this error on SQLite, but postgree is complaining (with all the rights to)

Logs on Stage:

`
2021/07/08 00:17:24 [31;1m/src/mypackage/myapp/pkg/images/images.go:117 [35;1mERROR: insert or update on table "images" violates foreign key constraint "fk_images_installer" (SQLSTATE 23503)
[0m[33m[7.404ms] [34;1m[rows:0][0m INSERT INTO "images" ("created_at","updated_at","deleted_at","name","account","distribution","description","status","version","commit_id","installer_id") VALUES ('2021-07-08 00:17:24.936','2021-07-08 00:17:24.936',NULL,'Bia\'s First Image on Stage','6089719','rhel-84','Cool description. Fleeters are awesome.','CREATED',1,17,0) RETURNING "id"
{"@timestamp":"8087+00+00T87:717:240.2400Z","level":"error","msg":"\u003cnil\u003e"}
2021/07/08 00:17:24 "POST http://edge-api-service.edge-stage.svc.cluster.local/api/edge/v1/images HTTP/1.1" from 127.0.0.1 - 500 70B in 7.677954ms
`

This *should* fix it.