### PR TITLE
Fix rhc-worker-playbook package name

### DIFF
--- a/pkg/models/commits.go
+++ b/pkg/models/commits.go
@@ -31,7 +31,7 @@ type Package struct {
 var requiredPackages = [6]string{
 	"ansible",
 	"rhc",
-	"rhc-playbook-worker",
+	"rhc-worker-playbook",
 	"subscription-manager",
 	"subscription-manager-plugin-ostree",
 	"insights-client",

--- a/pkg/models/commits_test.go
+++ b/pkg/models/commits_test.go
@@ -24,7 +24,7 @@ func TestGetPackagesList(t *testing.T) {
 	packages := []string{
 		"ansible",
 		"rhc",
-		"rhc-playbook-worker",
+		"rhc-worker-playbook",
 		"subscription-manager",
 		"subscription-manager-plugin-ostree",
 		"insights-client",


### PR DESCRIPTION
The package name was wrong in the JIRA ticket and I was stupid enough not to check 🤦🏻 