### PR TITLE
Add username and ssh to image validation

### DIFF
--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -18,8 +18,10 @@ import (
 	"github.com/redhatinsights/edge-api/pkg/models"
 )
 
-var image models.Image
-var repo models.Repo
+var (
+	image models.Image
+	repo  models.Repo
+)
 
 func setUp() {
 	config.Init()
@@ -103,9 +105,20 @@ func (rb *MockRepositoryBuilder) ImportRepo(r *models.Repo) (*models.Repo, error
 	return &repo, nil
 }
 
-func TestCreateWasCalledWithAccountNotSet(t *testing.T) {
+func TestCreateWasCalledWithNameNotSet(t *testing.T) {
 	config.Get().Debug = false
-	var jsonStr = []byte(`{"Distribution": "rhel-8", "ImageType": "rhel-edge-installer", "Commit": {"Arch": "x86_64", "Packages" : [ { "name" : "vim"  } ]}}`)
+	var jsonStr = []byte(`{
+		"Distribution": "rhel-8",
+		"ImageType": "rhel-edge-installer",
+		"Commit": {
+			"Arch": "x86_64",
+			"Packages" : [ { "name" : "vim"  } ]
+		},
+		"Installer": {
+			"Username": "root",
+			"Sshkey": "ssh-rsa d9:f158:00:abcd"
+		}
+	}`)
 	req, err := http.NewRequest("POST", "/", bytes.NewBuffer(jsonStr))
 	if err != nil {
 		t.Fatal(err)
@@ -123,7 +136,19 @@ func TestCreateWasCalledWithAccountNotSet(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-	var jsonStr = []byte(`{"Name": "image1", "Distribution": "rhel-8", "ImageType": "rhel-edge-installer", "Commit": {"Arch": "x86_64", "Packages" : [ { "name" : "vim"  } ]}}`)
+	var jsonStr = []byte(`{
+		"Name": "image1",
+		"Distribution": "rhel-8",
+		"ImageType": "rhel-edge-installer",
+		"Commit": {
+			"Arch": "x86_64",
+			"Packages" : [ { "name" : "vim"  } ]
+		},
+		"Installer": {
+			"Username": "root",
+			"Sshkey": "ssh-rsa d9:f158:00:abcd"
+		}
+	}`)
 	req, err := http.NewRequest("POST", "/", bytes.NewBuffer(jsonStr))
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/models/images_test.go
+++ b/pkg/models/images_test.go
@@ -1,88 +1,162 @@
 package models
 
 import (
+	"errors"
 	"testing"
 )
 
-func TestValidateRequestWithEmptyDistribution(t *testing.T) {
-	img := &Image{}
-
-	err := img.ValidateRequest()
-
-	if err == nil {
-		t.Errorf("Error expected")
-	}
-	if err.Error() != DistributionCantBeNilMessage {
-		t.Errorf("expected distribution can't be empty")
-	}
-}
-func TestValidateRequestWithInvalidName(t *testing.T) {
-	img := &Image{
-		Distribution: "rhel-8",
-		ImageType:    ImageTypeInstaller,
-	}
-
-	err := img.ValidateRequest()
-
-	if err == nil {
-		t.Errorf("Error expected")
-	}
-	if err.Error() != NameCantBeInvalidMessage {
-		t.Errorf("expected name must start with alphanumeric characters and can contain underscore and hyphen characters")
-	}
-}
-func TestValidateRequestWithEmptyArchitecture(t *testing.T) {
-	img := &Image{
-		Distribution: "rhel-8",
-		ImageType:    ImageTypeInstaller,
-		Name:         "image1",
-	}
-
-	err := img.ValidateRequest()
-	if err == nil {
-		t.Errorf("Error expected")
-	}
-	if err.Error() != ArchitectureCantBeEmptyMessage {
-		t.Errorf("expected architecture can't be empty")
-	}
-}
-func TestValidateRequestWithEdgeInstallerOutputType(t *testing.T) {
-	img := &Image{
-		Distribution: "rhel-8",
-		Name:         "image1",
-		ImageType:    ImageTypeInstaller,
-		Commit:       &Commit{Arch: "x86_64"},
-	}
-
-	err := img.ValidateRequest()
-	if err != nil {
-		t.Errorf("Error not expected")
-	}
-}
-func TestValidateRequestWithEdgeCommitImageType(t *testing.T) {
-	img := &Image{
-		Distribution: "rhel-8",
-		Name:         "image1",
-		ImageType:    ImageTypeCommit,
-		Commit:       &Commit{Arch: "x86_64"},
-	}
-
-	err := img.ValidateRequest()
-	if err != nil {
-		t.Errorf("Error not expected")
-	}
-}
-
 func TestValidateRequest(t *testing.T) {
-	img := &Image{
-		Distribution: "rhel-8",
-		Name:         "image1",
-		ImageType:    ImageTypeInstaller,
-		Commit:       &Commit{Arch: "x86_64"},
+	tt := []struct {
+		name     string
+		image    *Image
+		expected error
+	}{
+		{
+			name:     "empty distribution",
+			image:    &Image{},
+			expected: errors.New(DistributionCantBeNilMessage),
+		},
+		{
+			name:     "empty name",
+			image:    &Image{Distribution: "rhel-8"},
+			expected: errors.New(NameCantBeInvalidMessage),
+		},
+		{
+			name:     "invalid characters in name",
+			image:    &Image{Distribution: "rhel-8", Name: "image?"},
+			expected: errors.New(NameCantBeInvalidMessage),
+		},
+		{
+			name: "no commit in image",
+			image: &Image{
+				Distribution: "rhel-8",
+				Name:         "image_name",
+			},
+			expected: errors.New(ArchitectureCantBeEmptyMessage),
+		},
+		{
+			name: "empty architecture",
+			image: &Image{
+				Distribution: "rhel-8",
+				Name:         "image_name",
+				Commit:       &Commit{Arch: ""},
+			},
+			expected: errors.New(ArchitectureCantBeEmptyMessage),
+		},
+		{
+			name: "empty architecture",
+			image: &Image{
+				Distribution: "rhel-8",
+				Name:         "image_name",
+				Commit:       &Commit{Arch: ""},
+			},
+			expected: errors.New(ArchitectureCantBeEmptyMessage),
+		},
+		{
+			name: "no image type",
+			image: &Image{
+				Distribution: "rhel-8",
+				Name:         "image_name",
+				Commit:       &Commit{Arch: "x86_64"},
+			},
+			expected: errors.New(ImageTypeNotAccepted),
+		},
+		{
+			name: "invalid image type",
+			image: &Image{
+				Distribution: "rhel-8",
+				Name:         "image_name",
+				Commit:       &Commit{Arch: "x86_64"},
+				ImageType:    "zip-image-type",
+			},
+			expected: errors.New(ImageTypeNotAccepted),
+		},
+		{
+			name: "no installer when image type is installer",
+			image: &Image{
+				Distribution: "rhel-8",
+				Name:         "image_name",
+				Commit:       &Commit{Arch: "x86_64"},
+				ImageType:    ImageTypeInstaller,
+			},
+			expected: errors.New(MissingUsernameError),
+		},
+		{
+			name: "empty username when image type is installer",
+			image: &Image{
+				Distribution: "rhel-8",
+				Name:         "image_name",
+				Commit:       &Commit{Arch: "x86_64"},
+				ImageType:    ImageTypeInstaller,
+				Installer: &Installer{
+					Username: "",
+				},
+			},
+			expected: errors.New(MissingUsernameError),
+		},
+		{
+			name: "empty ssh key when image type is installer",
+			image: &Image{
+				Distribution: "rhel-8",
+				Name:         "image_name",
+				Commit:       &Commit{Arch: "x86_64"},
+				ImageType:    ImageTypeInstaller,
+				Installer: &Installer{
+					Username: "root",
+				},
+			},
+			expected: errors.New(MissingSSHKeyError),
+		},
+		{
+			name: "invalid ssh key",
+			image: &Image{
+				Distribution: "rhel-8",
+				Name:         "image_name",
+				Commit:       &Commit{Arch: "x86_64"},
+				ImageType:    ImageTypeInstaller,
+				Installer: &Installer{
+					Username: "root",
+					SSHKey:   "dd:00:eeff:10",
+				},
+			},
+			expected: errors.New(InvalidSSHKeyError),
+		},
+		{
+			name: "valid image request",
+			image: &Image{
+				Distribution: "rhel-8",
+				Name:         "image_name",
+				Commit:       &Commit{Arch: "x86_64"},
+				ImageType:    ImageTypeInstaller,
+				Installer: &Installer{
+					Username: "root",
+					SSHKey:   "ssh-rsa dd:00:eeff:10",
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "valid image request for commit",
+			image: &Image{
+				Distribution: "rhel-8",
+				Name:         "image_name",
+				Commit:       &Commit{Arch: "x86_64"},
+				ImageType:    ImageTypeCommit,
+			},
+			expected: nil,
+		},
 	}
 
-	err := img.ValidateRequest()
-	if err != nil {
-		t.Errorf("Image object should be valid")
+	for _, te := range tt {
+		err := te.image.ValidateRequest()
+		if err == nil && te.expected != nil {
+			t.Errorf("Test %q was supposed to fail but passed successfully", te.name)
+		}
+		if err != nil && te.expected == nil {
+			t.Errorf("Test %q was supposed to pass but failed: %s", te.name, err)
+		}
+		if err != nil && te.expected != nil && err.Error() != te.expected.Error() {
+			t.Errorf("Test %q: expected to fail on %q but got %q", te.name, te.expected, err)
+		}
 	}
 }


### PR DESCRIPTION
* Add validation to make sure username and ssh-key are presented in the request when creating a new image.
* Small updates to the testing -> moving to test table form.