### PR TITLE
Add GetDeviceStatus endpoint under /updates/

### DIFF
--- a/pkg/updates/updates_test.go
+++ b/pkg/updates/updates_test.go
@@ -1,0 +1,129 @@
+package updates
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/go-chi/chi"
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/db"
+	"github.com/redhatinsights/edge-api/pkg/models"
+)
+
+var (
+	updateDevices = []models.Device{
+		{UUID: "1", DesiredHash: "11"},
+		{UUID: "2", DesiredHash: "11"},
+		{UUID: "3", DesiredHash: "22"},
+		{UUID: "4", DesiredHash: "12"},
+	}
+
+	updateTrans = []models.UpdateTransaction{
+		{
+			Account: "0000000",
+			Devices: []models.Device{updateDevices[0], updateDevices[1]},
+		},
+		{
+			Account: "0000001",
+			Devices: []models.Device{updateDevices[2], updateDevices[3]},
+		},
+	}
+)
+
+func setUp() {
+	config.Init()
+	config.Get().Debug = true
+	db.InitDB()
+	db.DB.AutoMigrate(
+		&models.Commit{},
+		&models.UpdateTransaction{},
+		&models.Device{},
+		&models.DispatchRecord{},
+	)
+	db.DB.Create(&updateTrans)
+}
+
+func tearDown() {
+	db.DB.Unscoped().Delete(&updateTrans)
+	for _, uTran := range updateTrans {
+		db.DB.Unscoped().Delete(&uTran)
+	}
+}
+
+func TestMain(m *testing.M) {
+	setUp()
+	retCode := m.Run()
+	tearDown()
+	os.Exit(retCode)
+}
+
+func TestGetDevicesStatus(t *testing.T) {
+	tt := []struct {
+		name         string
+		searchUUID   string
+		expectedHash string
+	}{
+		{
+			name:         "display devices for uuid under account (0000000)",
+			searchUUID:   "1",
+			expectedHash: "11",
+		},
+		{
+			name:         "no devices for uuid not under account (0000000)",
+			searchUUID:   "3",
+			expectedHash: "",
+		},
+	}
+
+	for _, te := range tt {
+		req, err := http.NewRequest("GET", "/", nil)
+		if err != nil {
+			t.Errorf("%s: Failed creating a new request: %s", te.name, err)
+			return
+		}
+		ctx := context.WithValue(req.Context(), chi.RouteCtxKey, &chi.Context{
+			URLParams: chi.RouteParams{
+				Keys:   []string{"DeviceUUID"},
+				Values: []string{te.searchUUID},
+			},
+		})
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(GetDeviceStatus)
+		handler.ServeHTTP(rr, req.WithContext(ctx))
+
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("%s: handler returned wrong status code: got %v want %v", te.name, status, http.StatusOK)
+			return
+		}
+		var dvcs []models.Device
+		respBody, err := ioutil.ReadAll(rr.Body)
+		if err != nil {
+			t.Errorf("%s: Failed reading response body: %s", te.name, err.Error())
+			return
+		}
+
+		err = json.Unmarshal(respBody, &dvcs)
+		if err != nil {
+			t.Errorf("%s: Failed unmarshaling json from the response body: %s", te.name, err.Error())
+			return
+		}
+
+		if te.expectedHash == "" && len(dvcs) > 0 {
+			t.Errorf("%s was expecting not to have any results but got %+v", te.name, dvcs)
+			return
+		}
+		for _, dvc := range dvcs {
+			if dvc.UUID != te.searchUUID {
+				t.Errorf("%s was expecting UUID to be %s but got %s", te.name, te.searchUUID, dvc.UUID)
+			}
+			if dvc.DesiredHash != te.expectedHash {
+				t.Errorf("%s was expecting hash to be %s but got %s", te.name, te.expectedHash, dvc.DesiredHash)
+			}
+		}
+	}
+}


### PR DESCRIPTION
@maxamillion and @acosferreira can you review this code.

In stage you can find the following device:

```
      "insights_id": "097013b6-6e65-48cf-8c68-b1af1c9a92c6",                                                            
      "rhel_machine_id": null,    
      "subscription_manager_id": "99106db5-8bb7-4912-8e91-3f90953ab779",                                                
      "satellite_id": null,                                 
      "bios_uuid": "20e09da8-3d76-4bf5-9654-46225db15b5e",                                                              
      "ip_addresses": [
        ...                                 
      ],                                                    
      "fqdn": "localhost",                                  
      "mac_addresses": [                                    
        ...                                 
      ],                                                    
      "external_id": null,                                  
      "provider_id": null,                                  
      "provider_type": null,                                
      "id": "c4c86d36-23fb-445a-80b1-4c12d9f412fe",         
      "account": ...,                                 
      "display_name": "localhost",                          
      "ansible_host": null,                                 
      "facts": [ ... ],                                                    
      "reporter": "rhsm-conduit",                           
      "stale_timestamp": ...,                                                            
      "stale_warning_timestamp": ...,                                                    
      "culled_timestamp": ...,                                                           
      "created": ...,        
      "updated":  ....,
      "system_profile": {                                   
        "host_type": "edge",                                
        "operating_system": {                               
          "major": 8,                                       
          "minor": 4,                                       
          "name": "RHEL"                                    
        },                                                  
        "greenboot_status": "green",                        
        "greenboot_fallback_detected": false,               
        "rpm_ostree_deployments": [                         
          {                                                 
            "pinned": false,                                
            "origin": "rhel-edge:rhel/8/x86_64/edge",                                                                   
            "checksum": "ec5d1592f19ea2260bfc2e5b389609d3d9008c0d31a09072dd49e9a29a2dc96a",                             
            "booted": true,                                 
            "id": "rhel-edge-ec5d1592f19ea2260bfc2e5b389609d3d9008c0d31a09072dd49e9a29a2dc96a.0",                       
            "version": "8.4",                               
            "osname": "rhel-edge"                           
          }                                                 
        ]                                                   
      }
```

When trying to get updates data for that devices:

curl ${STAGE}/api/edge/v1/updates/c4c86d36-23fb-445a-80b1-4c12d9f412fe/
I get the following response: `must pass id`.

I believe this is because we use `updateID` as Param URL while we are trying to read `DeviceUUID` in the `UpdateCtx` method