### PR TITLE
Add output types as a list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
+	github.com/lib/pq v1.3.0
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect

--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -4,24 +4,26 @@ import (
 	"errors"
 	"regexp"
 
+	"github.com/lib/pq"
 	"gorm.io/gorm"
 )
 
 // Image is what generates a OSTree Commit.
 type Image struct {
 	gorm.Model
-	Name         string     `json:"Name"`
-	Account      string     `json:"Account"`
-	Distribution string     `json:"Distribution"`
-	Description  string     `json:"Description"`
-	Status       string     `json:"Status"`
-	Version      int        `json:"Version" gorm:"default:1"`
-	ImageType    string     `json:"ImageType"`
-	CommitID     uint       `json:"CommitID"`
-	Commit       *Commit    `json:"Commit"`
-	InstallerID  *uint      `json:"InstallerID"`
-	Installer    *Installer `json:"Installer"`
-	ParentId     *uint      `gorm:"foreignKey:Image"`
+	Name         string         `json:"Name"`
+	Account      string         `json:"Account"`
+	Distribution string         `json:"Distribution"`
+	Description  string         `json:"Description"`
+	Status       string         `json:"Status"`
+	Version      int            `json:"Version" gorm:"default:1"`
+	ImageType    string         `json:"ImageType"` // TODO: Remove as soon as the frontend stops using
+	OutputTypes  pq.StringArray `gorm:"type:text[]" json:"OutputTypes"`
+	CommitID     uint           `json:"CommitID"`
+	Commit       *Commit        `json:"Commit"`
+	InstallerID  *uint          `json:"InstallerID"`
+	Installer    *Installer     `json:"Installer"`
+	ParentId     *uint          `gorm:"foreignKey:Image"`
 }
 
 const (
@@ -33,6 +35,8 @@ const (
 	NameCantBeInvalidMessage = "name must start with alphanumeric characters and can contain underscore and hyphen characters"
 	// ImageTypeNotAccepted is the error message when an image type is not accepted
 	ImageTypeNotAccepted = "this image type is not accepted"
+	// NoOutputTypes is the error message when the output types list is empty
+	NoOutputTypes = "an output type is required"
 
 	// ImageTypeInstaller is the installer image type on Image Builder
 	ImageTypeInstaller = "rhel-edge-installer"
@@ -48,6 +52,8 @@ const (
 	// ImageStatusSuccess is for when a image is available to the user
 	ImageStatusSuccess = "SUCCESS"
 
+	// MissingInstaller is the error message for not passing an installer in the request
+	MissingInstaller = "installer info must be provided"
 	// MissingUsernameError is the error message for not passing username in the request
 	MissingUsernameError = "username must be provided"
 	// MissingSSHKeyError is the error message when SSH Key is not given
@@ -57,8 +63,9 @@ const (
 )
 
 var (
-	validSSHPrefix = regexp.MustCompile(`^(ssh-(rsa|dss|ed25519)|ecdsa-sha2-nistp(256|384|521)) \S+`)
-	validImageName = regexp.MustCompile(`^[A-Za-z0-9]+[A-Za-z0-9\s_-]*$`)
+	validSSHPrefix     = regexp.MustCompile(`^(ssh-(rsa|dss|ed25519)|ecdsa-sha2-nistp(256|384|521)) \S+`)
+	validImageName     = regexp.MustCompile(`^[A-Za-z0-9]+[A-Za-z0-9\s_-]*$`)
+	acceptedImageTypes = map[string]interface{}{ImageTypeCommit: nil, ImageTypeInstaller: nil}
 )
 
 // ValidateRequest validates an Image Request
@@ -72,17 +79,39 @@ func (i *Image) ValidateRequest() error {
 	if i.Commit == nil || i.Commit.Arch == "" {
 		return errors.New(ArchitectureCantBeEmptyMessage)
 	}
-	if i.ImageType != ImageTypeCommit && i.ImageType != ImageTypeInstaller {
-		return errors.New(ImageTypeNotAccepted)
+	if len(i.OutputTypes) == 0 {
+		return errors.New(NoOutputTypes)
 	}
-	if i.ImageType == ImageTypeInstaller && (i.Installer == nil || i.Installer.Username == "") {
-		return errors.New(MissingUsernameError)
+	for _, out := range i.OutputTypes {
+		if _, ok := acceptedImageTypes[out]; !ok {
+			return errors.New(ImageTypeNotAccepted)
+		}
 	}
-	if i.ImageType == ImageTypeInstaller && (i.Installer == nil || i.Installer.SSHKey == "") {
-		return errors.New(MissingSSHKeyError)
-	}
-	if i.ImageType == ImageTypeInstaller && !validSSHPrefix.MatchString(i.Installer.SSHKey) {
-		return errors.New(InvalidSSHKeyError)
+	// Installer checks
+	if i.HasOutputType(ImageTypeInstaller) {
+		if i.Installer == nil {
+			return errors.New(MissingInstaller)
+		}
+		if i.Installer.Username == "" {
+			return errors.New(MissingUsernameError)
+		}
+		if i.Installer.SSHKey == "" {
+			return errors.New(MissingSSHKeyError)
+		}
+		if !validSSHPrefix.MatchString(i.Installer.SSHKey) {
+			return errors.New(InvalidSSHKeyError)
+		}
+
 	}
 	return nil
+}
+
+// HasOutputType checks if an image has an specific output type
+func (i *Image) HasOutputType(imageType string) bool {
+	for _, out := range i.OutputTypes {
+		if out == imageType {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/models/images_test.go
+++ b/pkg/models/images_test.go
@@ -53,21 +53,21 @@ func TestValidateRequest(t *testing.T) {
 			expected: errors.New(ArchitectureCantBeEmptyMessage),
 		},
 		{
-			name: "no image type",
+			name: "no output type",
 			image: &Image{
 				Distribution: "rhel-8",
 				Name:         "image_name",
 				Commit:       &Commit{Arch: "x86_64"},
 			},
-			expected: errors.New(ImageTypeNotAccepted),
+			expected: errors.New(NoOutputTypes),
 		},
 		{
-			name: "invalid image type",
+			name: "invalid output type",
 			image: &Image{
 				Distribution: "rhel-8",
 				Name:         "image_name",
 				Commit:       &Commit{Arch: "x86_64"},
-				ImageType:    "zip-image-type",
+				OutputTypes:  []string{"zip-image-type"},
 			},
 			expected: errors.New(ImageTypeNotAccepted),
 		},
@@ -77,9 +77,9 @@ func TestValidateRequest(t *testing.T) {
 				Distribution: "rhel-8",
 				Name:         "image_name",
 				Commit:       &Commit{Arch: "x86_64"},
-				ImageType:    ImageTypeInstaller,
+				OutputTypes:  []string{ImageTypeInstaller},
 			},
-			expected: errors.New(MissingUsernameError),
+			expected: errors.New(MissingInstaller),
 		},
 		{
 			name: "empty username when image type is installer",
@@ -87,7 +87,7 @@ func TestValidateRequest(t *testing.T) {
 				Distribution: "rhel-8",
 				Name:         "image_name",
 				Commit:       &Commit{Arch: "x86_64"},
-				ImageType:    ImageTypeInstaller,
+				OutputTypes:  []string{ImageTypeInstaller},
 				Installer: &Installer{
 					Username: "",
 				},
@@ -100,7 +100,7 @@ func TestValidateRequest(t *testing.T) {
 				Distribution: "rhel-8",
 				Name:         "image_name",
 				Commit:       &Commit{Arch: "x86_64"},
-				ImageType:    ImageTypeInstaller,
+				OutputTypes:  []string{ImageTypeInstaller},
 				Installer: &Installer{
 					Username: "root",
 				},
@@ -113,7 +113,7 @@ func TestValidateRequest(t *testing.T) {
 				Distribution: "rhel-8",
 				Name:         "image_name",
 				Commit:       &Commit{Arch: "x86_64"},
-				ImageType:    ImageTypeInstaller,
+				OutputTypes:  []string{ImageTypeInstaller},
 				Installer: &Installer{
 					Username: "root",
 					SSHKey:   "dd:00:eeff:10",
@@ -127,7 +127,7 @@ func TestValidateRequest(t *testing.T) {
 				Distribution: "rhel-8",
 				Name:         "image_name",
 				Commit:       &Commit{Arch: "x86_64"},
-				ImageType:    ImageTypeInstaller,
+				OutputTypes:  []string{ImageTypeInstaller},
 				Installer: &Installer{
 					Username: "root",
 					SSHKey:   "ssh-rsa dd:00:eeff:10",
@@ -141,7 +141,7 @@ func TestValidateRequest(t *testing.T) {
 				Distribution: "rhel-8",
 				Name:         "image_name",
 				Commit:       &Commit{Arch: "x86_64"},
-				ImageType:    ImageTypeCommit,
+				OutputTypes:  []string{ImageTypeCommit},
 			},
 			expected: nil,
 		},

--- a/pkg/routes/images_test.go
+++ b/pkg/routes/images_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -102,9 +101,6 @@ func TestCreate(t *testing.T) {
 	if status := rr.Code; status != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v, want %v",
 			status, http.StatusOK)
-		b, _ := io.ReadAll(rr.Body)
-		t.Errorf("body %s",
-			b)
 
 	}
 }

--- a/pkg/routes/images_test.go
+++ b/pkg/routes/images_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -39,7 +40,7 @@ func TestCreateWasCalledWithNameNotSet(t *testing.T) {
 	config.Get().Debug = false
 	var jsonStr = []byte(`{
 		"Distribution": "rhel-8",
-		"ImageType": "rhel-edge-installer",
+		"OutputTypes": ["rhel-edge-installer"],
 		"Commit": {
 			"Arch": "x86_64",
 			"Packages" : [ { "name" : "vim"  } ]
@@ -69,7 +70,7 @@ func TestCreate(t *testing.T) {
 	var jsonStr = []byte(`{
 		"Name": "image1",
 		"Distribution": "rhel-8",
-		"ImageType": "rhel-edge-installer",
+		"OutputTypes": ["rhel-edge-installer"],
 		"Commit": {
 			"Arch": "x86_64",
 			"Packages" : [ { "name" : "vim"  } ]
@@ -99,8 +100,12 @@ func TestCreate(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v",
+		t.Errorf("handler returned wrong status code: got %v, want %v",
 			status, http.StatusOK)
+		b, _ := io.ReadAll(rr.Body)
+		t.Errorf("body %s",
+			b)
+
 	}
 }
 func TestGetStatus(t *testing.T) {

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -54,7 +54,14 @@ func (s *ImageService) CreateImage(image *models.Image, account string) error {
 	image.Commit.Account = account
 	image.Commit.Status = models.ImageStatusBuilding
 	image.Status = models.ImageStatusBuilding
-	if image.ImageType == models.ImageTypeInstaller {
+	// TODO: Remove code when frontend is not using ImageType on the table
+	if image.HasOutputType(models.ImageTypeInstaller) {
+		image.ImageType = models.ImageTypeInstaller
+	} else {
+		image.ImageType = models.ImageTypeCommit
+	}
+	// TODO: End of remove block
+	if image.HasOutputType(models.ImageTypeInstaller) {
 		image.Installer.Status = models.ImageStatusCreated
 		image.Installer.Account = image.Account
 		tx := db.DB.Create(&image.Installer)
@@ -124,7 +131,7 @@ func (s *ImageService) postProcessImage(id uint) {
 	repo := s.CreateRepoForImage(i)
 
 	// TODO: We need to discuss this whole thing post-July deliverable
-	if i.ImageType == models.ImageTypeInstaller {
+	if i.HasOutputType(models.ImageTypeInstaller) {
 		i, err := s.imageBuilder.ComposeInstaller(repo, i)
 		if err != nil {
 			log.Error(err)


### PR DESCRIPTION
Related to https://github.com/RedHatInsights/edge-frontend/pull/140 and this one has to be merged first otherwise validation will break on image creation.


When the frontend uses the OutputType to display on the table, we can remove the ImageType field.