### PR TITLE
Correction db.DB.Save on GetMetadataForImage

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -188,8 +188,8 @@ func postProcessImage(id uint, headers map[string]string) {
 		}
 		time.Sleep(1 * time.Minute)
 	}
-  
- 	go imagebuilder.Client.GetMetadata(i, headers)
+
+	go imagebuilder.Client.GetMetadata(i, headers)
 
 	repo := createRepoForImage(i)
 
@@ -725,7 +725,7 @@ func GetMetadataForImage(w http.ResponseWriter, r *http.Request) {
 			log.Fatal(err)
 		}
 		if image.Commit.OSTreeCommit != "" {
-			tx := db.DB.Save(&image.Commit.OSTreeCommit)
+			tx := db.DB.Save(&image.Commit)
 			if tx.Error != nil {
 				panic(tx.Error)
 			}


### PR DESCRIPTION
Fixing the `panic: unsupported data type: 0xc0003f6a48: Table not set, please set it like: db.Model(&user) or db.Table("users")`