### PR TITLE
Update pr_check script to match bonfire template, add missing IQE_CJI…

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,26 +1,27 @@
 #!/bin/bash
 
-echo "os: $OSTYPE"
-echo "shell: $SHELL"
-export PATH=$PATH:$PWD
+export APP_NAME="edge"  # name of app-sre "application" folder this component lives in
+export COMPONENT_NAME="edge"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
+export IMAGE="quay.io/cloudservices/edge"  # image location on quay
 
-# --------------------------------------------
-# Options that must be configured by app owner
-# --------------------------------------------
-APP_NAME="edge"  # name of app-sre "application" folder this component lives in
-COMPONENT_NAME="edge-api"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
-IMAGE="quay.io/cloudservices/edge-api"
+export IQE_PLUGINS="edge"  # name of the IQE plugin for this app.
+export IQE_MARKER_EXPRESSION="edge_smoke"  # This is the value passed to pytest -m
+export IQE_FILTER_EXPRESSION=""  # This is the value passed to pytest -k
+export IQE_CJI_TIMEOUT="30m"  # This is the time to wait for smoke test to complete or fail
 
-IQE_PLUGINS="edge"
-IQE_MARKER_EXPRESSION="edge_smoke"
-IQE_FILTER_EXPRESSION=""
-
-echo "LABEL quay.expires-after=3d" >> ./Dockerfile # tag expire in 3 days
 
 # Install bonfire repo/initialize
 CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
 curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 
+# Build the image and push to quay
 source $CICD_ROOT/build.sh
+
+# Run the unit tests with an ephemeral db
+# source $APP_ROOT/unit_test.sh
+
+# Deploy edge to an ephemeral namespace for testing
 source $CICD_ROOT/deploy_ephemeral_env.sh
+
+# Run smoke tests with ClowdJobInvocation
 source $CICD_ROOT/cji_smoke_test.sh


### PR DESCRIPTION
This PR updates `pr_check.sh` to add the missing `IQE_CJI_TIMEOUT` parameter required by the new `cji_smoke_test.sh` script.