### PR TITLE
Update openapi spec cmd to pretty-print json file

### DIFF
--- a/cmd/spec/main.go
+++ b/cmd/spec/main.go
@@ -96,7 +96,7 @@ func main() {
 	doc, err := openapi3.NewLoader().LoadFromData(b.Bytes())
 	checkErr(err)
 
-	jsonB, err := doc.MarshalJSON()
+	jsonB, err := json.MarshalIndent(doc, "", "  ")
 	checkErr(err)
 	err = ioutil.WriteFile("./cmd/spec/openapi.json", jsonB, 0666)
 	checkErr(err)

--- a/cmd/spec/openapi.json
+++ b/cmd/spec/openapi.json
@@ -1,1 +1,2871 @@
-{"components":{"schemas":{"v1.AddUpdate":{"properties":{"CommitID":{},"DeviceUUID":{"type":"string"}},"type":"object"},"v1.BadRequest":{"properties":{"Code":{"type":"string"},"Status":{"type":"integer"},"Title":{"type":"string"}},"type":"object"},"v1.Device":{"properties":{"Connected":{"type":"boolean"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"DesiredHash":{"type":"string"},"ID":{},"RHCClientID":{"type":"string"},"UUID":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"v1.DeviceDetails":{"properties":{"Device":{"properties":{"Connected":{"type":"boolean"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"DesiredHash":{"type":"string"},"ID":{},"RHCClientID":{"type":"string"},"UUID":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"ImageInfo":{"properties":{"Image":{"properties":{"Account":{"type":"string"},"Commit":{"properties":{"Account":{"type":"string"},"Arch":{"type":"string"},"BlueprintToml":{"type":"string"},"BuildDate":{"type":"string"},"BuildNumber":{},"ComposeJobID":{"type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"ImageBuildHash":{"type":"string"},"ImageBuildParentHash":{"type":"string"},"ImageBuildTarURL":{"type":"string"},"InstalledPackages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"UpdatedAt":{"format":"date-time","type":"string"},"arch":{"type":"string"},"epoch":{"type":"string"},"name":{"type":"string"},"release":{"type":"string"},"sigmd5":{"type":"string"},"signature":{"type":"string"},"type":{"type":"string"},"version":{"type":"string"}},"type":"object"},"type":"array"},"OSTreeCommit":{"type":"string"},"OSTreeParentCommit":{"type":"string"},"OSTreeRef":{"type":"string"},"Packages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"Name":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"CommitID":{},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"Description":{"type":"string"},"Distribution":{"type":"string"},"ID":{},"ImageSetID":{},"ImageType":{"type":"string"},"Installer":{"properties":{"Account":{"type":"string"},"Checksum":{"type":"string"},"ComposeJobID":{"type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"ImageBuildISOURL":{"type":"string"},"SshKey":{"type":"string"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"},"Username":{"type":"string"}},"type":"object"},"InstallerID":{},"Name":{"type":"string"},"OutputTypes":{"items":{"type":"string"},"type":"array"},"ParentId":{},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"},"Version":{"type":"integer"}},"type":"object"},"RollbackImage":{"properties":{"Account":{"type":"string"},"Commit":{"properties":{"Account":{"type":"string"},"Arch":{"type":"string"},"BlueprintToml":{"type":"string"},"BuildDate":{"type":"string"},"BuildNumber":{},"ComposeJobID":{"type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"ImageBuildHash":{"type":"string"},"ImageBuildParentHash":{"type":"string"},"ImageBuildTarURL":{"type":"string"},"InstalledPackages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"UpdatedAt":{"format":"date-time","type":"string"},"arch":{"type":"string"},"epoch":{"type":"string"},"name":{"type":"string"},"release":{"type":"string"},"sigmd5":{"type":"string"},"signature":{"type":"string"},"type":{"type":"string"},"version":{"type":"string"}},"type":"object"},"type":"array"},"OSTreeCommit":{"type":"string"},"OSTreeParentCommit":{"type":"string"},"OSTreeRef":{"type":"string"},"Packages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"Name":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"CommitID":{},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"Description":{"type":"string"},"Distribution":{"type":"string"},"ID":{},"ImageSetID":{},"ImageType":{"type":"string"},"Installer":{"properties":{"Account":{"type":"string"},"Checksum":{"type":"string"},"ComposeJobID":{"type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"ImageBuildISOURL":{"type":"string"},"SshKey":{"type":"string"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"},"Username":{"type":"string"}},"type":"object"},"InstallerID":{},"Name":{"type":"string"},"OutputTypes":{"items":{"type":"string"},"type":"array"},"ParentId":{},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"},"Version":{"type":"integer"}},"type":"object"},"UpdatesAvailable":{"items":{"properties":{"Image":{"properties":{"Account":{"type":"string"},"Commit":{"properties":{"Account":{"type":"string"},"Arch":{"type":"string"},"BlueprintToml":{"type":"string"},"BuildDate":{"type":"string"},"BuildNumber":{},"ComposeJobID":{"type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"ImageBuildHash":{"type":"string"},"ImageBuildParentHash":{"type":"string"},"ImageBuildTarURL":{"type":"string"},"InstalledPackages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"UpdatedAt":{"format":"date-time","type":"string"},"arch":{"type":"string"},"epoch":{"type":"string"},"name":{"type":"string"},"release":{"type":"string"},"sigmd5":{"type":"string"},"signature":{"type":"string"},"type":{"type":"string"},"version":{"type":"string"}},"type":"object"},"type":"array"},"OSTreeCommit":{"type":"string"},"OSTreeParentCommit":{"type":"string"},"OSTreeRef":{"type":"string"},"Packages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"Name":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"CommitID":{},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"Description":{"type":"string"},"Distribution":{"type":"string"},"ID":{},"ImageSetID":{},"ImageType":{"type":"string"},"Installer":{"properties":{"Account":{"type":"string"},"Checksum":{"type":"string"},"ComposeJobID":{"type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"ImageBuildISOURL":{"type":"string"},"SshKey":{"type":"string"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"},"Username":{"type":"string"}},"type":"object"},"InstallerID":{},"Name":{"type":"string"},"OutputTypes":{"items":{"type":"string"},"type":"array"},"ParentId":{},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"},"Version":{"type":"integer"}},"type":"object"},"PackageDiff":{"properties":{"Added":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"UpdatedAt":{"format":"date-time","type":"string"},"arch":{"type":"string"},"epoch":{"type":"string"},"name":{"type":"string"},"release":{"type":"string"},"sigmd5":{"type":"string"},"signature":{"type":"string"},"type":{"type":"string"},"version":{"type":"string"}},"type":"object"},"type":"array"},"Removed":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"UpdatedAt":{"format":"date-time","type":"string"},"arch":{"type":"string"},"epoch":{"type":"string"},"name":{"type":"string"},"release":{"type":"string"},"sigmd5":{"type":"string"},"signature":{"type":"string"},"type":{"type":"string"},"version":{"type":"string"}},"type":"object"},"type":"array"},"Upgraded":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"UpdatedAt":{"format":"date-time","type":"string"},"arch":{"type":"string"},"epoch":{"type":"string"},"name":{"type":"string"},"release":{"type":"string"},"sigmd5":{"type":"string"},"signature":{"type":"string"},"type":{"type":"string"},"version":{"type":"string"}},"type":"object"},"type":"array"}},"type":"object"}},"type":"object"},"type":"array"}},"type":"object"},"UpdateTransactions":{"items":{"properties":{"Account":{"type":"string"},"Commit":{"properties":{"Account":{"type":"string"},"Arch":{"type":"string"},"BlueprintToml":{"type":"string"},"BuildDate":{"type":"string"},"BuildNumber":{},"ComposeJobID":{"type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"ImageBuildHash":{"type":"string"},"ImageBuildParentHash":{"type":"string"},"ImageBuildTarURL":{"type":"string"},"InstalledPackages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"UpdatedAt":{"format":"date-time","type":"string"},"arch":{"type":"string"},"epoch":{"type":"string"},"name":{"type":"string"},"release":{"type":"string"},"sigmd5":{"type":"string"},"signature":{"type":"string"},"type":{"type":"string"},"version":{"type":"string"}},"type":"object"},"type":"array"},"OSTreeCommit":{"type":"string"},"OSTreeParentCommit":{"type":"string"},"OSTreeRef":{"type":"string"},"Packages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"Name":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"CommitID":{},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"Devices":{"items":{"properties":{"Connected":{"type":"boolean"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"DesiredHash":{"type":"string"},"ID":{},"RHCClientID":{"type":"string"},"UUID":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"DispatchRecords":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"Device":{"properties":{"Connected":{"type":"boolean"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"DesiredHash":{"type":"string"},"ID":{},"RHCClientID":{"type":"string"},"UUID":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"DeviceID":{},"ID":{},"PlaybookDispatcherID":{"type":"string"},"PlaybookURL":{"type":"string"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"ID":{},"OldCommits":{"items":{"properties":{"Account":{"type":"string"},"Arch":{"type":"string"},"BlueprintToml":{"type":"string"},"BuildDate":{"type":"string"},"BuildNumber":{},"ComposeJobID":{"type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"ImageBuildHash":{"type":"string"},"ImageBuildParentHash":{"type":"string"},"ImageBuildTarURL":{"type":"string"},"InstalledPackages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"UpdatedAt":{"format":"date-time","type":"string"},"arch":{"type":"string"},"epoch":{"type":"string"},"name":{"type":"string"},"release":{"type":"string"},"sigmd5":{"type":"string"},"signature":{"type":"string"},"type":{"type":"string"},"version":{"type":"string"}},"type":"object"},"type":"array"},"OSTreeCommit":{"type":"string"},"OSTreeParentCommit":{"type":"string"},"OSTreeRef":{"type":"string"},"Packages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"Name":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"Repo":{"properties":{"Commit":{"properties":{"Account":{"type":"string"},"Arch":{"type":"string"},"BlueprintToml":{"type":"string"},"BuildDate":{"type":"string"},"BuildNumber":{},"ComposeJobID":{"type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"ImageBuildHash":{"type":"string"},"ImageBuildParentHash":{"type":"string"},"ImageBuildTarURL":{"type":"string"},"InstalledPackages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"UpdatedAt":{"format":"date-time","type":"string"},"arch":{"type":"string"},"epoch":{"type":"string"},"name":{"type":"string"},"release":{"type":"string"},"sigmd5":{"type":"string"},"signature":{"type":"string"},"type":{"type":"string"},"version":{"type":"string"}},"type":"object"},"type":"array"},"OSTreeCommit":{"type":"string"},"OSTreeParentCommit":{"type":"string"},"OSTreeRef":{"type":"string"},"Packages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"Name":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"CommitID":{},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"RepoStatus":{"type":"string"},"RepoURL":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"RepoID":{},"Status":{"type":"string"},"Tag":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"}},"type":"object"},"v1.Image":{"properties":{"Account":{"type":"string"},"Commit":{"properties":{"Account":{"type":"string"},"Arch":{"type":"string"},"BlueprintToml":{"type":"string"},"BuildDate":{"type":"string"},"BuildNumber":{},"ComposeJobID":{"type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"ImageBuildHash":{"type":"string"},"ImageBuildParentHash":{"type":"string"},"ImageBuildTarURL":{"type":"string"},"InstalledPackages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"UpdatedAt":{"format":"date-time","type":"string"},"arch":{"type":"string"},"epoch":{"type":"string"},"name":{"type":"string"},"release":{"type":"string"},"sigmd5":{"type":"string"},"signature":{"type":"string"},"type":{"type":"string"},"version":{"type":"string"}},"type":"object"},"type":"array"},"OSTreeCommit":{"type":"string"},"OSTreeParentCommit":{"type":"string"},"OSTreeRef":{"type":"string"},"Packages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"Name":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"CommitID":{},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"Description":{"type":"string"},"Distribution":{"type":"string"},"ID":{},"ImageSetID":{},"ImageType":{"type":"string"},"Installer":{"properties":{"Account":{"type":"string"},"Checksum":{"type":"string"},"ComposeJobID":{"type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"ImageBuildISOURL":{"type":"string"},"SshKey":{"type":"string"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"},"Username":{"type":"string"}},"type":"object"},"InstallerID":{},"Name":{"type":"string"},"OutputTypes":{"items":{"type":"string"},"type":"array"},"ParentId":{},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"},"Version":{"type":"integer"}},"type":"object"},"v1.InternalServerError":{"properties":{"Code":{"type":"string"},"Status":{"type":"integer"},"Title":{"type":"string"}},"type":"object"},"v1.NotFound":{"properties":{"Code":{"type":"string"},"Status":{"type":"integer"},"Title":{"type":"string"}},"type":"object"},"v1.Repo":{"properties":{"Commit":{"properties":{"Account":{"type":"string"},"Arch":{"type":"string"},"BlueprintToml":{"type":"string"},"BuildDate":{"type":"string"},"BuildNumber":{},"ComposeJobID":{"type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"ImageBuildHash":{"type":"string"},"ImageBuildParentHash":{"type":"string"},"ImageBuildTarURL":{"type":"string"},"InstalledPackages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"UpdatedAt":{"format":"date-time","type":"string"},"arch":{"type":"string"},"epoch":{"type":"string"},"name":{"type":"string"},"release":{"type":"string"},"sigmd5":{"type":"string"},"signature":{"type":"string"},"type":{"type":"string"},"version":{"type":"string"}},"type":"object"},"type":"array"},"OSTreeCommit":{"type":"string"},"OSTreeParentCommit":{"type":"string"},"OSTreeRef":{"type":"string"},"Packages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"Name":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"CommitID":{},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"RepoStatus":{"type":"string"},"RepoURL":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"v1.UpdateTransaction":{"properties":{"Account":{"type":"string"},"Commit":{"properties":{"Account":{"type":"string"},"Arch":{"type":"string"},"BlueprintToml":{"type":"string"},"BuildDate":{"type":"string"},"BuildNumber":{},"ComposeJobID":{"type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"ImageBuildHash":{"type":"string"},"ImageBuildParentHash":{"type":"string"},"ImageBuildTarURL":{"type":"string"},"InstalledPackages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"UpdatedAt":{"format":"date-time","type":"string"},"arch":{"type":"string"},"epoch":{"type":"string"},"name":{"type":"string"},"release":{"type":"string"},"sigmd5":{"type":"string"},"signature":{"type":"string"},"type":{"type":"string"},"version":{"type":"string"}},"type":"object"},"type":"array"},"OSTreeCommit":{"type":"string"},"OSTreeParentCommit":{"type":"string"},"OSTreeRef":{"type":"string"},"Packages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"Name":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"CommitID":{},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"Devices":{"items":{"properties":{"Connected":{"type":"boolean"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"DesiredHash":{"type":"string"},"ID":{},"RHCClientID":{"type":"string"},"UUID":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"DispatchRecords":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"Device":{"properties":{"Connected":{"type":"boolean"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"DesiredHash":{"type":"string"},"ID":{},"RHCClientID":{"type":"string"},"UUID":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"DeviceID":{},"ID":{},"PlaybookDispatcherID":{"type":"string"},"PlaybookURL":{"type":"string"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"ID":{},"OldCommits":{"items":{"properties":{"Account":{"type":"string"},"Arch":{"type":"string"},"BlueprintToml":{"type":"string"},"BuildDate":{"type":"string"},"BuildNumber":{},"ComposeJobID":{"type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"ImageBuildHash":{"type":"string"},"ImageBuildParentHash":{"type":"string"},"ImageBuildTarURL":{"type":"string"},"InstalledPackages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"UpdatedAt":{"format":"date-time","type":"string"},"arch":{"type":"string"},"epoch":{"type":"string"},"name":{"type":"string"},"release":{"type":"string"},"sigmd5":{"type":"string"},"signature":{"type":"string"},"type":{"type":"string"},"version":{"type":"string"}},"type":"object"},"type":"array"},"OSTreeCommit":{"type":"string"},"OSTreeParentCommit":{"type":"string"},"OSTreeRef":{"type":"string"},"Packages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"Name":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"Repo":{"properties":{"Commit":{"properties":{"Account":{"type":"string"},"Arch":{"type":"string"},"BlueprintToml":{"type":"string"},"BuildDate":{"type":"string"},"BuildNumber":{},"ComposeJobID":{"type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"ImageBuildHash":{"type":"string"},"ImageBuildParentHash":{"type":"string"},"ImageBuildTarURL":{"type":"string"},"InstalledPackages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"UpdatedAt":{"format":"date-time","type":"string"},"arch":{"type":"string"},"epoch":{"type":"string"},"name":{"type":"string"},"release":{"type":"string"},"sigmd5":{"type":"string"},"signature":{"type":"string"},"type":{"type":"string"},"version":{"type":"string"}},"type":"object"},"type":"array"},"OSTreeCommit":{"type":"string"},"OSTreeParentCommit":{"type":"string"},"OSTreeRef":{"type":"string"},"Packages":{"items":{"properties":{"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"Name":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"type":"array"},"Status":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"CommitID":{},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{},"RepoStatus":{"type":"string"},"RepoURL":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"RepoID":{},"Status":{"type":"string"},"Tag":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"}}},"info":{"license":{"name":"MIT"},"title":"edge-api","version":"1.0.0"},"openapi":"3.0.0","paths":{"/devices/{DeviceUUID}":{"get":{"operationId":"getDevice","parameters":[{"description":"DeviceUUID","in":"path","name":"DeviceUUID","required":true,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.DeviceDetails"}}},"description":"OK"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.BadRequest"}}},"description":"The request sent couldn't be processed."},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.NotFound"}}},"description":"The device was not found."},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.InternalServerError"}}},"description":"There was an internal server error."}},"summary":"Get a device by UUID."}},"/images":{"get":{"operationId":"listImages","responses":{"200":{"content":{"application/json":{"schema":{"properties":{"count":{"example":100,"type":"integer"},"data":{"items":{"$ref":"#/components/schemas/v1.Image"},"type":"array"}},"type":"object"}}},"description":"OK"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.BadRequest"}}},"description":"The request sent couldn't be processed."},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.InternalServerError"}}},"description":"There was an internal server error."}},"summary":"Lists all images for an account."},"post":{"operationId":"createImage","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.Image"}}},"required":true},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.Image"}}},"description":"OK"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.BadRequest"}}},"description":"The request sent couldn't be processed."},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.InternalServerError"}}},"description":"There was an internal server error."}},"summary":"Composes an image on Image Builder"}},"/images/{imageId}":{"get":{"operationId":"getImage","parameters":[{"description":"ImageID","in":"path","name":"imageId","required":true,"schema":{"type":"integer"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.Image"}}},"description":"OK"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.BadRequest"}}},"description":"The request sent couldn't be processed."},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.InternalServerError"}}},"description":"There was an internal server error."}},"summary":"Get an image by id."}},"/images/{imageId}/repo":{"get":{"description":"Returns the information of the OSTree Repository of a particular Image.","operationId":"getImageRepo","parameters":[{"description":"ImageID","in":"path","name":"imageId","required":true,"schema":{"type":"integer"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.Repo"}}},"description":"OK"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.BadRequest"}}},"description":"The request sent couldn't be processed."},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.InternalServerError"}}},"description":"There was an internal server error."}},"summary":"Get Image OSTree repo."}},"/images/{imageId}/status":{"get":{"description":"This method goes to image builder if the image is still building and updates the status if needed.","operationId":"getImageStatus","parameters":[{"description":"ImageID","in":"path","name":"imageId","required":true,"schema":{"type":"integer"}}],"responses":{"200":{"content":{"application/json":{"schema":{"properties":{"Status":{"example":"BUILDING","type":"string"}},"type":"object"}}},"description":"OK"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.BadRequest"}}},"description":"The request sent couldn't be processed."},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.InternalServerError"}}},"description":"There was an internal server error."}},"summary":"Get image status."}},"/images/{imageId}/update":{"post":{"operationId":"CreateImageUpdate","parameters":[{"description":"ImageID","in":"path","name":"imageId","required":true,"schema":{"type":"integer"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.Image"}}},"required":true},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.Image"}}},"description":"OK"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.BadRequest"}}},"description":"The request sent couldn't be processed."},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.InternalServerError"}}},"description":"There was an internal server error."}},"summary":"Composes an Update for a image"}},"/updates":{"get":{"description":"Gets all device updates.","operationId":"ListUpdates","responses":{"200":{"content":{"application/json":{"schema":{"properties":{"data":{"items":{"$ref":"#/components/schemas/v1.UpdateTransaction"},"type":"array"}},"type":"object"}}},"description":"OK"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.BadRequest"}}},"description":"The request sent couldn't be processed."},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.BadRequest"}}},"description":"There was an internal server error."}},"summary":"Gets all device updates."},"post":{"description":"Executes a device update.","operationId":"UpdateDevice","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.AddUpdate"}}},"required":true},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.UpdateTransaction"}}},"description":"OK"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.BadRequest"}}},"description":"The request sent couldn't be processed."},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.BadRequest"}}},"description":"There was an internal server error."}},"summary":"Executes a device update."}},"/updates/device/{DeviceUUID}":{"get":{"description":"Return list of available updates for a device.","operationId":"GetUpdateStatusForDevice","parameters":[{"description":"DeviceUUID","in":"path","name":"DeviceUUID","required":true,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.Device"}}},"description":"OK"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.BadRequest"}}},"description":"The request sent couldn't be processed."}},"summary":"Return list of available updates for a device."}},"/updates/device/{DeviceUUID}/image":{"get":{"description":"Return image running on device.","operationId":"GetImageInfo","parameters":[{"description":"DeviceUUID","in":"path","name":"DeviceUUID","required":true,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"properties":{"Image":{"$ref":"#/components/schemas/v1.Image"}},"type":"object"}}},"description":"OK"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.BadRequest"}}},"description":"The request sent couldn't be processed."},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.InternalServerError"}}},"description":"There was an internal server error."}},"summary":"Return image running on device."}},"/updates/device/{DeviceUUID}/updates":{"get":{"description":"Return list of available updates for a device.","operationId":"GetUpdateAvailableForDevice","parameters":[{"description":"DeviceUUID","in":"path","name":"DeviceUUID","required":true,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"items":{"properties":{"Image":{"$ref":"#/components/schemas/v1.Image"}},"type":"object"},"type":"array"}}},"description":"OK"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.BadRequest"}}},"description":"The request sent couldn't be processed."},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.InternalServerError"}}},"description":"There was an internal server error."}},"summary":"Return list of available updates for a device."}},"/updates/{updateID}":{"get":{"description":"Gets a single requested update.","operationId":"GetUpdate","parameters":[{"description":"An unique ID to identify the update","in":"path","name":"updateID","required":true,"schema":{"type":"integer"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.UpdateTransaction"}}},"description":"OK"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.BadRequest"}}},"description":"The request sent couldn't be processed."},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.InternalServerError"}}},"description":"There was an internal server error."}},"summary":"Gets a single requested update."}},"/updates/{updateID}/update-playbook.yml":{"get":{"operationId":"GetUpdatePlaybook","parameters":[{"description":"An unique ID to identify the update the playbook belongs to","in":"path","name":"updateID","required":true,"schema":{"type":"integer"}}],"responses":{"200":{"content":{"text/plain":{"schema":{"example":"ansible playbook for an update","type":"string"}}},"description":"OK"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.BadRequest"}}},"description":"The request sent couldn't be processed."},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/v1.InternalServerError"}}},"description":"There was an internal server error."}}}}}}
+{
+  "components": {
+    "schemas": {
+      "v1.AddUpdate": {
+        "properties": {
+          "CommitID": {},
+          "DeviceUUID": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "v1.BadRequest": {
+        "properties": {
+          "Code": {
+            "type": "string"
+          },
+          "Status": {
+            "type": "integer"
+          },
+          "Title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "v1.Device": {
+        "properties": {
+          "Connected": {
+            "type": "boolean"
+          },
+          "CreatedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "DeletedAt": {},
+          "DesiredHash": {
+            "type": "string"
+          },
+          "ID": {},
+          "RHCClientID": {
+            "type": "string"
+          },
+          "UUID": {
+            "type": "string"
+          },
+          "UpdatedAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "v1.DeviceDetails": {
+        "properties": {
+          "Device": {
+            "properties": {
+              "Connected": {
+                "type": "boolean"
+              },
+              "CreatedAt": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "DeletedAt": {},
+              "DesiredHash": {
+                "type": "string"
+              },
+              "ID": {},
+              "RHCClientID": {
+                "type": "string"
+              },
+              "UUID": {
+                "type": "string"
+              },
+              "UpdatedAt": {
+                "format": "date-time",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "ImageInfo": {
+            "properties": {
+              "Image": {
+                "properties": {
+                  "Account": {
+                    "type": "string"
+                  },
+                  "Commit": {
+                    "properties": {
+                      "Account": {
+                        "type": "string"
+                      },
+                      "Arch": {
+                        "type": "string"
+                      },
+                      "BlueprintToml": {
+                        "type": "string"
+                      },
+                      "BuildDate": {
+                        "type": "string"
+                      },
+                      "BuildNumber": {},
+                      "ComposeJobID": {
+                        "type": "string"
+                      },
+                      "CreatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "DeletedAt": {},
+                      "ID": {},
+                      "ImageBuildHash": {
+                        "type": "string"
+                      },
+                      "ImageBuildParentHash": {
+                        "type": "string"
+                      },
+                      "ImageBuildTarURL": {
+                        "type": "string"
+                      },
+                      "InstalledPackages": {
+                        "items": {
+                          "properties": {
+                            "CreatedAt": {
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "DeletedAt": {},
+                            "ID": {},
+                            "UpdatedAt": {
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "arch": {
+                              "type": "string"
+                            },
+                            "epoch": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "release": {
+                              "type": "string"
+                            },
+                            "sigmd5": {
+                              "type": "string"
+                            },
+                            "signature": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "version": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "OSTreeCommit": {
+                        "type": "string"
+                      },
+                      "OSTreeParentCommit": {
+                        "type": "string"
+                      },
+                      "OSTreeRef": {
+                        "type": "string"
+                      },
+                      "Packages": {
+                        "items": {
+                          "properties": {
+                            "CreatedAt": {
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "DeletedAt": {},
+                            "ID": {},
+                            "Name": {
+                              "type": "string"
+                            },
+                            "UpdatedAt": {
+                              "format": "date-time",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "Status": {
+                        "type": "string"
+                      },
+                      "UpdatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "CommitID": {},
+                  "CreatedAt": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "DeletedAt": {},
+                  "Description": {
+                    "type": "string"
+                  },
+                  "Distribution": {
+                    "type": "string"
+                  },
+                  "ID": {},
+                  "ImageSetID": {},
+                  "ImageType": {
+                    "type": "string"
+                  },
+                  "Installer": {
+                    "properties": {
+                      "Account": {
+                        "type": "string"
+                      },
+                      "Checksum": {
+                        "type": "string"
+                      },
+                      "ComposeJobID": {
+                        "type": "string"
+                      },
+                      "CreatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "DeletedAt": {},
+                      "ID": {},
+                      "ImageBuildISOURL": {
+                        "type": "string"
+                      },
+                      "SshKey": {
+                        "type": "string"
+                      },
+                      "Status": {
+                        "type": "string"
+                      },
+                      "UpdatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "Username": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "InstallerID": {},
+                  "Name": {
+                    "type": "string"
+                  },
+                  "OutputTypes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "Status": {
+                    "type": "string"
+                  },
+                  "UpdatedAt": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "Version": {
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "RollbackImage": {
+                "properties": {
+                  "Account": {
+                    "type": "string"
+                  },
+                  "Commit": {
+                    "properties": {
+                      "Account": {
+                        "type": "string"
+                      },
+                      "Arch": {
+                        "type": "string"
+                      },
+                      "BlueprintToml": {
+                        "type": "string"
+                      },
+                      "BuildDate": {
+                        "type": "string"
+                      },
+                      "BuildNumber": {},
+                      "ComposeJobID": {
+                        "type": "string"
+                      },
+                      "CreatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "DeletedAt": {},
+                      "ID": {},
+                      "ImageBuildHash": {
+                        "type": "string"
+                      },
+                      "ImageBuildParentHash": {
+                        "type": "string"
+                      },
+                      "ImageBuildTarURL": {
+                        "type": "string"
+                      },
+                      "InstalledPackages": {
+                        "items": {
+                          "properties": {
+                            "CreatedAt": {
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "DeletedAt": {},
+                            "ID": {},
+                            "UpdatedAt": {
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "arch": {
+                              "type": "string"
+                            },
+                            "epoch": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "release": {
+                              "type": "string"
+                            },
+                            "sigmd5": {
+                              "type": "string"
+                            },
+                            "signature": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "version": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "OSTreeCommit": {
+                        "type": "string"
+                      },
+                      "OSTreeParentCommit": {
+                        "type": "string"
+                      },
+                      "OSTreeRef": {
+                        "type": "string"
+                      },
+                      "Packages": {
+                        "items": {
+                          "properties": {
+                            "CreatedAt": {
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "DeletedAt": {},
+                            "ID": {},
+                            "Name": {
+                              "type": "string"
+                            },
+                            "UpdatedAt": {
+                              "format": "date-time",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "Status": {
+                        "type": "string"
+                      },
+                      "UpdatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "CommitID": {},
+                  "CreatedAt": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "DeletedAt": {},
+                  "Description": {
+                    "type": "string"
+                  },
+                  "Distribution": {
+                    "type": "string"
+                  },
+                  "ID": {},
+                  "ImageSetID": {},
+                  "ImageType": {
+                    "type": "string"
+                  },
+                  "Installer": {
+                    "properties": {
+                      "Account": {
+                        "type": "string"
+                      },
+                      "Checksum": {
+                        "type": "string"
+                      },
+                      "ComposeJobID": {
+                        "type": "string"
+                      },
+                      "CreatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "DeletedAt": {},
+                      "ID": {},
+                      "ImageBuildISOURL": {
+                        "type": "string"
+                      },
+                      "SshKey": {
+                        "type": "string"
+                      },
+                      "Status": {
+                        "type": "string"
+                      },
+                      "UpdatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "Username": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "InstallerID": {},
+                  "Name": {
+                    "type": "string"
+                  },
+                  "OutputTypes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "Status": {
+                    "type": "string"
+                  },
+                  "UpdatedAt": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "Version": {
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "UpdatesAvailable": {
+                "items": {
+                  "properties": {
+                    "Image": {
+                      "properties": {
+                        "Account": {
+                          "type": "string"
+                        },
+                        "Commit": {
+                          "properties": {
+                            "Account": {
+                              "type": "string"
+                            },
+                            "Arch": {
+                              "type": "string"
+                            },
+                            "BlueprintToml": {
+                              "type": "string"
+                            },
+                            "BuildDate": {
+                              "type": "string"
+                            },
+                            "BuildNumber": {},
+                            "ComposeJobID": {
+                              "type": "string"
+                            },
+                            "CreatedAt": {
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "DeletedAt": {},
+                            "ID": {},
+                            "ImageBuildHash": {
+                              "type": "string"
+                            },
+                            "ImageBuildParentHash": {
+                              "type": "string"
+                            },
+                            "ImageBuildTarURL": {
+                              "type": "string"
+                            },
+                            "InstalledPackages": {
+                              "items": {
+                                "properties": {
+                                  "CreatedAt": {
+                                    "format": "date-time",
+                                    "type": "string"
+                                  },
+                                  "DeletedAt": {},
+                                  "ID": {},
+                                  "UpdatedAt": {
+                                    "format": "date-time",
+                                    "type": "string"
+                                  },
+                                  "arch": {
+                                    "type": "string"
+                                  },
+                                  "epoch": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "release": {
+                                    "type": "string"
+                                  },
+                                  "sigmd5": {
+                                    "type": "string"
+                                  },
+                                  "signature": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "OSTreeCommit": {
+                              "type": "string"
+                            },
+                            "OSTreeParentCommit": {
+                              "type": "string"
+                            },
+                            "OSTreeRef": {
+                              "type": "string"
+                            },
+                            "Packages": {
+                              "items": {
+                                "properties": {
+                                  "CreatedAt": {
+                                    "format": "date-time",
+                                    "type": "string"
+                                  },
+                                  "DeletedAt": {},
+                                  "ID": {},
+                                  "Name": {
+                                    "type": "string"
+                                  },
+                                  "UpdatedAt": {
+                                    "format": "date-time",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "Status": {
+                              "type": "string"
+                            },
+                            "UpdatedAt": {
+                              "format": "date-time",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "CommitID": {},
+                        "CreatedAt": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "DeletedAt": {},
+                        "Description": {
+                          "type": "string"
+                        },
+                        "Distribution": {
+                          "type": "string"
+                        },
+                        "ID": {},
+                        "ImageSetID": {},
+                        "ImageType": {
+                          "type": "string"
+                        },
+                        "Installer": {
+                          "properties": {
+                            "Account": {
+                              "type": "string"
+                            },
+                            "Checksum": {
+                              "type": "string"
+                            },
+                            "ComposeJobID": {
+                              "type": "string"
+                            },
+                            "CreatedAt": {
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "DeletedAt": {},
+                            "ID": {},
+                            "ImageBuildISOURL": {
+                              "type": "string"
+                            },
+                            "SshKey": {
+                              "type": "string"
+                            },
+                            "Status": {
+                              "type": "string"
+                            },
+                            "UpdatedAt": {
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "Username": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "InstallerID": {},
+                        "Name": {
+                          "type": "string"
+                        },
+                        "OutputTypes": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "Status": {
+                          "type": "string"
+                        },
+                        "UpdatedAt": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "Version": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "PackageDiff": {
+                      "properties": {
+                        "Added": {
+                          "items": {
+                            "properties": {
+                              "CreatedAt": {
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "DeletedAt": {},
+                              "ID": {},
+                              "UpdatedAt": {
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "arch": {
+                                "type": "string"
+                              },
+                              "epoch": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "release": {
+                                "type": "string"
+                              },
+                              "sigmd5": {
+                                "type": "string"
+                              },
+                              "signature": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "version": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "Removed": {
+                          "items": {
+                            "properties": {
+                              "CreatedAt": {
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "DeletedAt": {},
+                              "ID": {},
+                              "UpdatedAt": {
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "arch": {
+                                "type": "string"
+                              },
+                              "epoch": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "release": {
+                                "type": "string"
+                              },
+                              "sigmd5": {
+                                "type": "string"
+                              },
+                              "signature": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "version": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "Upgraded": {
+                          "items": {
+                            "properties": {
+                              "CreatedAt": {
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "DeletedAt": {},
+                              "ID": {},
+                              "UpdatedAt": {
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "arch": {
+                                "type": "string"
+                              },
+                              "epoch": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "release": {
+                                "type": "string"
+                              },
+                              "sigmd5": {
+                                "type": "string"
+                              },
+                              "signature": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "version": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "UpdateTransactions": {
+            "items": {
+              "properties": {
+                "Account": {
+                  "type": "string"
+                },
+                "Commit": {
+                  "properties": {
+                    "Account": {
+                      "type": "string"
+                    },
+                    "Arch": {
+                      "type": "string"
+                    },
+                    "BlueprintToml": {
+                      "type": "string"
+                    },
+                    "BuildDate": {
+                      "type": "string"
+                    },
+                    "BuildNumber": {},
+                    "ComposeJobID": {
+                      "type": "string"
+                    },
+                    "CreatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "DeletedAt": {},
+                    "ID": {},
+                    "ImageBuildHash": {
+                      "type": "string"
+                    },
+                    "ImageBuildParentHash": {
+                      "type": "string"
+                    },
+                    "ImageBuildTarURL": {
+                      "type": "string"
+                    },
+                    "InstalledPackages": {
+                      "items": {
+                        "properties": {
+                          "CreatedAt": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "DeletedAt": {},
+                          "ID": {},
+                          "UpdatedAt": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "arch": {
+                            "type": "string"
+                          },
+                          "epoch": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "release": {
+                            "type": "string"
+                          },
+                          "sigmd5": {
+                            "type": "string"
+                          },
+                          "signature": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "OSTreeCommit": {
+                      "type": "string"
+                    },
+                    "OSTreeParentCommit": {
+                      "type": "string"
+                    },
+                    "OSTreeRef": {
+                      "type": "string"
+                    },
+                    "Packages": {
+                      "items": {
+                        "properties": {
+                          "CreatedAt": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "DeletedAt": {},
+                          "ID": {},
+                          "Name": {
+                            "type": "string"
+                          },
+                          "UpdatedAt": {
+                            "format": "date-time",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "Status": {
+                      "type": "string"
+                    },
+                    "UpdatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "CommitID": {},
+                "CreatedAt": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "DeletedAt": {},
+                "Devices": {
+                  "items": {
+                    "properties": {
+                      "Connected": {
+                        "type": "boolean"
+                      },
+                      "CreatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "DeletedAt": {},
+                      "DesiredHash": {
+                        "type": "string"
+                      },
+                      "ID": {},
+                      "RHCClientID": {
+                        "type": "string"
+                      },
+                      "UUID": {
+                        "type": "string"
+                      },
+                      "UpdatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "DispatchRecords": {
+                  "items": {
+                    "properties": {
+                      "CreatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "DeletedAt": {},
+                      "Device": {
+                        "properties": {
+                          "Connected": {
+                            "type": "boolean"
+                          },
+                          "CreatedAt": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "DeletedAt": {},
+                          "DesiredHash": {
+                            "type": "string"
+                          },
+                          "ID": {},
+                          "RHCClientID": {
+                            "type": "string"
+                          },
+                          "UUID": {
+                            "type": "string"
+                          },
+                          "UpdatedAt": {
+                            "format": "date-time",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "DeviceID": {},
+                      "ID": {},
+                      "PlaybookDispatcherID": {
+                        "type": "string"
+                      },
+                      "PlaybookURL": {
+                        "type": "string"
+                      },
+                      "Status": {
+                        "type": "string"
+                      },
+                      "UpdatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "ID": {},
+                "OldCommits": {
+                  "items": {
+                    "properties": {
+                      "Account": {
+                        "type": "string"
+                      },
+                      "Arch": {
+                        "type": "string"
+                      },
+                      "BlueprintToml": {
+                        "type": "string"
+                      },
+                      "BuildDate": {
+                        "type": "string"
+                      },
+                      "BuildNumber": {},
+                      "ComposeJobID": {
+                        "type": "string"
+                      },
+                      "CreatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "DeletedAt": {},
+                      "ID": {},
+                      "ImageBuildHash": {
+                        "type": "string"
+                      },
+                      "ImageBuildParentHash": {
+                        "type": "string"
+                      },
+                      "ImageBuildTarURL": {
+                        "type": "string"
+                      },
+                      "InstalledPackages": {
+                        "items": {
+                          "properties": {
+                            "CreatedAt": {
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "DeletedAt": {},
+                            "ID": {},
+                            "UpdatedAt": {
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "arch": {
+                              "type": "string"
+                            },
+                            "epoch": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "release": {
+                              "type": "string"
+                            },
+                            "sigmd5": {
+                              "type": "string"
+                            },
+                            "signature": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "version": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "OSTreeCommit": {
+                        "type": "string"
+                      },
+                      "OSTreeParentCommit": {
+                        "type": "string"
+                      },
+                      "OSTreeRef": {
+                        "type": "string"
+                      },
+                      "Packages": {
+                        "items": {
+                          "properties": {
+                            "CreatedAt": {
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "DeletedAt": {},
+                            "ID": {},
+                            "Name": {
+                              "type": "string"
+                            },
+                            "UpdatedAt": {
+                              "format": "date-time",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "Status": {
+                        "type": "string"
+                      },
+                      "UpdatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "Repo": {
+                  "properties": {
+                    "Commit": {
+                      "properties": {
+                        "Account": {
+                          "type": "string"
+                        },
+                        "Arch": {
+                          "type": "string"
+                        },
+                        "BlueprintToml": {
+                          "type": "string"
+                        },
+                        "BuildDate": {
+                          "type": "string"
+                        },
+                        "BuildNumber": {},
+                        "ComposeJobID": {
+                          "type": "string"
+                        },
+                        "CreatedAt": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "DeletedAt": {},
+                        "ID": {},
+                        "ImageBuildHash": {
+                          "type": "string"
+                        },
+                        "ImageBuildParentHash": {
+                          "type": "string"
+                        },
+                        "ImageBuildTarURL": {
+                          "type": "string"
+                        },
+                        "InstalledPackages": {
+                          "items": {
+                            "properties": {
+                              "CreatedAt": {
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "DeletedAt": {},
+                              "ID": {},
+                              "UpdatedAt": {
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "arch": {
+                                "type": "string"
+                              },
+                              "epoch": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "release": {
+                                "type": "string"
+                              },
+                              "sigmd5": {
+                                "type": "string"
+                              },
+                              "signature": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "version": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "OSTreeCommit": {
+                          "type": "string"
+                        },
+                        "OSTreeParentCommit": {
+                          "type": "string"
+                        },
+                        "OSTreeRef": {
+                          "type": "string"
+                        },
+                        "Packages": {
+                          "items": {
+                            "properties": {
+                              "CreatedAt": {
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "DeletedAt": {},
+                              "ID": {},
+                              "Name": {
+                                "type": "string"
+                              },
+                              "UpdatedAt": {
+                                "format": "date-time",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "Status": {
+                          "type": "string"
+                        },
+                        "UpdatedAt": {
+                          "format": "date-time",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "CommitID": {},
+                    "CreatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "DeletedAt": {},
+                    "ID": {},
+                    "RepoStatus": {
+                      "type": "string"
+                    },
+                    "RepoURL": {
+                      "type": "string"
+                    },
+                    "UpdatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "RepoID": {},
+                "Status": {
+                  "type": "string"
+                },
+                "Tag": {
+                  "type": "string"
+                },
+                "UpdatedAt": {
+                  "format": "date-time",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "v1.Image": {
+        "properties": {
+          "Account": {
+            "type": "string"
+          },
+          "Commit": {
+            "properties": {
+              "Account": {
+                "type": "string"
+              },
+              "Arch": {
+                "type": "string"
+              },
+              "BlueprintToml": {
+                "type": "string"
+              },
+              "BuildDate": {
+                "type": "string"
+              },
+              "BuildNumber": {},
+              "ComposeJobID": {
+                "type": "string"
+              },
+              "CreatedAt": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "DeletedAt": {},
+              "ID": {},
+              "ImageBuildHash": {
+                "type": "string"
+              },
+              "ImageBuildParentHash": {
+                "type": "string"
+              },
+              "ImageBuildTarURL": {
+                "type": "string"
+              },
+              "InstalledPackages": {
+                "items": {
+                  "properties": {
+                    "CreatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "DeletedAt": {},
+                    "ID": {},
+                    "UpdatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "arch": {
+                      "type": "string"
+                    },
+                    "epoch": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "release": {
+                      "type": "string"
+                    },
+                    "sigmd5": {
+                      "type": "string"
+                    },
+                    "signature": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "OSTreeCommit": {
+                "type": "string"
+              },
+              "OSTreeParentCommit": {
+                "type": "string"
+              },
+              "OSTreeRef": {
+                "type": "string"
+              },
+              "Packages": {
+                "items": {
+                  "properties": {
+                    "CreatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "DeletedAt": {},
+                    "ID": {},
+                    "Name": {
+                      "type": "string"
+                    },
+                    "UpdatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "Status": {
+                "type": "string"
+              },
+              "UpdatedAt": {
+                "format": "date-time",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "CommitID": {},
+          "CreatedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "DeletedAt": {},
+          "Description": {
+            "type": "string"
+          },
+          "Distribution": {
+            "type": "string"
+          },
+          "ID": {},
+          "ImageSetID": {},
+          "ImageType": {
+            "type": "string"
+          },
+          "Installer": {
+            "properties": {
+              "Account": {
+                "type": "string"
+              },
+              "Checksum": {
+                "type": "string"
+              },
+              "ComposeJobID": {
+                "type": "string"
+              },
+              "CreatedAt": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "DeletedAt": {},
+              "ID": {},
+              "ImageBuildISOURL": {
+                "type": "string"
+              },
+              "SshKey": {
+                "type": "string"
+              },
+              "Status": {
+                "type": "string"
+              },
+              "UpdatedAt": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "Username": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "InstallerID": {},
+          "Name": {
+            "type": "string"
+          },
+          "OutputTypes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "Status": {
+            "type": "string"
+          },
+          "UpdatedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "Version": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "v1.InternalServerError": {
+        "properties": {
+          "Code": {
+            "type": "string"
+          },
+          "Status": {
+            "type": "integer"
+          },
+          "Title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "v1.NotFound": {
+        "properties": {
+          "Code": {
+            "type": "string"
+          },
+          "Status": {
+            "type": "integer"
+          },
+          "Title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "v1.Repo": {
+        "properties": {
+          "Commit": {
+            "properties": {
+              "Account": {
+                "type": "string"
+              },
+              "Arch": {
+                "type": "string"
+              },
+              "BlueprintToml": {
+                "type": "string"
+              },
+              "BuildDate": {
+                "type": "string"
+              },
+              "BuildNumber": {},
+              "ComposeJobID": {
+                "type": "string"
+              },
+              "CreatedAt": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "DeletedAt": {},
+              "ID": {},
+              "ImageBuildHash": {
+                "type": "string"
+              },
+              "ImageBuildParentHash": {
+                "type": "string"
+              },
+              "ImageBuildTarURL": {
+                "type": "string"
+              },
+              "InstalledPackages": {
+                "items": {
+                  "properties": {
+                    "CreatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "DeletedAt": {},
+                    "ID": {},
+                    "UpdatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "arch": {
+                      "type": "string"
+                    },
+                    "epoch": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "release": {
+                      "type": "string"
+                    },
+                    "sigmd5": {
+                      "type": "string"
+                    },
+                    "signature": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "OSTreeCommit": {
+                "type": "string"
+              },
+              "OSTreeParentCommit": {
+                "type": "string"
+              },
+              "OSTreeRef": {
+                "type": "string"
+              },
+              "Packages": {
+                "items": {
+                  "properties": {
+                    "CreatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "DeletedAt": {},
+                    "ID": {},
+                    "Name": {
+                      "type": "string"
+                    },
+                    "UpdatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "Status": {
+                "type": "string"
+              },
+              "UpdatedAt": {
+                "format": "date-time",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "CommitID": {},
+          "CreatedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "DeletedAt": {},
+          "ID": {},
+          "RepoStatus": {
+            "type": "string"
+          },
+          "RepoURL": {
+            "type": "string"
+          },
+          "UpdatedAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "v1.UpdateTransaction": {
+        "properties": {
+          "Account": {
+            "type": "string"
+          },
+          "Commit": {
+            "properties": {
+              "Account": {
+                "type": "string"
+              },
+              "Arch": {
+                "type": "string"
+              },
+              "BlueprintToml": {
+                "type": "string"
+              },
+              "BuildDate": {
+                "type": "string"
+              },
+              "BuildNumber": {},
+              "ComposeJobID": {
+                "type": "string"
+              },
+              "CreatedAt": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "DeletedAt": {},
+              "ID": {},
+              "ImageBuildHash": {
+                "type": "string"
+              },
+              "ImageBuildParentHash": {
+                "type": "string"
+              },
+              "ImageBuildTarURL": {
+                "type": "string"
+              },
+              "InstalledPackages": {
+                "items": {
+                  "properties": {
+                    "CreatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "DeletedAt": {},
+                    "ID": {},
+                    "UpdatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "arch": {
+                      "type": "string"
+                    },
+                    "epoch": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "release": {
+                      "type": "string"
+                    },
+                    "sigmd5": {
+                      "type": "string"
+                    },
+                    "signature": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "OSTreeCommit": {
+                "type": "string"
+              },
+              "OSTreeParentCommit": {
+                "type": "string"
+              },
+              "OSTreeRef": {
+                "type": "string"
+              },
+              "Packages": {
+                "items": {
+                  "properties": {
+                    "CreatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "DeletedAt": {},
+                    "ID": {},
+                    "Name": {
+                      "type": "string"
+                    },
+                    "UpdatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "Status": {
+                "type": "string"
+              },
+              "UpdatedAt": {
+                "format": "date-time",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "CommitID": {},
+          "CreatedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "DeletedAt": {},
+          "Devices": {
+            "items": {
+              "properties": {
+                "Connected": {
+                  "type": "boolean"
+                },
+                "CreatedAt": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "DeletedAt": {},
+                "DesiredHash": {
+                  "type": "string"
+                },
+                "ID": {},
+                "RHCClientID": {
+                  "type": "string"
+                },
+                "UUID": {
+                  "type": "string"
+                },
+                "UpdatedAt": {
+                  "format": "date-time",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "DispatchRecords": {
+            "items": {
+              "properties": {
+                "CreatedAt": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "DeletedAt": {},
+                "Device": {
+                  "properties": {
+                    "Connected": {
+                      "type": "boolean"
+                    },
+                    "CreatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "DeletedAt": {},
+                    "DesiredHash": {
+                      "type": "string"
+                    },
+                    "ID": {},
+                    "RHCClientID": {
+                      "type": "string"
+                    },
+                    "UUID": {
+                      "type": "string"
+                    },
+                    "UpdatedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "DeviceID": {},
+                "ID": {},
+                "PlaybookDispatcherID": {
+                  "type": "string"
+                },
+                "PlaybookURL": {
+                  "type": "string"
+                },
+                "Status": {
+                  "type": "string"
+                },
+                "UpdatedAt": {
+                  "format": "date-time",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "ID": {},
+          "OldCommits": {
+            "items": {
+              "properties": {
+                "Account": {
+                  "type": "string"
+                },
+                "Arch": {
+                  "type": "string"
+                },
+                "BlueprintToml": {
+                  "type": "string"
+                },
+                "BuildDate": {
+                  "type": "string"
+                },
+                "BuildNumber": {},
+                "ComposeJobID": {
+                  "type": "string"
+                },
+                "CreatedAt": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "DeletedAt": {},
+                "ID": {},
+                "ImageBuildHash": {
+                  "type": "string"
+                },
+                "ImageBuildParentHash": {
+                  "type": "string"
+                },
+                "ImageBuildTarURL": {
+                  "type": "string"
+                },
+                "InstalledPackages": {
+                  "items": {
+                    "properties": {
+                      "CreatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "DeletedAt": {},
+                      "ID": {},
+                      "UpdatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "arch": {
+                        "type": "string"
+                      },
+                      "epoch": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "release": {
+                        "type": "string"
+                      },
+                      "sigmd5": {
+                        "type": "string"
+                      },
+                      "signature": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "OSTreeCommit": {
+                  "type": "string"
+                },
+                "OSTreeParentCommit": {
+                  "type": "string"
+                },
+                "OSTreeRef": {
+                  "type": "string"
+                },
+                "Packages": {
+                  "items": {
+                    "properties": {
+                      "CreatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "DeletedAt": {},
+                      "ID": {},
+                      "Name": {
+                        "type": "string"
+                      },
+                      "UpdatedAt": {
+                        "format": "date-time",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "Status": {
+                  "type": "string"
+                },
+                "UpdatedAt": {
+                  "format": "date-time",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "Repo": {
+            "properties": {
+              "Commit": {
+                "properties": {
+                  "Account": {
+                    "type": "string"
+                  },
+                  "Arch": {
+                    "type": "string"
+                  },
+                  "BlueprintToml": {
+                    "type": "string"
+                  },
+                  "BuildDate": {
+                    "type": "string"
+                  },
+                  "BuildNumber": {},
+                  "ComposeJobID": {
+                    "type": "string"
+                  },
+                  "CreatedAt": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "DeletedAt": {},
+                  "ID": {},
+                  "ImageBuildHash": {
+                    "type": "string"
+                  },
+                  "ImageBuildParentHash": {
+                    "type": "string"
+                  },
+                  "ImageBuildTarURL": {
+                    "type": "string"
+                  },
+                  "InstalledPackages": {
+                    "items": {
+                      "properties": {
+                        "CreatedAt": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "DeletedAt": {},
+                        "ID": {},
+                        "UpdatedAt": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "arch": {
+                          "type": "string"
+                        },
+                        "epoch": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "release": {
+                          "type": "string"
+                        },
+                        "sigmd5": {
+                          "type": "string"
+                        },
+                        "signature": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "OSTreeCommit": {
+                    "type": "string"
+                  },
+                  "OSTreeParentCommit": {
+                    "type": "string"
+                  },
+                  "OSTreeRef": {
+                    "type": "string"
+                  },
+                  "Packages": {
+                    "items": {
+                      "properties": {
+                        "CreatedAt": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "DeletedAt": {},
+                        "ID": {},
+                        "Name": {
+                          "type": "string"
+                        },
+                        "UpdatedAt": {
+                          "format": "date-time",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "Status": {
+                    "type": "string"
+                  },
+                  "UpdatedAt": {
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "CommitID": {},
+              "CreatedAt": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "DeletedAt": {},
+              "ID": {},
+              "RepoStatus": {
+                "type": "string"
+              },
+              "RepoURL": {
+                "type": "string"
+              },
+              "UpdatedAt": {
+                "format": "date-time",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "RepoID": {},
+          "Status": {
+            "type": "string"
+          },
+          "Tag": {
+            "type": "string"
+          },
+          "UpdatedAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "license": {
+      "name": "MIT"
+    },
+    "title": "edge-api",
+    "version": "1.0.0"
+  },
+  "openapi": "3.0.0",
+  "paths": {
+    "/devices/{DeviceUUID}": {
+      "get": {
+        "operationId": "getDevice",
+        "parameters": [
+          {
+            "description": "DeviceUUID",
+            "in": "path",
+            "name": "DeviceUUID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DeviceDetails"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.BadRequest"
+                }
+              }
+            },
+            "description": "The request sent couldn't be processed."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.NotFound"
+                }
+              }
+            },
+            "description": "The device was not found."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.InternalServerError"
+                }
+              }
+            },
+            "description": "There was an internal server error."
+          }
+        },
+        "summary": "Get a device by UUID."
+      }
+    },
+    "/images": {
+      "get": {
+        "operationId": "listImages",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "count": {
+                      "example": 100,
+                      "type": "integer"
+                    },
+                    "data": {
+                      "items": {
+                        "$ref": "#/components/schemas/v1.Image"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.BadRequest"
+                }
+              }
+            },
+            "description": "The request sent couldn't be processed."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.InternalServerError"
+                }
+              }
+            },
+            "description": "There was an internal server error."
+          }
+        },
+        "summary": "Lists all images for an account."
+      },
+      "post": {
+        "operationId": "createImage",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.Image"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Image"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.BadRequest"
+                }
+              }
+            },
+            "description": "The request sent couldn't be processed."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.InternalServerError"
+                }
+              }
+            },
+            "description": "There was an internal server error."
+          }
+        },
+        "summary": "Composes an image on Image Builder"
+      }
+    },
+    "/images/{imageId}": {
+      "get": {
+        "operationId": "getImage",
+        "parameters": [
+          {
+            "description": "ImageID",
+            "in": "path",
+            "name": "imageId",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Image"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.BadRequest"
+                }
+              }
+            },
+            "description": "The request sent couldn't be processed."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.InternalServerError"
+                }
+              }
+            },
+            "description": "There was an internal server error."
+          }
+        },
+        "summary": "Get an image by id."
+      }
+    },
+    "/images/{imageId}/repo": {
+      "get": {
+        "description": "Returns the information of the OSTree Repository of a particular Image.",
+        "operationId": "getImageRepo",
+        "parameters": [
+          {
+            "description": "ImageID",
+            "in": "path",
+            "name": "imageId",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Repo"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.BadRequest"
+                }
+              }
+            },
+            "description": "The request sent couldn't be processed."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.InternalServerError"
+                }
+              }
+            },
+            "description": "There was an internal server error."
+          }
+        },
+        "summary": "Get Image OSTree repo."
+      }
+    },
+    "/images/{imageId}/status": {
+      "get": {
+        "description": "This method goes to image builder if the image is still building and updates the status if needed.",
+        "operationId": "getImageStatus",
+        "parameters": [
+          {
+            "description": "ImageID",
+            "in": "path",
+            "name": "imageId",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "Status": {
+                      "example": "BUILDING",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.BadRequest"
+                }
+              }
+            },
+            "description": "The request sent couldn't be processed."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.InternalServerError"
+                }
+              }
+            },
+            "description": "There was an internal server error."
+          }
+        },
+        "summary": "Get image status."
+      }
+    },
+    "/images/{imageId}/update": {
+      "post": {
+        "operationId": "CreateImageUpdate",
+        "parameters": [
+          {
+            "description": "ImageID",
+            "in": "path",
+            "name": "imageId",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.Image"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Image"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.BadRequest"
+                }
+              }
+            },
+            "description": "The request sent couldn't be processed."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.InternalServerError"
+                }
+              }
+            },
+            "description": "There was an internal server error."
+          }
+        },
+        "summary": "Composes an Update for a image"
+      }
+    },
+    "/updates": {
+      "get": {
+        "description": "Gets all device updates.",
+        "operationId": "ListUpdates",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "$ref": "#/components/schemas/v1.UpdateTransaction"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.BadRequest"
+                }
+              }
+            },
+            "description": "The request sent couldn't be processed."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.BadRequest"
+                }
+              }
+            },
+            "description": "There was an internal server error."
+          }
+        },
+        "summary": "Gets all device updates."
+      },
+      "post": {
+        "description": "Executes a device update.",
+        "operationId": "UpdateDevice",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.AddUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.UpdateTransaction"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.BadRequest"
+                }
+              }
+            },
+            "description": "The request sent couldn't be processed."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.BadRequest"
+                }
+              }
+            },
+            "description": "There was an internal server error."
+          }
+        },
+        "summary": "Executes a device update."
+      }
+    },
+    "/updates/device/{DeviceUUID}": {
+      "get": {
+        "description": "Return list of available updates for a device.",
+        "operationId": "GetUpdateStatusForDevice",
+        "parameters": [
+          {
+            "description": "DeviceUUID",
+            "in": "path",
+            "name": "DeviceUUID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Device"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.BadRequest"
+                }
+              }
+            },
+            "description": "The request sent couldn't be processed."
+          }
+        },
+        "summary": "Return list of available updates for a device."
+      }
+    },
+    "/updates/device/{DeviceUUID}/image": {
+      "get": {
+        "description": "Return image running on device.",
+        "operationId": "GetImageInfo",
+        "parameters": [
+          {
+            "description": "DeviceUUID",
+            "in": "path",
+            "name": "DeviceUUID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "Image": {
+                      "$ref": "#/components/schemas/v1.Image"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.BadRequest"
+                }
+              }
+            },
+            "description": "The request sent couldn't be processed."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.InternalServerError"
+                }
+              }
+            },
+            "description": "There was an internal server error."
+          }
+        },
+        "summary": "Return image running on device."
+      }
+    },
+    "/updates/device/{DeviceUUID}/updates": {
+      "get": {
+        "description": "Return list of available updates for a device.",
+        "operationId": "GetUpdateAvailableForDevice",
+        "parameters": [
+          {
+            "description": "DeviceUUID",
+            "in": "path",
+            "name": "DeviceUUID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "Image": {
+                        "$ref": "#/components/schemas/v1.Image"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.BadRequest"
+                }
+              }
+            },
+            "description": "The request sent couldn't be processed."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.InternalServerError"
+                }
+              }
+            },
+            "description": "There was an internal server error."
+          }
+        },
+        "summary": "Return list of available updates for a device."
+      }
+    },
+    "/updates/{updateID}": {
+      "get": {
+        "description": "Gets a single requested update.",
+        "operationId": "GetUpdate",
+        "parameters": [
+          {
+            "description": "An unique ID to identify the update",
+            "in": "path",
+            "name": "updateID",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.UpdateTransaction"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.BadRequest"
+                }
+              }
+            },
+            "description": "The request sent couldn't be processed."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.InternalServerError"
+                }
+              }
+            },
+            "description": "There was an internal server error."
+          }
+        },
+        "summary": "Gets a single requested update."
+      }
+    },
+    "/updates/{updateID}/update-playbook.yml": {
+      "get": {
+        "operationId": "GetUpdatePlaybook",
+        "parameters": [
+          {
+            "description": "An unique ID to identify the update the playbook belongs to",
+            "in": "path",
+            "name": "updateID",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "example": "ansible playbook for an update",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.BadRequest"
+                }
+              }
+            },
+            "description": "The request sent couldn't be processed."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.InternalServerError"
+                }
+              }
+            },
+            "description": "There was an internal server error."
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/spec/openapi.yaml
+++ b/cmd/spec/openapi.yaml
@@ -186,7 +186,6 @@ components:
                   items:
                     type: string
                   type: array
-                ParentId: {}
                 Status:
                   type: string
                 UpdatedAt:
@@ -324,7 +323,6 @@ components:
                   items:
                     type: string
                   type: array
-                ParentId: {}
                 Status:
                   type: string
                 UpdatedAt:
@@ -465,7 +463,6 @@ components:
                         items:
                           type: string
                         type: array
-                      ParentId: {}
                       Status:
                         type: string
                       UpdatedAt:
@@ -1036,7 +1033,6 @@ components:
           items:
             type: string
           type: array
-        ParentId: {}
         Status:
           type: string
         UpdatedAt:


### PR DESCRIPTION
This PR updates the OpenAPI spec generation tool `cmd/spec/main.go` so that the resulting `openapi.json` output file is in pretty-print format. This will make it easier to verify the differences in git commits and in the QE automated test suite that uses this file to generate its REST API client.