### PR TITLE
Stop going to image builder to get image status - background processes do a lot more

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -188,8 +188,8 @@ func postProcessImage(id uint, headers map[string]string) {
 		}
 		time.Sleep(1 * time.Minute)
 	}
-  
- 	go imagebuilder.Client.GetMetadata(i, headers)
+
+	go imagebuilder.Client.GetMetadata(i, headers)
 
 	repo := createRepoForImage(i)
 
@@ -408,21 +408,9 @@ func updateImageStatus(image *models.Image, headers map[string]string) (*models.
 	return image, nil
 }
 
-// GetStatusByID returns the image status. If still building, goes to image builder API.
+// GetStatusByID returns the image status.
 func GetStatusByID(w http.ResponseWriter, r *http.Request) {
 	if image := getImage(w, r); image != nil {
-		if image.Status == models.ImageStatusBuilding {
-			var err error
-			headers := common.GetOutgoingHeaders(r)
-			image, err = updateImageStatus(image, headers)
-			if err != nil {
-				log.Error(err)
-				err := errors.NewInternalServerError()
-				w.WriteHeader(err.Status)
-				json.NewEncoder(w).Encode(&err)
-				return
-			}
-		}
 		json.NewEncoder(w).Encode(struct {
 			Status string
 			Name   string
@@ -438,18 +426,6 @@ func GetStatusByID(w http.ResponseWriter, r *http.Request) {
 // GetByID obtains a image from the database for an account
 func GetByID(w http.ResponseWriter, r *http.Request) {
 	if image := getImage(w, r); image != nil {
-		if image.Status == models.ImageStatusBuilding {
-			var err error
-			headers := common.GetOutgoingHeaders(r)
-			image, err = updateImageStatus(image, headers)
-			if err != nil {
-				log.Error(err)
-				err := errors.NewInternalServerError()
-				w.WriteHeader(err.Status)
-				json.NewEncoder(w).Encode(&err)
-				return
-			}
-		}
 		json.NewEncoder(w).Encode(image)
 	}
 }


### PR DESCRIPTION
This made sense in the beginning but now that we have a background process doing a lot more, this is not useful anymore. The get status and get image by id methods should return what's reflected on the database and the background process is taking care of hitting image builder for updated status.