### PR TITLE
fix preload of dispatch record and add expected result to unit test

### DIFF
--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -331,6 +331,7 @@ func (s *UpdateService) ProcessPlaybookDispatcherRunEvent(message []byte) error 
 	} else if e.Payload.Status == PlaybookStatusRunning {
 		dispatchRecord.Status = models.DispatchRecordStatusRunning
 	} else {
+		dispatchRecord.Status = models.DispatchRecordStatusError
 		log.Fatal("Playbook status is not on the json schema for this event")
 	}
 	result = db.DB.Save(&dispatchRecord)
@@ -344,7 +345,7 @@ func (s *UpdateService) ProcessPlaybookDispatcherRunEvent(message []byte) error 
 // SetUpdateStatusBasedOnDispatchRecord is the function that, given a dispatch record, finds the update transaction related to and update its status if necessary
 func (s *UpdateService) SetUpdateStatusBasedOnDispatchRecord(dispatchRecord models.DispatchRecord) error {
 	var update models.UpdateTransaction
-	result := db.DB.
+	result := db.DB.Preload("DispatchRecords").
 		Table("update_transactions").
 		Joins(
 			`JOIN updatetransaction_dispatchrecords ON update_transactions.id = updatetransaction_dispatchrecords.update_transaction_id`).
@@ -365,6 +366,7 @@ func (s *UpdateService) SetUpdateStatusBasedOnDispatchRecord(dispatchRecord mode
 			break
 		}
 	}
+
 	if allSuccess {
 		update.Status = models.UpdateStatusSuccess
 	}

--- a/pkg/services/updates_test.go
+++ b/pkg/services/updates_test.go
@@ -167,7 +167,9 @@ var _ = Describe("UpdateService Basic functions", func() {
 				err := updateService.ProcessPlaybookDispatcherRunEvent(message)
 				Expect(err).To(BeNil())
 				db.DB.First(&d, d.ID)
+				db.DB.First(&u, u.ID)
 				Expect(d.Status).To(Equal(models.DispatchRecordStatusError))
+				Expect(u.Status).To(Equal(models.UpdateStatusError))
 			})
 		})
 


### PR DESCRIPTION
# Description

Fix Update transaction status when dispatch get timeout response. We should preload the record, once the many2many relationship didnt load the object and allSucess was always as true

Fixes # (issue[https://issues.redhat.com/browse/THEEDGE-1385])

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes