### PR TITLE
Fix appName on post-deployment test

### DIFF
--- a/deploy/stage-post-deployment-tests.yaml
+++ b/deploy/stage-post-deployment-tests.yaml
@@ -9,7 +9,7 @@ objects:
   metadata:
     name: edge-post-deployment-tests-${IMAGE_TAG}-${UID}
   spec:
-    appName: edge
+    appName: edge-api
     testing:
       iqe:
         debug: false


### PR DESCRIPTION
# Description

Fixes app-name on post-deployment test as the ClowdJobInvocation was failing due to not finding a ClowdApp named edge.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I run `go fmt ./...` to check that my code is properly formatted
- [ ] I run `go vet ./...` to check that my code is free of common Go style mistakes