### PR TITLE
pre-prod playbook verification workaround

### DIFF
--- a/scripts/registration/register_edge_device.yml
+++ b/scripts/registration/register_edge_device.yml
@@ -33,6 +33,12 @@
       - rhc_connect
       - register
 
+  - name: configure rhc worker-playbook for non-production
+    lineinfile:
+      path: "/etc/rhc/workers/rhc-worker-playbook.toml"
+      regexp: '^verify_playbook = true'
+      line: 'verify_playbook = false'
+
   - name: rhcd service enable and start
     service:
       name: rhcd


### PR DESCRIPTION
We are not currently signing Ansible playbooks for use in playbook
dispatcher for local development nor in stage (yet) so we need to
configure the rhc-worker-playbook plugin accordingly at device
onboarding time.

Signed-off-by: Adam Miller <admiller@redhat.com>