### PR TITLE
Update app-common-go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/go-openapi/runtime v0.19.29
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/uuid v1.1.1
 	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
 	github.com/lib/pq v1.3.0
 	github.com/magiconair/properties v1.8.5 // indirect
@@ -19,7 +18,7 @@ require (
 	github.com/pelletier/go-toml v1.9.1 // indirect
 	github.com/prometheus/client_golang v1.10.0
 	github.com/prometheus/common v0.25.0 // indirect
-	github.com/redhatinsights/app-common-go v1.5.0
+	github.com/redhatinsights/app-common-go v1.5.2
 	github.com/redhatinsights/platform-go-middlewares v0.8.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -529,8 +529,8 @@ github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3x
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/redhatinsights/app-common-go v1.5.0 h1:tKJHmRKWjwxh91SQNU5XJ1KaEw+0RNu2aVqYPCUWElE=
-github.com/redhatinsights/app-common-go v1.5.0/go.mod h1:SqgG5JkX/RNlk2d+sXamIFxhOIvWLgCBr8uK6q70ESk=
+github.com/redhatinsights/app-common-go v1.5.2 h1:d3AWa54B5ZHdetP3Kzo5vCCsJZr2VWDQv0DrP0RS8XE=
+github.com/redhatinsights/app-common-go v1.5.2/go.mod h1:SqgG5JkX/RNlk2d+sXamIFxhOIvWLgCBr8uK6q70ESk=
 github.com/redhatinsights/platform-go-middlewares v0.8.1 h1:PNmD3kk4OhrnR+tYQBLOxq6Rf0INcim4/H+6dHlWwFc=
 github.com/redhatinsights/platform-go-middlewares v0.8.1/go.mod h1:koDaxx4Ht3ZgXqAhfkKFhBy9586kZ3aDm9IAlEs0Oo4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=


### PR DESCRIPTION
With `app-common-go` version 1.5.0, updating the OpenAPI spec gives a benign but confusing error message:

```
$ go run cmd/spec/main.go 
open : no such file or directory
```

This PR updates the dependency to version 1.5.2, which still outputs a message, but at least it's more understandable:

```
$ go run cmd/spec/main.go 
Clowder is not enabled, skipping init...
```

(The clowder config package prints this message during import if the `ACG_CONFIG` environment variable is not set, but `cmd/spec/main.go` doesn't use that package, so the message can be ignored.)