### PR TITLE
Refactor devices routes to be on a separate file

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,6 +89,7 @@ func main() {
 		s.Route("/commits", routes.MakeCommitsRouter)
 		s.Route("/images", routes.MakeImagesRouter)
 		s.Route("/updates", routes.MakeUpdatesRouter)
+		s.Route("/devices", routes.MakeDevicesRouter)
 	})
 
 	mr := chi.NewRouter()

--- a/pkg/routes/devices.go
+++ b/pkg/routes/devices.go
@@ -1,0 +1,107 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi"
+	"github.com/redhatinsights/edge-api/pkg/clients/inventory"
+	"github.com/redhatinsights/edge-api/pkg/db"
+	"github.com/redhatinsights/edge-api/pkg/dependencies"
+	"github.com/redhatinsights/edge-api/pkg/models"
+	"github.com/redhatinsights/edge-api/pkg/routes/common"
+	log "github.com/sirupsen/logrus"
+)
+
+// MakeDevicesRouter adds support for operations on update
+func MakeDevicesRouter(sub chi.Router) {
+	sub.Route("/device/", func(r chi.Router) {
+		r.Use(DeviceCtx)
+		sub.Get("/{DeviceUUID}", GetDeviceStatus)
+		sub.Get("/{DeviceUUID}/updates", GetUpdateAvailableForDevice)
+	})
+}
+
+type deviceContextKey int
+
+const DeviceContextKey deviceContextKey = iota
+
+// DeviceContext implements context interfaces so we can shuttle around multiple values
+type DeviceContext struct {
+	DeviceUUID string
+	Tag        string
+}
+
+//  DeviceCtx is a handler for Device requests
+func DeviceCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var uCtx DeviceContext
+		uCtx.DeviceUUID = chi.URLParam(r, "DeviceUUID")
+		uCtx.Tag = chi.URLParam(r, "Tag")
+		log.Debugf("UpdateCtx::uCtx: %#v", uCtx)
+		ctx := context.WithValue(r.Context(), DeviceContextKey, &uCtx)
+		log.Debugf("UpdateCtx::ctx: %#v", ctx)
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// GetDeviceStatus returns the device with the given UUID that is associate to the account.
+// This is being used for the inventory table to determine whether the current device image
+// is the latest or older version.
+func GetDeviceStatus(w http.ResponseWriter, r *http.Request) {
+	// var devices []models.Device
+	var results []models.Device
+	//var results []models.UpdateTransaction
+	account, err := common.GetAccount(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	uuid := chi.URLParam(r, "DeviceUUID")
+	result := db.DB.
+		Select("desired_hash, connected, uuid").
+		Table("devices").
+		Joins(
+			`JOIN updatetransaction_devices ON
+			(updatetransaction_devices.device_id = devices.id AND devices.uuid = ?)`,
+			uuid,
+		).
+		Joins(
+			`JOIN update_transactions ON
+			(
+				update_transactions.id = updatetransaction_devices.update_transaction_id AND
+				update_transactions.account = ?
+			)`,
+			account,
+		).Find(&results)
+	if result.Error != nil {
+		http.Error(w, result.Error.Error(), http.StatusBadRequest)
+		return
+	}
+	json.NewEncoder(w).Encode(&results)
+}
+
+// GetUpdateAvailableForDevice returns if exists update for the current image at the device.
+func GetUpdateAvailableForDevice(w http.ResponseWriter, r *http.Request) {
+	uuid := chi.URLParam(r, "DeviceUUID")
+
+	client := inventory.InitClient(r.Context())
+	var device inventory.InventoryResponse
+	device, err := client.ReturnDevicesByID(uuid)
+	fmt.Printf("Device:: %v", device)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+
+	currentCheckSum := device.Result[len(device.Result)-1].Ostree.RpmOstreeDeployments[len(device.Result[len(device.Result)-1].Ostree.RpmOstreeDeployments)-1].Checksum
+	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	result, err := services.DeviceService.GetUpdateAvailableForDevice(currentCheckSum)
+	if err == nil {
+		json.NewEncoder(w).Encode(result)
+		return
+	}
+	json.NewEncoder(w).Encode(http.StatusNotFound)
+}

--- a/pkg/routes/devices.go
+++ b/pkg/routes/devices.go
@@ -3,7 +3,6 @@ package routes
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/go-chi/chi"
@@ -31,7 +30,8 @@ const DeviceContextKey deviceContextKey = iota
 // DeviceContext implements context interfaces so we can shuttle around multiple values
 type DeviceContext struct {
 	DeviceUUID string
-	Tag        string
+	// TODO: Implement devices by tag
+	// Tag string
 }
 
 //  DeviceCtx is a handler for Device requests
@@ -39,7 +39,8 @@ func DeviceCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var uCtx DeviceContext
 		uCtx.DeviceUUID = chi.URLParam(r, "DeviceUUID")
-		uCtx.Tag = chi.URLParam(r, "Tag")
+		// TODO: Implement devices by tag
+		// uCtx.Tag = chi.URLParam(r, "Tag")
 		log.Debugf("UpdateCtx::uCtx: %#v", uCtx)
 		ctx := context.WithValue(r.Context(), DeviceContextKey, &uCtx)
 		log.Debugf("UpdateCtx::ctx: %#v", ctx)
@@ -52,9 +53,7 @@ func DeviceCtx(next http.Handler) http.Handler {
 // This is being used for the inventory table to determine whether the current device image
 // is the latest or older version.
 func GetDeviceStatus(w http.ResponseWriter, r *http.Request) {
-	// var devices []models.Device
 	var results []models.Device
-	//var results []models.UpdateTransaction
 	account, err := common.GetAccount(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -91,7 +90,6 @@ func GetUpdateAvailableForDevice(w http.ResponseWriter, r *http.Request) {
 	client := inventory.InitClient(r.Context())
 	var device inventory.InventoryResponse
 	device, err := client.ReturnDevicesByID(uuid)
-	fmt.Printf("Device:: %v", device)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	}

--- a/pkg/routes/updates.go
+++ b/pkg/routes/updates.go
@@ -1,17 +1,14 @@
 package routes
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
 
-	"context"
-	"time"
-
 	"github.com/go-chi/chi"
-	"github.com/google/uuid"
 	"github.com/redhatinsights/edge-api/pkg/clients/inventory"
 	"github.com/redhatinsights/edge-api/pkg/db"
 	"github.com/redhatinsights/edge-api/pkg/dependencies"
@@ -20,44 +17,69 @@ import (
 	"github.com/redhatinsights/edge-api/pkg/routes/common"
 	"github.com/redhatinsights/edge-api/pkg/services"
 
-	apierrors "github.com/redhatinsights/edge-api/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-// MakeRouter adds support for operations on update
+// MakeUpdatesRouter adds support for operations on update
 func MakeUpdatesRouter(sub chi.Router) {
-	sub.Use(UpdateCtx)
-	sub.Get("/device/{DeviceUUID}", GetDeviceStatus)
-	sub.Get("/device/{DeviceUUID}/updates", GetUpdateAvailableForDevice)
 	sub.With(common.Paginate).Get("/", GetUpdates)
 	sub.Post("/", AddUpdate)
 	sub.Route("/{updateID}", func(r chi.Router) {
 		r.Use(UpdateCtx)
 		r.Get("/", GetUpdateByID)
 		r.Get("/update-playbook.yml", GetUpdatePlaybook)
-		r.Put("/", UpdatesUpdate)
 	})
+	// TODO: This is for backwards compatibility with the previous route
+	// Once the frontend starts querying the device
+	sub.Route("/device/", MakeDevicesRouter)
 }
 
-// GetUpdatePlaybook returns the playbook for a update transaction
-func GetUpdatePlaybook(w http.ResponseWriter, r *http.Request) {
-	account, err := common.GetAccount(r)
-	if err != nil {
-		err := errors.NewBadRequest("Account can't be empty")
-		w.WriteHeader(err.Status)
-		json.NewEncoder(w).Encode(&err)
-		return
-	}
-	var update *models.UpdateTransaction
-	if updateID := chi.URLParam(r, "updateID"); updateID != "" {
-		id, err := strconv.Atoi(updateID)
+type updateContextKey int
+
+const UpdateContextKey updateContextKey = iota
+
+// UpdateCtx is a handler for Update requests
+func UpdateCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var update models.UpdateTransaction
+		account, err := common.GetAccount(r)
 		if err != nil {
+			err := errors.NewBadRequest(err.Error())
+			w.WriteHeader(err.Status)
+			json.NewEncoder(w).Encode(&err)
+			return
+		}
+		updateID := chi.URLParam(r, "updateID")
+		if updateID == "" {
 			err := errors.NewBadRequest("UpdateTransactionID can't be empty")
 			w.WriteHeader(err.Status)
 			json.NewEncoder(w).Encode(&err)
 			return
 		}
-		db.DB.Where("update_transactions.account = ?", account).Find(&update, id)
+		id, err := strconv.Atoi(updateID)
+		if err != nil {
+			err := errors.NewBadRequest(err.Error())
+			w.WriteHeader(err.Status)
+			json.NewEncoder(w).Encode(&err)
+			return
+		}
+		result := db.DB.Preload("DispatchRecords").Preload("Devices").Where("update_transactions.account = ?", account).Joins("Commit").Joins("Repo").Find(&update, id)
+		if result.Error != nil {
+			err := errors.NewInternalServerError()
+			w.WriteHeader(err.Status)
+			json.NewEncoder(w).Encode(&err)
+			return
+		}
+		ctx := context.WithValue(r.Context(), UpdateContextKey, &update)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// GetUpdatePlaybook returns the playbook for a update transaction
+func GetUpdatePlaybook(w http.ResponseWriter, r *http.Request) {
+	update := getUpdate(w, r)
+	if update == nil {
+		return
 	}
 	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
 	playbook, err := services.UpdateService.GetUpdatePlaybook(update)
@@ -77,64 +99,6 @@ func GetUpdatePlaybook(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// GetDeviceStatus returns the device with the given UUID that is associate to the account.
-// This is being used for the inventory table to determine whether the current device image
-// is the latest or older version.
-func GetDeviceStatus(w http.ResponseWriter, r *http.Request) {
-	// var devices []models.Device
-	var results []models.Device
-	//var results []models.UpdateTransaction
-	account, err := common.GetAccount(r)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	uuid := chi.URLParam(r, "DeviceUUID")
-	result := db.DB.
-		Select("desired_hash, connected, uuid").
-		Table("devices").
-		Joins(
-			`JOIN updatetransaction_devices ON
-			(updatetransaction_devices.device_id = devices.id AND devices.uuid = ?)`,
-			uuid,
-		).
-		Joins(
-			`JOIN update_transactions ON
-			(
-				update_transactions.id = updatetransaction_devices.update_transaction_id AND
-				update_transactions.account = ?
-			)`,
-			account,
-		).Find(&results)
-	if result.Error != nil {
-		http.Error(w, result.Error.Error(), http.StatusBadRequest)
-		return
-	}
-	json.NewEncoder(w).Encode(&results)
-}
-
-// GetUpdateAvailableForDevice returns if exists update for the current image at the device.
-func GetUpdateAvailableForDevice(w http.ResponseWriter, r *http.Request) {
-	uuid := chi.URLParam(r, "DeviceUUID")
-
-	client := inventory.InitClient(r.Context())
-	var device inventory.InventoryResponse
-	device, err := client.ReturnDevicesByID(uuid)
-	fmt.Printf("Device:: %v", device)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-	}
-
-	currentCheckSum := device.Result[len(device.Result)-1].Ostree.RpmOstreeDeployments[len(device.Result[len(device.Result)-1].Ostree.RpmOstreeDeployments)-1].Checksum
-	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
-	result, err := services.DeviceService.GetUpdateAvailableForDevice(currentCheckSum)
-	if err == nil {
-		json.NewEncoder(w).Encode(result)
-		return
-	}
-	json.NewEncoder(w).Encode(http.StatusNotFound)
-}
-
 func GetUpdates(w http.ResponseWriter, r *http.Request) {
 	var updates []models.UpdateTransaction
 	account, err := common.GetAccount(r)
@@ -152,16 +116,11 @@ func GetUpdates(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(&updates)
 }
 
-func isUUID(param string) bool {
-	_, err := uuid.Parse(param)
-	return err == nil
-
-}
-
 type UpdatePostJSON struct {
 	CommitID   uint   `json:"CommitID"`
-	Tag        string `json:"Tag"`
 	DeviceUUID string `json:"DeviceUUID"`
+	// TODO: Implement updates by tag
+	// Tag        string `json:"Tag"`
 }
 
 func updateFromHTTP(w http.ResponseWriter, r *http.Request) (*models.UpdateTransaction, error) {
@@ -169,7 +128,7 @@ func updateFromHTTP(w http.ResponseWriter, r *http.Request) (*models.UpdateTrans
 
 	account, err := common.GetAccount(r)
 	if err != nil {
-		err := apierrors.NewInternalServerError()
+		err := errors.NewInternalServerError()
 		err.Title = "No account found"
 		w.WriteHeader(err.Status)
 		return nil, err
@@ -178,40 +137,40 @@ func updateFromHTTP(w http.ResponseWriter, r *http.Request) (*models.UpdateTrans
 	var updateJSON UpdatePostJSON
 	err = json.NewDecoder(r.Body).Decode(&updateJSON)
 	if err != nil {
-		err := apierrors.NewBadRequest("Invalid JSON")
+		err := errors.NewBadRequest("Invalid JSON")
 		w.WriteHeader(err.Status)
 		return nil, err
 	}
 	log.Infof("updateFromHTTP::updateJSON: %#v", updateJSON)
 
 	if updateJSON.CommitID == 0 {
-		err := apierrors.NewBadRequest("Must provide a CommitID")
+		err := errors.NewBadRequest("Must provide a CommitID")
 		w.WriteHeader(err.Status)
 		return nil, err
 	}
-	if (updateJSON.Tag == "") && (updateJSON.DeviceUUID == "") {
-		err := apierrors.NewBadRequest("At least one of Tag or DeviceUUID required.")
+	// TODO: Implement update by tag - Add validation per tag
+	if updateJSON.DeviceUUID == "" {
+		err := errors.NewBadRequest("DeviceUUID required.")
 		w.WriteHeader(err.Status)
 		return nil, err
 	}
 	client := inventory.InitClient(r.Context())
 	var inventory inventory.InventoryResponse
-	if updateJSON.Tag != "" {
-		uCtx, _ := r.Context().Value(UpdateContextKey).(UpdateContext) // this is sanitized in updates/updates
-		tag := uCtx.Tag
-		inventory, err = client.ReturnDevicesByTag(tag)
-		if err != nil {
-			err := apierrors.NewNotFound(fmt.Sprintf("No devices in this tag %s", updateJSON.Tag))
-			w.WriteHeader(err.Status)
-			return &models.UpdateTransaction{}, err
-		}
-	}
+	// TODO: Implement update by tag
+	// if updateJSON.Tag != "" {
+	// 	inventory, err = client.ReturnDevicesByTag(updateJSON.Tag)
+	// 	if err != nil || inventory.Count == 0 {
+	// 		err := errors.NewNotFound(fmt.Sprintf("No devices found for Tag %s", updateJSON.Tag))
+	// 		w.WriteHeader(err.Status)
+	// 		return nil, err
+	// 	}
+	// }
 	if updateJSON.DeviceUUID != "" {
 		inventory, err = client.ReturnDevicesByID(updateJSON.DeviceUUID)
 		if err != nil || inventory.Count == 0 {
-			err := apierrors.NewNotFound(fmt.Sprintf("No devices found for UUID %s", updateJSON.DeviceUUID))
+			err := errors.NewNotFound(fmt.Sprintf("No devices found for UUID %s", updateJSON.DeviceUUID))
 			w.WriteHeader(err.Status)
-			return &models.UpdateTransaction{}, err
+			return nil, err
 		}
 	}
 
@@ -221,7 +180,8 @@ func updateFromHTTP(w http.ResponseWriter, r *http.Request) (*models.UpdateTrans
 	update := models.UpdateTransaction{
 		Account:  account,
 		CommitID: updateJSON.CommitID,
-		Tag:      updateJSON.Tag,
+		// TODO: Implement update by tag
+		// Tag:      updateJSON.Tag,
 	}
 
 	// Get the models.Commit from the Commit ID passed in via JSON
@@ -230,7 +190,7 @@ func updateFromHTTP(w http.ResponseWriter, r *http.Request) (*models.UpdateTrans
 	log.Infof("updateFromHTTP::update.Commit: %#v", update.Commit)
 	update.DispatchRecords = []models.DispatchRecord{}
 	if err != nil {
-		err := apierrors.NewInternalServerError()
+		err := errors.NewInternalServerError()
 		err.Title = fmt.Sprintf("No commit found for CommitID %d", updateJSON.CommitID)
 		w.WriteHeader(err.Status)
 		return &models.UpdateTransaction{}, err
@@ -318,32 +278,6 @@ func updateFromHTTP(w http.ResponseWriter, r *http.Request) (*models.UpdateTrans
 	return &update, nil
 }
 
-type key int
-
-const UpdateContextKey key = 0
-
-// Implement Context interface so we can shuttle around multiple values
-type UpdateContext struct {
-	DeviceUUID string
-	Tag        string
-	UpdateID   string
-}
-
-// UpdateCtx is a handler for Update requests
-func UpdateCtx(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var uCtx UpdateContext
-		uCtx.DeviceUUID = chi.URLParam(r, "DeviceUUID")
-		uCtx.Tag = chi.URLParam(r, "Tag")
-		uCtx.UpdateID = chi.URLParam(r, "updateID")
-		log.Debugf("UpdateCtx::uCtx: %#v", uCtx)
-		ctx := context.WithValue(r.Context(), UpdateContextKey, &uCtx)
-		log.Debugf("UpdateCtx::ctx: %#v", ctx)
-
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
-}
-
 // AddUpdate adds an object to the database for an account
 func AddUpdate(w http.ResponseWriter, r *http.Request) {
 	log.Infof("AddUpdate::update:: Begin")
@@ -395,50 +329,11 @@ func AddUpdate(w http.ResponseWriter, r *http.Request) {
 
 // GetUpdateByID obtains an update from the database for an account
 func GetUpdateByID(w http.ResponseWriter, r *http.Request) {
-	var update models.UpdateTransaction
-
-	account, err := common.GetAccount(r)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	if updateID := chi.URLParam(r, "updateID"); updateID != "" {
-		id, err := strconv.Atoi(updateID)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		result := db.DB.Preload("DispatchRecords").Preload("Devices").Where("update_transactions.account = ?", account).Joins("Commit").Joins("Repo").Find(&update, id)
-		if result.Error != nil {
-			http.Error(w, result.Error.Error(), http.StatusNotFound)
-			return
-		}
-		json.NewEncoder(w).Encode(update)
-	} else {
-		json.NewEncoder(w).Encode(&models.UpdateTransaction{})
-	}
-}
-
-// UpdatesUpdate a update object in the database for an an account
-func UpdatesUpdate(w http.ResponseWriter, r *http.Request) {
 	update := getUpdate(w, r)
 	if update == nil {
 		return
 	}
-
-	incoming, err := updateFromHTTP(w, r)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	now := time.Now()
-	incoming.ID = update.ID
-	incoming.CreatedAt = now
-	incoming.UpdatedAt = now
-	db.DB.Save(&incoming)
-
-	json.NewEncoder(w).Encode(incoming)
+	json.NewEncoder(w).Encode(update)
 }
 
 func getUpdate(w http.ResponseWriter, r *http.Request) *models.UpdateTransaction {


### PR DESCRIPTION
Yesterday while coding the update playbook method I noticed some improvements and talked to @acosferreira about it today.

I want to do some unit tests for the code pushed yesterday, so this should make things easier to test too.

- Creates devices route file.
- Separates device and update context
- Makes getUpdate work again
- Delete code that is not used or could be reused