### PR TITLE
Add validation to db error type in checkImageName API 

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -21,6 +21,8 @@ import (
 	"github.com/redhatinsights/edge-api/pkg/errors"
 	"github.com/redhatinsights/edge-api/pkg/models"
 	log "github.com/sirupsen/logrus"
+
+	"gorm.io/gorm"
 )
 
 // WaitGroup is the waitg roup for pending image builds
@@ -493,6 +495,9 @@ func (s *ImageService) CheckImageName(name, account string) (bool, error) {
 	var imageFindByName *models.Image
 	result := db.DB.Where("name = ? AND account = ?", name, account).First(&imageFindByName)
 	if result.Error != nil {
+		if result.Error == gorm.ErrRecordNotFound {
+			return false, nil
+		}
 		return false, result.Error
 	}
 	return imageFindByName != nil, nil


### PR DESCRIPTION
### What is inside?
After add new api in previous PR, I try to use it to add validation in frontend but I was getting error 500 everytime that new image name is not present in database, after debug it, I found this link that explain the case:

- https://gorm.io/docs/error_handling.html#ErrRecordNotFound 
So for fix it, I add a check in error handling inside image service, so we can return false as expected for names not present in the database.

### How is it build?
Add an validation using error type provide by GORM package.

### Additional details 
This PR is current necessary to unblock this frontend PR: https://github.com/RedHatInsights/edge-frontend/pull/182 