### PR TITLE
Fix internal server errors in custom repo API due to missing context.

### DIFF
--- a/cmd/spec/openapi.json
+++ b/cmd/spec/openapi.json
@@ -2845,45 +2845,6 @@
       }
     },
     "/thirdpartyrepo/{ID}": {
-      "get": {
-        "operationId": "GetThirdPartyRepoByID",
-        "parameters": [
-          {
-            "description": "An unique existing third party repository id.",
-            "in": "path",
-            "name": "ID",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/v1.CreateThirdPartyRepo"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/v1.InternalServerError"
-                }
-              }
-            },
-            "description": "There was an internal server error."
-          }
-        },
-        "summary": "Get third party repository by id."
-      }
-    },
-    "/thirdpartyrepo/{ID}/delete": {
       "delete": {
         "operationId": "DeleteThirdPartyRepoByID",
         "parameters": [
@@ -2920,9 +2881,44 @@
           }
         },
         "summary": "Delete third party repository using id."
-      }
-    },
-    "/thirdpartyrepo/{ID}/update": {
+      },
+      "get": {
+        "operationId": "GetThirdPartyRepoByID",
+        "parameters": [
+          {
+            "description": "An unique existing third party repository id.",
+            "in": "path",
+            "name": "ID",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.CreateThirdPartyRepo"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.InternalServerError"
+                }
+              }
+            },
+            "description": "There was an internal server error."
+          }
+        },
+        "summary": "Get third party repository by id."
+      },
       "put": {
         "operationId": "CreateThirdPartyRepoUpdate",
         "parameters": [

--- a/cmd/spec/openapi.yaml
+++ b/cmd/spec/openapi.yaml
@@ -2167,7 +2167,6 @@ paths:
                 $ref: '#/components/schemas/v1.InternalServerError'
           description: There was an internal server error.
       summary: Get third party repository by id.
-  /thirdpartyrepo/{ID}/update:
     put:
       operationId: CreateThirdPartyRepoUpdate
       parameters:
@@ -2204,7 +2203,6 @@ paths:
                 $ref: "#/components/schemas/v1.InternalServerError"
           description: There was an internal server error.
       summary: Creates an Update for third party repository  
-  /thirdpartyrepo/{ID}/delete:
     delete:
       operationId: DeleteThirdPartyRepoByID
       parameters:

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -652,7 +652,6 @@ paths:
                 $ref: '#/components/schemas/v1.InternalServerError'
           description: There was an internal server error.
       summary: Get third party repository by id.
-  /thirdpartyrepo/{ID}/update:
     put:
       operationId: CreateThirdPartyRepoUpdate
       parameters:
@@ -689,7 +688,6 @@ paths:
                 $ref: "#/components/schemas/v1.InternalServerError"
           description: There was an internal server error.
       summary: Creates an Update for third party repository  
-  /thirdpartyrepo/{ID}/delete:
     delete:
       operationId: DeleteThirdPartyRepoByID
       parameters:

--- a/pkg/routes/thirdpartyrepo.go
+++ b/pkg/routes/thirdpartyrepo.go
@@ -26,8 +26,8 @@ func MakeThirdPartyRepoRouter(sub chi.Router) {
 	sub.Route("/{ID}", func(r chi.Router) {
 		r.Use(ThirdPartyRepoCtx)
 		r.Get("/", GetThirdPartyRepoByID)
-		r.Put("/update", CreateThirdPartyRepoUpdate)
-		r.Delete("/delete", DeleteThirdPartyRepoByID)
+		r.Put("/", CreateThirdPartyRepoUpdate)
+		r.Delete("/", DeleteThirdPartyRepoByID)
 	})
 }
 

--- a/pkg/services/thirdpartyrepo.go
+++ b/pkg/services/thirdpartyrepo.go
@@ -21,7 +21,9 @@ type ThirdPartyRepoServiceInterface interface {
 
 // NewThirdPartyRepoService gives a instance of the main implementation of a ThirdPartyRepoServiceInterface
 func NewThirdPartyRepoService(ctx context.Context) ThirdPartyRepoServiceInterface {
-	return &ThirdPartyRepoService{}
+	return &ThirdPartyRepoService{
+		ctx:	ctx,
+	}
 }
 
 // ThirdPartyRepoService is the main implementation of a ThirdPartyRepoServiceInterface


### PR DESCRIPTION
This PR fixes the following issues:
- Remove `/delete` and `/update` from the `DELETE` and `PUT` API endpoints. The new endpoints are now:
```
DELETE /thirdpartyrepo/{ID}
PUT /thirdpartyrepo/{ID}
```
- Add missing context variable to the `ThirdPartyRepoService` instance, to resolve internal server errors for `DELETE|PUT|GET /thirdpartyrepo/{ID}` calls when the edge-api service is run with `AUTH=true` (as is the case when deployed via clowder).