### PR TITLE
get the url after uploading the file to S3

### DIFF
--- a/pkg/commits/uploader.go
+++ b/pkg/commits/uploader.go
@@ -18,7 +18,7 @@ import (
 //Uploader is an interface for uploading repository
 type Uploader interface {
 	UploadRepo(src string, account string) (string, error)
-	UploadFile(fname string, uploadPath string) error
+	UploadFile(fname string, uploadPath string) (string, error)
 }
 
 //S3Uploader defines the mechanism to upload data to S3
@@ -43,8 +43,8 @@ func (u *FileUploader) UploadRepo(src string, account string) (string, error) {
 
 // UploadFile is Basically a dummy function that returns no error but allows offline
 // development without S3 and satisfies the interface
-func (u *FileUploader) UploadFile(fname string, uploadPath string) error {
-	return nil
+func (u *FileUploader) UploadFile(fname string, uploadPath string) (string, error) {
+	return fname, nil
 }
 
 //NewS3Uploader creates a method to obtain a new S3 uploader
@@ -97,7 +97,7 @@ func (u *S3Uploader) UploadRepo(src string, account string) (string, error) {
 			return nil
 		}
 
-		err = u.UploadFile(path,
+		_, err = u.UploadFile(path,
 			fmt.Sprintf("%s/%s", account, strings.TrimPrefix(path, cfg.RepoTempPath)),
 		)
 		if err != nil {
@@ -114,12 +114,12 @@ func (u *S3Uploader) UploadRepo(src string, account string) (string, error) {
 
 // UploadFIle takes a Filename path as a string and then uploads that to
 // the supplied location in s3
-func (u *S3Uploader) UploadFile(fname string, uploadPath string) error {
+func (u *S3Uploader) UploadFile(fname string, uploadPath string) (string, error) {
 	log.Debugf("S3Uploader::UploadFileToS3::fname: %#v", fname)
 	log.Debugf("S3Uploader::UploadFileToS3::S3path: %#v", uploadPath)
 	f, err := os.Open(fname)
 	if err != nil {
-		return fmt.Errorf("failed to open file %q, %v", fname, err)
+		return "", fmt.Errorf("failed to open file %q, %v", fname, err)
 	}
 	defer f.Close()
 	// Upload the file to S3.
@@ -132,7 +132,9 @@ func (u *S3Uploader) UploadFile(fname string, uploadPath string) error {
 
 	log.Debugf("S3Uploader::UploadRepo::result: %#v", result)
 	if err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	region := *u.Client.Config.Region
+	s3URL := fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", u.Bucket, region, uploadPath)
+	return s3URL, nil
 }

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -629,14 +629,19 @@ func uploadISO(image *models.Image, url string) error {
 	if cfg.BucketName != "" {
 		uploader = commits.NewS3Uploader()
 	}
+
 	uploadPath := fmt.Sprintf("%s/isos/%s.iso", image.Account, image.Name)
-	image.Installer.ImageBuildISOURL = fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", cfg.BucketName, *cfg.BucketRegion, uploadPath)
-	tx := db.DB.Save(&image.Installer)
-	if tx.Error != nil {
-		return tx.Error
+	url, err := uploader.UploadFile(image.Name, uploadPath)
+
+	if err != nil {
+		image.Installer.ImageBuildISOURL = url
+		tx := db.DB.Save(&image.Installer)
+		if tx.Error != nil {
+			return tx.Error
+		}
 	}
 
-	return uploader.UploadFile(image.Name, uploadPath)
+	return err
 }
 
 // Remove edited kickstart after use.


### PR DESCRIPTION
This was breaking during local development, we need to get the BucketRegion not from the config, but from the AWS client because if cfg.Debug is true, we're doing:
```
	if cfg.Debug {
		sess = session.Must(session.NewSessionWithOptions(session.Options{
			// Force enable Shared Config support
			SharedConfigState: session.SharedConfigEnable,
		}))
	} else {
		var err error
		sess, err = session.NewSession(&aws.Config{
			Region:      cfg.BucketRegion,
			Credentials: credentials.NewStaticCredentials(cfg.AccessKey, cfg.SecretKey, ""),
		})
		if err != nil {
			panic(err)
		}
	}
```

which means that we get the region from the shared config - and the AWS_REGION environment variable - that is not used for production.