### PR TITLE
fix/checkImageName route on OpenAPI files

### DIFF
--- a/cmd/spec/openapi.json
+++ b/cmd/spec/openapi.json
@@ -2176,7 +2176,7 @@
   },
   "openapi": "3.0.0",
   "paths": {
-    "/checkImageName": {
+    "/images/checkImageName": {
       "post": {
         "operationId": "checkImageName",
         "requestBody": {

--- a/cmd/spec/openapi.yaml
+++ b/cmd/spec/openapi.yaml
@@ -2054,7 +2054,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/v1.ImageSetDetails"
           description: OK
-  /checkImageName:
+  /images/checkImageName:
     post:
       operationId: checkImageName
       requestBody:

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -539,7 +539,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/v1.ImageSetDetails"
           description: OK
-  /checkImageName:
+  /images/checkImageName:
     post:
       operationId: checkImageName
       requestBody:


### PR DESCRIPTION
The **checkImageName** route is wrong on the OpenAPI file and it's affecting the tests.