### PR TITLE
Fix: set image status logic

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -260,18 +260,19 @@ func (s *ImageService) setFinalImageStatus(i *models.Image) error {
 				success = false
 			}
 			if i.Commit.Status == models.ImageStatusBuilding {
+				success = false
 				i.Commit.Status = models.ImageStatusError
 				db.DB.Save(i.Commit)
 			}
 		}
-
 		if out == models.ImageTypeInstaller {
 			if i.Installer == nil || i.Installer.Status != models.ImageStatusSuccess {
 				success = false
 			}
 			if i.Installer.Status == models.ImageStatusBuilding {
+				success = false
 				i.Installer.Status = models.ImageStatusError
-				db.DB.Save(i.Commit)
+				db.DB.Save(i.Installer)
 			}
 		}
 	}
@@ -282,7 +283,7 @@ func (s *ImageService) setFinalImageStatus(i *models.Image) error {
 		i.Status = models.ImageStatusError
 	}
 
-	tx := db.DB.Save(i.Commit)
+	tx := db.DB.Save(i)
 	return tx.Error
 }
 

--- a/pkg/services/images_test.go
+++ b/pkg/services/images_test.go
@@ -53,4 +53,133 @@ var _ = Describe("Image Service Test", func() {
 		})
 
 	})
+	Describe("should set status properly on a built image", func() {
+		Context("when image is type of rhel for edge commit", func() {
+			It("should set status to success when success", func() {
+				image := &models.Image{
+					Commit: &models.Commit{
+						Status: models.ImageStatusSuccess,
+					},
+					OutputTypes: []string{models.ImageTypeCommit},
+				}
+				err := service.setFinalImageStatus(image)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(image.Status).To(Equal(models.ImageStatusSuccess))
+			})
+			It("should set status to error when error", func() {
+				image := &models.Image{
+					Commit: &models.Commit{
+						Status: models.ImageStatusError,
+					},
+					OutputTypes: []string{models.ImageTypeCommit},
+				}
+				err := service.setFinalImageStatus(image)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(image.Status).To(Equal(models.ImageStatusError))
+			})
+			It("should set status as error when building", func() {
+				image := &models.Image{
+					Commit: &models.Commit{
+						Status: models.ImageStatusBuilding,
+					},
+					OutputTypes: []string{models.ImageTypeCommit},
+				}
+				err := service.setFinalImageStatus(image)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(image.Commit.Status).To(Equal(models.ImageStatusError))
+				Expect(image.Status).To(Equal(models.ImageStatusError))
+			})
+		})
+		Context("when image is type of rhel for edge installer", func() {
+			It("should set status to success when success", func() {
+				image := &models.Image{
+					Installer: &models.Installer{
+						Status: models.ImageStatusSuccess,
+					},
+					OutputTypes: []string{models.ImageTypeInstaller},
+				}
+				err := service.setFinalImageStatus(image)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(image.Status).To(Equal(models.ImageStatusSuccess))
+			})
+			It("should set status to error when error", func() {
+				image := &models.Image{
+					Installer: &models.Installer{
+						Status: models.ImageStatusError,
+					},
+					OutputTypes: []string{models.ImageTypeInstaller},
+				}
+				err := service.setFinalImageStatus(image)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(image.Status).To(Equal(models.ImageStatusError))
+			})
+			It("should set status as error when building", func() {
+				image := &models.Image{
+					Installer: &models.Installer{
+						Status: models.ImageStatusBuilding,
+					},
+					OutputTypes: []string{models.ImageTypeInstaller},
+				}
+				err := service.setFinalImageStatus(image)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(image.Installer.Status).To(Equal(models.ImageStatusError))
+				Expect(image.Status).To(Equal(models.ImageStatusError))
+			})
+		})
+
+		Context("when image is type of rhel for edge installer and has output type commit", func() {
+			It("should set status to success when success", func() {
+				image := &models.Image{
+					Installer: &models.Installer{
+						Status: models.ImageStatusSuccess,
+					},
+					Commit: &models.Commit{
+						Status: models.ImageStatusSuccess,
+					},
+					OutputTypes: []string{models.ImageTypeInstaller, models.ImageTypeCommit},
+				}
+				err := service.setFinalImageStatus(image)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(image.Status).To(Equal(models.ImageStatusSuccess))
+			})
+			It("should set status to error when error", func() {
+				image := &models.Image{
+					Installer: &models.Installer{
+						Status: models.ImageStatusError,
+					},
+					Commit: &models.Commit{
+						Status: models.ImageStatusSuccess,
+					},
+					OutputTypes: []string{models.ImageTypeInstaller, models.ImageTypeCommit},
+				}
+				err := service.setFinalImageStatus(image)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(image.Status).To(Equal(models.ImageStatusError))
+			})
+			It("should set status as error when building", func() {
+				image := &models.Image{
+					Installer: &models.Installer{
+						Status: models.ImageStatusBuilding,
+					},
+					Commit: &models.Commit{
+						Status: models.ImageStatusSuccess,
+					},
+					OutputTypes: []string{models.ImageTypeInstaller, models.ImageTypeCommit},
+				}
+				err := service.setFinalImageStatus(image)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(image.Installer.Status).To(Equal(models.ImageStatusError))
+				Expect(image.Status).To(Equal(models.ImageStatusError))
+			})
+		})
+	})
 })


### PR DESCRIPTION
The status wasn't being properly set after a image was built. That happened because we weren't saving the image itself, just the installer/commit on the final step.