### PR TITLE
Fix logger timestamp format

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -42,7 +42,7 @@ func InitLogger() {
 		}
 		log.AddHook(hook)
 		log.SetFormatter(&log.JSONFormatter{
-			TimestampFormat: time.Now().Format("2006-01-02T15:04:05.999Z"),
+			TimestampFormat: time.RFC3339Nano,
 			FieldMap: log.FieldMap{
 				log.FieldKeyTime: "@timestamp",
 			},


### PR DESCRIPTION
This PR fixes the formatting of the `@timestamp` field in the `@message` field logged by edge-api:

```
@message	{"@timestamp":"191911-1111-119T16:140:1419.1119Z","file":"devices.go:64","func":"GetDeviceByUUID","level":"debug",[...]}
@timestamp	Nov 19, 2021 @ 16:46:14.936
```

Because of how `TimestampFormat` was being passed to `logrus`, the time was being formatted twice, resulting in the bad timestamp value.


