### PR TITLE
Changed DESC to ASC to fix asc sort issue

### DIFF
--- a/pkg/common/filters.go
+++ b/pkg/common/filters.go
@@ -59,6 +59,7 @@ func SortFilterHandler(defaultSortKey string, defaultOrder string) FilterFunc {
 		sortOrder := defaultOrder
 		if val := r.URL.Query().Get("sort_by"); val != "" {
 			if strings.HasPrefix(val, "-") {
+				sortOrder = "DESC"
 				sortBy = val[1:]
 			} else {
 				sortOrder = "ASC"

--- a/pkg/common/filters.go
+++ b/pkg/common/filters.go
@@ -59,9 +59,9 @@ func SortFilterHandler(defaultSortKey string, defaultOrder string) FilterFunc {
 		sortOrder := defaultOrder
 		if val := r.URL.Query().Get("sort_by"); val != "" {
 			if strings.HasPrefix(val, "-") {
-				sortOrder = "DESC"
 				sortBy = val[1:]
 			} else {
+				sortOrder = "ASC"
 				sortBy = val
 			}
 		}

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -186,7 +186,7 @@ var imageFilters = common.ComposeFilters(
 	common.ContainFilterHandler("name"),
 	common.ContainFilterHandler("distribution"),
 	common.CreatedAtFilterHandler(),
-	common.SortFilterHandler("created_at", "ASC"),
+	common.SortFilterHandler("created_at", "DESC"),
 )
 
 type validationError struct {

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -186,7 +186,7 @@ var imageFilters = common.ComposeFilters(
 	common.ContainFilterHandler("name"),
 	common.ContainFilterHandler("distribution"),
 	common.CreatedAtFilterHandler(),
-	common.SortFilterHandler("created_at", "DESC"),
+	common.SortFilterHandler("created_at", "ASC"),
 )
 
 type validationError struct {


### PR DESCRIPTION
I changed the default value to ASC from DESC so that asc sorting will work. The initial API call from the front-end is still created_at,
desc when the manage images table loads.