### PR TITLE
Set error status during migration

### DIFF
--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -32,6 +32,29 @@ func main() {
 		"DatabaseName":             cfg.Database.Name,
 	}).Info("Configuration Values:")
 	db.InitDB()
+
+	// If there any image builds in progress, in the current architecture, we need to set them as errors because this is a brand new deployment
+	var images []models.Image
+	db.DB.Where(&models.Image{Status: models.ImageStatusBuilding}).Find(&images)
+	for _, image := range images {
+		log.WithField("imageID", image.ID).Debug("Found image with building status")
+		image.Status = models.ImageStatusError
+		if image.Commit != nil {
+			image.Commit.Status = models.ImageStatusError
+			if image.Commit.Repo != nil {
+				image.Commit.Repo.Status = models.RepoStatusError
+				db.DB.Save(image.Commit.Repo)
+			}
+			db.DB.Save(image.Commit)
+		}
+		if image.Installer != nil {
+			image.Installer.Status = models.ImageStatusError
+			db.DB.Save(image.Installer)
+		}
+		db.DB.Save(image)
+	}
+
+	// Automigration
 	err := db.DB.AutoMigrate(&models.ImageSet{}, &models.Commit{}, &models.UpdateTransaction{}, &models.Package{}, &models.Image{}, &models.Repo{}, &models.DispatchRecord{}, &models.ThirdPartyRepo{})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
# Description

Due to a issue where we are discussing how to handle retries and updates to images with error status, I came up with this strategy to avoid images to get stuck on building status. With our current architecture the migration is the moment where we should set the status with an error and when we migrate to Kafka topics we can revisit that.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes