### PR TITLE
Bug fix for 1310, 1200

### DIFF
--- a/cmd/spec/openapi.json
+++ b/cmd/spec/openapi.json
@@ -2859,8 +2859,15 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "Successfully deleted third party repository with ID {ID}"
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.CreateThirdPartyRepo"
+                }
+              }
+            },
+            "description": "OK"
           },
           "404": {
             "content": {
@@ -2870,7 +2877,7 @@
                 }
               }
             },
-            "description": "Third Party Repository is not found."
+            "description": "third party repository was not found."
           },
           "500": {
             "content": {
@@ -2917,7 +2924,7 @@
                 }
               }
             },
-            "description": "Third Party Repository is not found."
+            "description": "third party repository was not found."
           },
           "500": {
             "content": {

--- a/cmd/spec/openapi.json
+++ b/cmd/spec/openapi.json
@@ -2859,15 +2859,18 @@
           }
         ],
         "responses": {
-          "200": {
+          "204": {
+            "description": "Successfully deleted third party repository with ID {ID}"
+          },
+          "404": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/v1.CreateThirdPartyRepo"
+                  "$ref": "#/components/schemas/v1.NotFound"
                 }
               }
             },
-            "description": "OK"
+            "description": "Third Party Repository is not found."
           },
           "500": {
             "content": {
@@ -2905,6 +2908,16 @@
               }
             },
             "description": "OK"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.NotFound"
+                }
+              }
+            },
+            "description": "Third Party Repository is not found."
           },
           "500": {
             "content": {

--- a/cmd/spec/openapi.yaml
+++ b/cmd/spec/openapi.yaml
@@ -2165,7 +2165,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/v1.NotFound"
-          description: Third Party Repository is not found.
+          description: third party repository was not found.
         "500":
           content:
             application/json:
@@ -2220,14 +2220,18 @@ paths:
             type:
               integer
       responses:
-        '204':
-          description: Successfully deleted third party repository with ID {ID}
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1.CreateThirdPartyRepo"
+          description: OK
         "404":
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/v1.NotFound"
-          description: Third Party Repository is not found.
+          description: third party repository was not found.
         "500":
           content:
             application/json:

--- a/cmd/spec/openapi.yaml
+++ b/cmd/spec/openapi.yaml
@@ -2160,6 +2160,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/v1.CreateThirdPartyRepo'
           description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1.NotFound"
+          description: Third Party Repository is not found.
         "500":
           content:
             application/json:
@@ -2214,12 +2220,14 @@ paths:
             type:
               integer
       responses:
-        "200":
+        '204':
+          description: Successfully deleted third party repository with ID {ID}
+        "404":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/v1.CreateThirdPartyRepo'
-          description: OK
+                $ref: "#/components/schemas/v1.NotFound"
+          description: Third Party Repository is not found.
         "500":
           content:
             application/json:

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -650,7 +650,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/v1.NotFound"
-          description: Third Party Repository is not found.
+          description: third party repository was not found.
         "500":
           content:
             application/json:
@@ -705,14 +705,18 @@ paths:
             type:
               integer
       responses:
-        '204':
-          description: Successfully deleted third party repository with ID {ID}
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1.CreateThirdPartyRepo"
+          description: OK
         "404":
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/v1.NotFound"
-          description: Third Party Repository is not found.
+          description: third party repository was not found.
         "500":
           content:
             application/json:

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -645,6 +645,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/v1.CreateThirdPartyRepo'
           description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1.NotFound"
+          description: Third Party Repository is not found.
         "500":
           content:
             application/json:
@@ -699,12 +705,14 @@ paths:
             type:
               integer
       responses:
-        "200":
+        '204':
+          description: Successfully deleted third party repository with ID {ID}
+        "404":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/v1.CreateThirdPartyRepo'
-          description: OK
+                $ref: "#/components/schemas/v1.NotFound"
+          description: Third Party Repository is not found.
         "500":
           content:
             application/json:

--- a/pkg/routes/thirdpartyrepo.go
+++ b/pkg/routes/thirdpartyrepo.go
@@ -3,7 +3,6 @@ package routes
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -230,6 +229,5 @@ func DeleteThirdPartyRepoByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_ = tprepo
-	msg := fmt.Sprintf("Successfully deleted third party repository with ID %v", ID)
-	json.NewEncoder(w).Encode(msg)
+	json.NewEncoder(w).Encode(&tprepo)
 }

--- a/pkg/routes/thirdpartyrepo.go
+++ b/pkg/routes/thirdpartyrepo.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/redhatinsights/edge-api/pkg/errors"
 	"github.com/redhatinsights/edge-api/pkg/models"
 	"github.com/redhatinsights/edge-api/pkg/routes/common"
+	"github.com/redhatinsights/edge-api/pkg/services"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -60,7 +62,6 @@ func CreateThirdPartyRepo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	err = services.ThirdPartyRepoService.CreateThirdPartyRepo(tprepo, account)
-
 	if err != nil {
 		log.Error(err)
 		err := errors.NewInternalServerError()
@@ -153,11 +154,17 @@ func GetThirdPartyRepoByID(w http.ResponseWriter, r *http.Request) {
 	ID := chi.URLParam(r, "ID")
 	tprepo, err := s.ThirdPartyRepoService.GetThirdPartyRepoByID(ID)
 	if err != nil {
-		log.Error(err)
-		err := errors.NewInternalServerError()
-		err.SetTitle("failed getting third party repository")
-		w.WriteHeader(err.GetStatus())
-		json.NewEncoder(w).Encode(&err)
+		var responseErr errors.APIError
+		switch err.(type) {
+		case *services.ThirdPartyRepositoryNotFound:
+			responseErr = errors.NewNotFound(err.Error())
+		default:
+			responseErr = errors.NewInternalServerError()
+			responseErr.SetTitle("failed getting third party repository")
+		}
+		log.Error(responseErr)
+		w.WriteHeader(responseErr.GetStatus())
+		json.NewEncoder(w).Encode(&responseErr)
 		return
 	}
 	json.NewEncoder(w).Encode(&tprepo)
@@ -195,8 +202,11 @@ func CreateThirdPartyRepoUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(&tprepo)
-
+	repoDetails, err := services.ThirdPartyRepoService.GetThirdPartyRepoByID(ID)
+	if err != nil {
+		log.Info(err)
+	}
+	json.NewEncoder(w).Encode(repoDetails)
 }
 
 // DeleteThirdPartyRepoByID deletes the third party repository using ID
@@ -206,12 +216,20 @@ func DeleteThirdPartyRepoByID(w http.ResponseWriter, r *http.Request) {
 
 	tprepo, err := s.ThirdPartyRepoService.DeleteThirdPartyRepoByID(ID)
 	if err != nil {
-		log.Error(err)
-		err := errors.NewInternalServerError()
-		err.SetTitle("failed deleting third party repository")
-		w.WriteHeader(err.GetStatus())
-		json.NewEncoder(w).Encode(&err)
+		var responseErr errors.APIError
+		switch err.(type) {
+		case *services.ThirdPartyRepositoryNotFound:
+			responseErr = errors.NewNotFound(err.Error())
+		default:
+			responseErr = errors.NewInternalServerError()
+			responseErr.SetTitle("failed deleting third party repository")
+		}
+		log.Error(responseErr)
+		w.WriteHeader(responseErr.GetStatus())
+		json.NewEncoder(w).Encode(&responseErr)
 		return
 	}
-	json.NewEncoder(w).Encode(&tprepo)
+	_ = tprepo
+	msg := fmt.Sprintf("Successfully deleted third party repository with ID %v", ID)
+	json.NewEncoder(w).Encode(msg)
 }

--- a/pkg/services/errors.go
+++ b/pkg/services/errors.go
@@ -34,3 +34,10 @@ type IDMustBeInteger struct{}
 func (e *IDMustBeInteger) Error() string {
 	return "ID needs to be an integer"
 }
+
+// ThirdPartyRepositoryNotFound indicates the Third Party Repository is not found
+type ThirdPartyRepositoryNotFound struct{}
+
+func (e *ThirdPartyRepositoryNotFound) Error() string {
+	return "Third Party Repository is not found"
+}

--- a/pkg/services/errors.go
+++ b/pkg/services/errors.go
@@ -35,9 +35,9 @@ func (e *IDMustBeInteger) Error() string {
 	return "ID needs to be an integer"
 }
 
-// ThirdPartyRepositoryNotFound indicates the Third Party Repository is not found
+// ThirdPartyRepositoryNotFound indicates the Third Party Repository was not found
 type ThirdPartyRepositoryNotFound struct{}
 
 func (e *ThirdPartyRepositoryNotFound) Error() string {
-	return "Third Party Repository is not found"
+	return "third party repository was not found"
 }

--- a/pkg/services/thirdpartyrepo.go
+++ b/pkg/services/thirdpartyrepo.go
@@ -110,7 +110,7 @@ func (s *ThirdPartyRepoService) DeleteThirdPartyRepoByID(ID string) (*models.Thi
 			return nil, errors.NewInternalServerError()
 		}
 
-		delForm := db.DB.Exec("DELETE FROM third_party_repos WHERE id=? and account=?", ID, account)
+		delForm := db.DB.Where("account = ? and id = ?", account, ID).Delete(&tprepo)
 		if delForm.Error != nil {
 			err := errors.NewInternalServerError()
 			return nil, err

--- a/pkg/services/thirdpartyrepo.go
+++ b/pkg/services/thirdpartyrepo.go
@@ -22,7 +22,7 @@ type ThirdPartyRepoServiceInterface interface {
 // NewThirdPartyRepoService gives a instance of the main implementation of a ThirdPartyRepoServiceInterface
 func NewThirdPartyRepoService(ctx context.Context) ThirdPartyRepoServiceInterface {
 	return &ThirdPartyRepoService{
-		ctx:	ctx,
+		ctx: ctx,
 	}
 }
 
@@ -57,10 +57,9 @@ func (s *ThirdPartyRepoService) GetThirdPartyRepoByID(ID string) (*models.ThirdP
 	if err != nil {
 		return nil, new(AccountNotSet)
 	}
-	result := db.DB.Where("account = ? and id = ?", account, ID).Find(&tprepo)
+	result := db.DB.Where("account = ? and id = ?", account, ID).First(&tprepo)
 	if result.Error != nil {
-		err := errors.NewInternalServerError()
-		return nil, err
+		return nil, new(ThirdPartyRepositoryNotFound)
 	}
 	return &tprepo, nil
 }
@@ -96,21 +95,26 @@ func (s *ThirdPartyRepoService) UpdateThirdPartyRepo(tprepo *models.ThirdPartyRe
 func (s *ThirdPartyRepoService) DeleteThirdPartyRepoByID(ID string) (*models.ThirdPartyRepo, error) {
 	var tprepo models.ThirdPartyRepo
 	account, err := common.GetAccountFromContext(s.ctx)
-	if err != nil {
-		return nil, new(AccountNotSet)
-	}
-	repoDetails, err := s.GetThirdPartyRepoByID(ID)
-	if err != nil {
-		log.Info(err)
-	}
-	if repoDetails.Name == "" {
-		return nil, errors.NewInternalServerError()
-	}
+	result := db.DB.Where("id = ?", ID).First(&tprepo)
+	if result.Error != nil {
+		return nil, new(ThirdPartyRepositoryNotFound)
+	} else {
+		if err != nil {
+			return nil, new(AccountNotSet)
+		}
+		repoDetails, err := s.GetThirdPartyRepoByID(ID)
+		if err != nil {
+			log.Info(err)
+		}
+		if repoDetails.Name == "" {
+			return nil, errors.NewInternalServerError()
+		}
 
-	delForm := db.DB.Exec("DELETE FROM third_party_repos WHERE id=? and account=?", ID, account)
-	if delForm.Error != nil {
-		err := errors.NewInternalServerError()
-		return nil, err
+		delForm := db.DB.Exec("DELETE FROM third_party_repos WHERE id=? and account=?", ID, account)
+		if delForm.Error != nil {
+			err := errors.NewInternalServerError()
+			return nil, err
+		}
 	}
 	return &tprepo, nil
 }


### PR DESCRIPTION
**Now, PUT response returns the correct value for CreatedAt and UpdatedAt**
```
curl --request PUT --url http://localhost:3000/api/edge/v1/thirdpartyrepo/8/  --data '{                                                      
    "URL": "http://www.hmm.com/in/repo/hmmm",
    "Description": "I will have a nice sleep now",
    "Name": "Sleep time"                                                                                                         
}' | jq

{
  "ID": 8,
  "CreatedAt": "2021-11-10T15:52:33.683344213+05:30",
  "UpdatedAt": "2021-11-11T00:55:14.174617616+05:30",
  "DeletedAt": null,
  "Name": "Sleep time",
  "URL": "http://www.hmm.com/in/repo/hmmm",
  "Description": "I will have a nice sleep now",
  "Account": "0000000"
}

```
**Now, we have a better response for DELETE and GET requests for non-existent and deleted objects**
```
curl --request DELETE --url http://localhost:3000/api/edge/v1/thirdpartyrepo/8/ | jq      
 
"Successfully deleted third party repository with ID 8"

```
```
curl --request GET --url http://localhost:3000/api/edge/v1/thirdpartyrepo/10 | jq    

{
  "Code": "NOT_FOUND",
  "Status": 404,
  "Title": "Third Party Repository is not found"
}

```