### PR TITLE
Add validation in image creation to image name already in use

### DIFF
--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 
 	"github.com/lib/pq"
+	"github.com/redhatinsights/edge-api/pkg/db"
 )
 
 type ImageSet struct {
@@ -44,6 +45,8 @@ const (
 	NameCantBeInvalidMessage = "name must start with alphanumeric characters and can contain underscore and hyphen characters"
 	// ImageTypeNotAccepted is the error message when an image type is not accepted
 	ImageTypeNotAccepted = "this image type is not accepted"
+	// ImageNameAlreadyExists is the error message when an image name alredy exists
+	ImageNameAlreadyExists = "this image name is already in use"
 	// NoOutputTypes is the error message when the output types list is empty
 	NoOutputTypes = "an output type is required"
 
@@ -96,6 +99,10 @@ func (i *Image) ValidateRequest() error {
 			return errors.New(ImageTypeNotAccepted)
 		}
 	}
+	if i.Version == 1 && checkIfImageExist(i.Name) {
+		return errors.New(ImageNameAlreadyExists)
+	}
+
 	// Installer checks
 	if i.HasOutputType(ImageTypeInstaller) {
 		if i.Installer == nil {
@@ -123,4 +130,14 @@ func (i *Image) HasOutputType(imageType string) bool {
 		}
 	}
 	return false
+}
+
+//checkIfImageExist checks if name to image is already in use
+func checkIfImageExist(imageName string) bool {
+	var imageFindByName *Image
+	result := db.DB.Where("Name = ?", imageName).First(&imageFindByName)
+	if result.Error != nil {
+		return false
+	}
+	return imageFindByName != nil
 }

--- a/pkg/models/images_test.go
+++ b/pkg/models/images_test.go
@@ -122,6 +122,17 @@ func TestValidateRequest(t *testing.T) {
 			expected: errors.New(InvalidSSHKeyError),
 		},
 		{
+			name: "check if image name is already in use",
+			image: &Image{
+				Distribution: "rhel-8",
+				Name:         "image_name_pre_exist",
+				Commit:       &Commit{Arch: "x86_64"},
+				OutputTypes:  []string{ImageTypeCommit},
+				Version:      1,
+			},
+			expected: errors.New(ImageNameAlreadyExists),
+		},
+		{
 			name: "valid image request",
 			image: &Image{
 				Distribution: "rhel-8",
@@ -142,6 +153,17 @@ func TestValidateRequest(t *testing.T) {
 				Name:         "image_name",
 				Commit:       &Commit{Arch: "x86_64"},
 				OutputTypes:  []string{ImageTypeCommit},
+			},
+			expected: nil,
+		},
+		{
+			name: "Update Image with name already in use",
+			image: &Image{
+				Distribution: "rhel-8",
+				Name:         "image_name_pre_exist",
+				Commit:       &Commit{Arch: "x86_64"},
+				OutputTypes:  []string{ImageTypeCommit},
+				Version:      2,
 			},
 			expected: nil,
 		},

--- a/pkg/models/main_test.go
+++ b/pkg/models/main_test.go
@@ -1,0 +1,55 @@
+package models
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/db"
+)
+
+func TestMain(m *testing.M) {
+	setUp()
+	retCode := m.Run()
+	tearDown()
+	os.Exit(retCode)
+}
+
+var dbName string
+
+func setUp() {
+	config.Init()
+	config.Get().Debug = true
+	time := time.Now().UnixNano()
+	dbName = fmt.Sprintf("%d-models.db", time)
+	config.Get().Database.Name = dbName
+	db.InitDB()
+	err := db.DB.AutoMigrate(
+		ImageSet{},
+		Commit{},
+		UpdateTransaction{},
+		Package{},
+		Image{},
+		Repo{},
+		Device{},
+		DispatchRecord{},
+	)
+	var testImage = Image{
+		Account:      "0000000",
+		Status:       ImageStatusBuilding,
+		Distribution: "rhel-8",
+		Name:         "image_name_pre_exist",
+		Commit:       &Commit{Arch: "x86_64"},
+		OutputTypes:  []string{ImageTypeCommit},
+	}
+	db.DB.Create(&testImage)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func tearDown() {
+	os.Remove(dbName)
+}

--- a/pkg/routes/images_test.go
+++ b/pkg/routes/images_test.go
@@ -67,7 +67,7 @@ func TestCreateWasCalledWithNameNotSet(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	var jsonStr = []byte(`{
-		"Name": "image1",
+		"Name": "image2",
 		"Distribution": "rhel-8",
 		"OutputTypes": ["rhel-edge-installer"],
 		"Commit": {


### PR DESCRIPTION
### What is inside?
- Add previous reverted changes to validate if image name is already in use but adding additional check to version to avoid to false fail in update process 

### how is it build?
- Add validation in model/image.go
- add test in model/image_test.go
- add db init for test in Model
- add an image to initial db 
- Add method to query db and retrieve first image using the name and fail if version equals 1  