### PR TITLE
changed S to s in 'string'

### DIFF
--- a/cmd/spec/openapi.json
+++ b/cmd/spec/openapi.json
@@ -2782,7 +2782,7 @@
             "name": "ostreeCommitHash",
             "required": true,
             "schema": {
-              "type": "String"
+              "type": "string"
             }
           }
         ],

--- a/cmd/spec/openapi.yaml
+++ b/cmd/spec/openapi.yaml
@@ -1789,7 +1789,7 @@ paths:
           required: true
           description: ostreeCommitHash
           schema:
-            type : String
+            type : string
       responses:
         "200":
           content:

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -139,7 +139,7 @@ paths:
           required: true
           description: ostreeCommitHash
           schema:
-            type : String
+            type : string
       responses:
         "200":
           content:


### PR DESCRIPTION
changed S to s in 'string' in path.yaml for the GetImageByOstree endpoint (this causes an error when trying to generate a client)