### PR TITLE
Update pr_check.sh to use new cji_smoke_test.sh from bonfire

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -23,4 +23,4 @@ curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 
 source $CICD_ROOT/build.sh
 source $CICD_ROOT/deploy_ephemeral_env.sh
-source $CICD_ROOT/smoke_test.sh
+source $CICD_ROOT/cji_smoke_test.sh


### PR DESCRIPTION
# Description

This PR updates the `pr_check.sh` script to use the new `cji_smoke_test.sh` script from bonfire, instead of the old `smoke_test.sh`.