### PR TITLE
Mark update with error status if all dispatch records have error status

### DIFF
--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -362,6 +362,7 @@ func (s *UpdateService) SetUpdateStatusBasedOnDispatchRecord(dispatchRecord mode
 
 }
 
+// SetUpdateStatus is the function to set the update status from an UpdateTransaction
 func (s *UpdateService) SetUpdateStatus(update *models.UpdateTransaction) error {
 	allSuccess := true
 

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -355,7 +355,6 @@ func (s *UpdateService) SetUpdateStatusBasedOnDispatchRecord(dispatchRecord mode
 			dispatchRecord.ID,
 		).First(&update)
 	if result.Error != nil {
-		update.Status = models.UpdateStatusError
 		result := db.DB.Save(&update)
 		return result.Error
 	}

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -191,9 +191,9 @@ func (s *UpdateService) CreateUpdate(id uint) (*models.UpdateTransaction, error)
 			db.DB.Save(&device)
 		}
 		update.DispatchRecords = dispatchRecords
-		tx := db.DB.Save(&update)
-		if tx.Error != nil {
-			log.Errorf("Error saving update: %s ", tx.Error.Error())
+		err = s.SetUpdateStatus(update)
+		if err != nil {
+			log.Errorf("Error saving update: %s ", err.Error())
 			return nil, err
 		}
 	}
@@ -347,7 +347,6 @@ func (s *UpdateService) ProcessPlaybookDispatcherRunEvent(message []byte) error 
 // SetUpdateStatusBasedOnDispatchRecord is the function that, given a dispatch record, finds the update transaction related to and update its status if necessary
 func (s *UpdateService) SetUpdateStatusBasedOnDispatchRecord(dispatchRecord models.DispatchRecord) error {
 	var update models.UpdateTransaction
-	allSuccess := true
 	result := db.DB.Preload("DispatchRecords").
 		Table("update_transactions").
 		Joins(
@@ -356,10 +355,16 @@ func (s *UpdateService) SetUpdateStatusBasedOnDispatchRecord(dispatchRecord mode
 			dispatchRecord.ID,
 		).First(&update)
 	if result.Error != nil {
-		allSuccess = false
 		update.Status = models.UpdateStatusError
+		result := db.DB.Save(&update)
 		return result.Error
 	}
+	return s.SetUpdateStatus(&update)
+
+}
+
+func (s *UpdateService) SetUpdateStatus(update *models.UpdateTransaction) error {
+	allSuccess := true
 
 	for _, d := range update.DispatchRecords {
 		if d.Status != models.DispatchRecordStatusComplete {
@@ -370,10 +375,9 @@ func (s *UpdateService) SetUpdateStatusBasedOnDispatchRecord(dispatchRecord mode
 			break
 		}
 	}
-
 	if allSuccess {
 		update.Status = models.UpdateStatusSuccess
 	}
-	result = db.DB.Save(&update)
+	result := db.DB.Save(update)
 	return result.Error
 }


### PR DESCRIPTION
# Description

When all systems were disconnected, it wasn't even setting the error status on the end and the update was stuck on building.

Fixes #THEEDGE-1404

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes