### PR TITLE
Shows error message when image is not found

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -63,7 +63,7 @@ func ImageCtx(next http.Handler) http.Handler {
 			}
 			result := db.DB.Where("`images`.account = ?", account).Joins("Commit").Joins("Installer").First(&image, id)
 			if result.Error != nil {
-				err := errors.NewNotFound(err.Error())
+				err := errors.NewNotFound(result.Error.Error())
 				w.WriteHeader(err.Status)
 				json.NewEncoder(w).Encode(&err)
 				return


### PR DESCRIPTION
http://localhost:3000/api/edge/v1/images/1200023293 (pick any random id here) was previously breaking due to a null pointer exception when referencing the error.

This PR makes it return a nicer error with:

{"Code":"NOT_FOUND","Status":404,"Title":"record not found"}