### PR TITLE
Feat: Add create repo for image to help debug

### DIFF
--- a/pkg/commits/repobuilder.go
+++ b/pkg/commits/repobuilder.go
@@ -205,8 +205,10 @@ func DownloadExtractVersionRepo(c *models.Commit, dest string) error {
 	// ensure we weren't passed a nil pointer
 	if c == nil {
 		log.Error("nil pointer to models.Commit provided")
-		return errors.New("Invalid Commit Provided: nil pointer")
+		return errors.New("invalid Commit Provided: nil pointer")
 	}
+	log.Debugf("DownloadExtractVersionRepo::CommitD: %d", c.ID)
+	log.Debugf("DownloadExtractVersionRepo::ImageBuildTarURL: %#v", c.ImageBuildTarURL)
 
 	// ensure the destination directory exists and then chdir there
 	log.Debugf("DownloadExtractVersionRepo::dest: %#v", dest)

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -35,6 +35,7 @@ func MakeRouter(sub chi.Router) {
 		r.Get("/repo", GetRepoForImage)
 		r.Post("/installer", CreateInstallerForImage)
 		r.Post("/repo", CreateRepoForImage)
+		r.Post("/kickstart", CreateKickStartForImage)
 	})
 }
 
@@ -683,5 +684,19 @@ func GetRepoForImage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		json.NewEncoder(w).Encode(repo)
+	}
+}
+
+func CreateKickStartForImage(w http.ResponseWriter, r *http.Request) {
+	if image := getImage(w, r); image != nil {
+		err := addUserInfo(image)
+		if err != nil {
+			// TODO: Temporary. Handle error better.
+			log.Errorf("Kickstart file injection failed %s", err.Error())
+			err := errors.NewInternalServerError()
+			w.WriteHeader(err.Status)
+			json.NewEncoder(w).Encode(&err)
+			return
+		}
 	}
 }


### PR DESCRIPTION
Co-author: @AaronH88 

This PR adds the create repo endpoint and an endpoint to add kickstart files to ISOs. They shouldn't be needed in the long run, but until we improve the dev flow I think we need to have those for our sanity.