### PR TITLE
Fix/create installer before compose

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -201,7 +201,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		// TODO: This is also where we need to get the metadata from image builder
 		// in a separate goroutine
 		i.Status = models.ImageStatusSuccess
-		db.DB.Save(&image)
+		db.DB.Save(&i)
 
 		// TODO: We need to discuss this whole thist post-July deliverable
 		if i.ImageType == models.ImageTypeInstaller {
@@ -210,7 +210,10 @@ func Create(w http.ResponseWriter, r *http.Request) {
 				log.Error(err)
 				return
 			}
-			i.Installer.Status = models.ImageStatusBuilding
+			i.Installer = &models.Installer{
+				Status:  models.ImageStatusBuilding,
+				Account: image.Account,
+			}
 			i.Status = models.ImageStatusBuilding
 			tx = db.DB.Save(&i)
 			if tx.Error != nil {

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -212,7 +212,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 			}
 			i.Installer = &models.Installer{
 				Status:  models.ImageStatusBuilding,
-				Account: image.Account,
+				Account: i.Account,
 			}
 			i.Status = models.ImageStatusBuilding
 			tx = db.DB.Save(&i)

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -205,11 +205,6 @@ func Create(w http.ResponseWriter, r *http.Request) {
 
 		// TODO: We need to discuss this whole thist post-July deliverable
 		if i.ImageType == models.ImageTypeInstaller {
-			i, err := imagebuilder.Client.ComposeInstaller(update, i, headers)
-			if err != nil {
-				log.Error(err)
-				return
-			}
 			i.Installer = &models.Installer{
 				Status:  models.ImageStatusBuilding,
 				Account: i.Account,
@@ -221,6 +216,11 @@ func Create(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			tx = db.DB.Save(&i.Installer)
+			i, err := imagebuilder.Client.ComposeInstaller(update, i, headers)
+			if err != nil {
+				log.Error(err)
+				return
+			}
 			if tx.Error != nil {
 				log.Error(err)
 				json.NewEncoder(w).Encode(&err)


### PR DESCRIPTION
Pod logs: 


panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x80 pc=0xeb76a2]

goroutine 241 [running]:
github.com/redhatinsights/edge-api/pkg/imagebuilder.(*ImageBuilderClient).ComposeInstaller(0xc0009006c0, 0xc0004fe840, 0xc00054cb60, 0xc000444000, 0xc00091ff18, 0x3, 0x3)
	/src/mypackage/myapp/pkg/imagebuilder/client.go:221 +0x382
github.com/redhatinsights/edge-api/pkg/images.Create.func1(0xc0005caf00, 0xc00000e890, 0xc000444000, 0xc00000e8a0, 0x7f10818f3280, 0xc00020ce80, 0x44)
	/src/mypackage/myapp/pkg/images/images.go:208 +0x6a2
created by github.com/redhatinsights/edge-api/pkg/images.Create
	/src/mypackage/myapp/pkg/images/images.go:170 +0x1228
