### PR TITLE
Use the edge iqe plugin image for smoke tests, instead of the full iqe test suite image

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -86,6 +86,8 @@ objects:
     - ${EDGE_TARBALLS_BUCKET}
     database:
       name: edge
+    testing:
+      iqePlugin: edge
 
 parameters:
 - description: Cpu limit of service


### PR DESCRIPTION
The GitHub PR checks were previously using the container images that contain the full test suite from all IQE plugins. To avoid potential problems caused by changes to other plugins, this PR updates `clowdapp.yaml` to use the images containing only the edge plugin.