### PR TITLE
Add total count in images get all response

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -321,6 +321,7 @@ func validateGetAllSearchParams(next http.Handler) http.Handler {
 
 // GetAll image objects from the database for an account
 func GetAll(w http.ResponseWriter, r *http.Request) {
+	var count int64
 	var images []models.Image
 	result := imageFilters(r, db.DB)
 	pagination := common.GetPagination(r)
@@ -332,6 +333,14 @@ func GetAll(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(&err)
 		return
 	}
+	countResult := imageFilters(r, db.DB.Model(&models.Image{})).Where("images.account = ?", account).Count(&count)
+	if countResult.Error != nil {
+		countErr := errors.NewInternalServerError()
+		log.Error(countErr)
+		w.WriteHeader(countErr.Status)
+		json.NewEncoder(w).Encode(&countErr)
+		return
+	}
 	result = result.Limit(pagination.Limit).Offset(pagination.Offset).Where("images.account = ?", account).Joins("Commit").Joins("Installer").Find(&images)
 	if result.Error != nil {
 		log.Error(err)
@@ -340,7 +349,7 @@ func GetAll(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(&err)
 		return
 	}
-	json.NewEncoder(w).Encode(&images)
+	json.NewEncoder(w).Encode(map[string]interface{}{"data": &images, "count": count})
 }
 
 func getImage(w http.ResponseWriter, r *http.Request) *models.Image {


### PR DESCRIPTION
This is necessary for pagination in the UI (RHELPLAN-90237). **DO NOT MERGE** this yet needs to update the UI first.

In the pagination component we are asked to pass:
* the total count of items
* the current page
* items to show per-page

To calculate page and per-page we are using the API request parameters to do calculate. However, for total page we are using the `length` property on the list of item we get.

This is bad because the `total count` needs to be the items available in general and not the number of items we got in the pagination. This causes the pagination to think that all the results fit into one page and there are no other pages.

How I fixed it is adding piggybacking total count value inside the HTTP response on the `/images` endpoint.