### PR TITLE
Fix typos

### DIFF
--- a/cmd/spec/main.go
+++ b/cmd/spec/main.go
@@ -128,7 +128,7 @@ func main() {
 	checkErr(err)
 	err = ioutil.WriteFile("./cmd/spec/openapi.yaml", b.Bytes(), 0666)
 	checkErr(err)
-	fmt.Println("Spec was generated sucessfully")
+	fmt.Println("Spec was generated successfully")
 }
 
 func checkErr(err error) {

--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -304,7 +304,7 @@ func (c *Client) getComposeStatus(jobID string) (*ComposeStatus, error) {
 		return nil, err
 	}
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("request for status was not sucessful")
+		return nil, fmt.Errorf("request for status was not successful")
 	}
 
 	err = json.Unmarshal(respBody, &cs)

--- a/pkg/routes/inventory.go
+++ b/pkg/routes/inventory.go
@@ -12,7 +12,7 @@ import (
 	"github.com/redhatinsights/edge-api/pkg/services"
 )
 
-// MakeInventoryRouter adds support for operations on invetory
+// MakeInventoryRouter adds support for operations on inventory
 func MakeInventoryRouter(sub chi.Router) {
 	sub.Get("/", GetInventory)
 }
@@ -87,7 +87,7 @@ func GetUpdateAvailableInfo(param *inventory.InventoryParams, r *http.Request, i
 		} else if imageInfo != nil {
 			i.ImageInfo = imageInfo
 		}
-		if param != nil && param.DeviceStatus == "update_availabe" && imageInfo.UpdatesAvailable != nil {
+		if param != nil && param.DeviceStatus == "update_available" && imageInfo.UpdatesAvailable != nil {
 			ivt = append(ivt, i)
 		} else if param != nil && param.DeviceStatus == "running" && imageInfo.UpdatesAvailable == nil {
 			ivt = append(ivt, i)

--- a/pkg/services/files/uploader.go
+++ b/pkg/services/files/uploader.go
@@ -101,7 +101,7 @@ type uploadDetails struct {
 func worker(uploadQueue chan *uploadDetails) {
 	for p := range uploadQueue {
 		fname, err := p.uploader.UploadFile(p.fileName, p.uploadPath)
-		log.Tracef("Filename: %s with counter %d was uploaded sucessfully", fname, p.count)
+		log.Tracef("Filename: %s with counter %d was uploaded successfully", fname, p.count)
 		if err != nil {
 			log.Errorf("error: %v", err)
 		}

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -294,8 +294,8 @@ func (s *ImageService) postProcessImage(id uint) {
 
 	WaitGroup.Add(1) // Processing one image
 	defer func() {
-		WaitGroup.Done() // Done with one image (sucessfuly or not)
-		s.log.Debug("Done with one image - sucessfuly or not")
+		WaitGroup.Done() // Done with one image (successfuly or not)
+		s.log.Debug("Done with one image - successfuly or not")
 		if err := recover(); err != nil {
 			s.log.Fatalf("%s", err)
 		}

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -101,8 +101,8 @@ func (s *UpdateService) CreateUpdate(id uint) (*models.UpdateTransaction, error)
 
 	WaitGroup.Add(1) // Processing one update
 	defer func() {
-		WaitGroup.Done() // Done with one update (sucessfuly or not)
-		log.Debug("Done with one update - sucessfuly or not")
+		WaitGroup.Done() // Done with one update (successfuly or not)
+		log.Debug("Done with one update - successfuly or not")
 		if err := recover(); err != nil {
 			log.Fatalf("%s", err)
 		}
@@ -290,7 +290,7 @@ func (s *UpdateService) GetUpdateTransactionsForDevice(device *models.Device) (*
 const (
 	// PlaybookStatusRunning is the status when a playbook is still running
 	PlaybookStatusRunning = "running"
-	// PlaybookStatusSuccess is the status when a playbook has run sucessfully
+	// PlaybookStatusSuccess is the status when a playbook has run successfully
 	PlaybookStatusSuccess = "success"
 	// PlaybookStatusFailure is the status when a playbook execution fails
 	PlaybookStatusFailure = "failure"
@@ -313,7 +313,7 @@ func (s *UpdateService) ProcessPlaybookDispatcherRunEvent(message []byte) error 
 		log.Debug("Playbook is running - waiting for next messages")
 		return nil
 	} else if e.Payload.Status == PlaybookStatusSuccess {
-		log.Debug("The playbook was applied sucessfully. Waiting two minutes for reboot before setting status to success.")
+		log.Debug("The playbook was applied successfully. Waiting two minutes for reboot before setting status to success.")
 		time.Sleep(s.WaitForReboot)
 	}
 


### PR DESCRIPTION
# Description

This PR fixes a few typos:

- The word `successful` and its variants were misspelled in image build-related comments and log messages
- The inventory sub-router (which doesn't appear to be implemented yet) incorrectly filtered device status by `update_availabe` instead of `update_available`.
