### PR TITLE
Fix the COMPONENT_NAME and IMAGE values in pr_check.sh

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 export APP_NAME="edge"  # name of app-sre "application" folder this component lives in
-export COMPONENT_NAME="edge"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
-export IMAGE="quay.io/cloudservices/edge"  # image location on quay
+export COMPONENT_NAME="edge-api"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
+export IMAGE="quay.io/cloudservices/edge-api"  # image location on quay
 
 export IQE_PLUGINS="edge"  # name of the IQE plugin for this app.
 export IQE_MARKER_EXPRESSION="edge_smoke"  # This is the value passed to pytest -m


### PR DESCRIPTION
# Description

The `COMPONENT_NAME` and `IMAGE` variables in `pr_check.sh` were accidentally changed in https://github.com/RedHatInsights/edge-api/pull/411, resulting in errors when the PR check tried to push the newly-built container image to the registry. This PR fixes those values (`edge` -> `edge-api`).