### PR TITLE
Fail when no devices are found

### DIFF
--- a/pkg/routes/updates.go
+++ b/pkg/routes/updates.go
@@ -166,8 +166,17 @@ type UpdatePostJSON struct {
 
 func updateFromHTTP(w http.ResponseWriter, r *http.Request) (*models.UpdateTransaction, error) {
 	log.Infof("updateFromHTTP:: Begin")
+
+	account, err := common.GetAccount(r)
+	if err != nil {
+		err := apierrors.NewInternalServerError()
+		err.Title = "No account found"
+		w.WriteHeader(err.Status)
+		return nil, err
+	}
+
 	var updateJSON UpdatePostJSON
-	err := json.NewDecoder(r.Body).Decode(&updateJSON)
+	err = json.NewDecoder(r.Body).Decode(&updateJSON)
 	if err != nil {
 		err := apierrors.NewBadRequest("Invalid JSON")
 		w.WriteHeader(err.Status)
@@ -199,7 +208,7 @@ func updateFromHTTP(w http.ResponseWriter, r *http.Request) (*models.UpdateTrans
 	}
 	if updateJSON.DeviceUUID != "" {
 		inventory, err = client.ReturnDevicesByID(updateJSON.DeviceUUID)
-		if err != nil {
+		if err != nil || inventory.Count == 0 {
 			err := apierrors.NewNotFound(fmt.Sprintf("No devices found for UUID %s", updateJSON.DeviceUUID))
 			w.WriteHeader(err.Status)
 			return &models.UpdateTransaction{}, err
@@ -207,14 +216,6 @@ func updateFromHTTP(w http.ResponseWriter, r *http.Request) (*models.UpdateTrans
 	}
 
 	log.Infof("updateFromHTTP::inventory: %#v", inventory)
-
-	account, err := common.GetAccount(r)
-	if err != nil {
-		err := apierrors.NewInternalServerError()
-		err.Title = "No account found"
-		w.WriteHeader(err.Status)
-		return nil, err
-	}
 
 	// Create the models.UpdateTransaction
 	update := models.UpdateTransaction{

--- a/pkg/routes/updates.go
+++ b/pkg/routes/updates.go
@@ -386,7 +386,7 @@ func AddUpdate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, result.Error.Error(), http.StatusBadRequest)
 	}
 	repoService := services.NewUpdateService(r.Context())
-	log.Infof("AddUpdate:: call:: RepoService.CreateUpdate")
+	log.Infof("AddUpdate:: call:: RepoService.CreateUpdate :: %d", update.ID)
 	go repoService.CreateUpdate(update)
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(update)

--- a/pkg/services/repobuilder.go
+++ b/pkg/services/repobuilder.go
@@ -65,7 +65,7 @@ func (rb *RepoBuilder) BuildUpdateRepo(ut *models.UpdateTransaction) (*models.Up
 	update.Status = models.UpdateStatusCreated
 	db.DB.Save(&update)
 
-	log.Infof("RepoBuilder::updateCommit: %#v", ut.Commit)
+	log.Infof("RepoBuilder::updateCommitID %d and UpdateTransactionID %d", ut.Commit.ID, ut.ID)
 
 	path := filepath.Join(cfg.RepoTempPath, strconv.FormatUint(uint64(ut.RepoID), 10))
 	log.Infof("RepoBuilder::path: %#v", path)

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -81,7 +81,6 @@ func (s *UpdateService) CreateUpdate(update *models.UpdateTransaction) (*models.
 		log.Error(err)
 		return nil, err
 	}
-	log.Debugf("playbooks:WriteTemplate: %#v", playbookURL)
 	// 3. Loop through all devices in UpdateTransaction
 	dispatchRecords := update.DispatchRecords
 	for _, device := range update.Devices {
@@ -193,7 +192,8 @@ func (s *UpdateService) writeTemplate(templateInfo TemplateRemoteInfo, account s
 		// The container will end up out of space if we don't fix it in the long run.
 		log.Errorf("Error deleting temp file: %s ", err.Error())
 	}
-	log.Infof("::WriteTemplate: ENDs")
 	playbookURL = s.getPlaybookURL(templateInfo.UpdateTransactionID)
+	log.Infof("Proxied playbook URL: %s", playbookURL)
+	log.Infof("::WriteTemplate: ENDs")
 	return playbookURL, nil
 }


### PR DESCRIPTION
- Moves up account validation - we should validate that before even calling an external API.
- Checks the total on the inventory response to return a 404 before moving forward with the update process for zero devices.