### PR TITLE
Add retrocompatibility by creating a new route for image details

### DIFF
--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -40,6 +40,7 @@ func MakeImagesRouter(sub chi.Router) {
 	sub.Route("/{imageId}", func(r chi.Router) {
 		r.Use(ImageByIDCtx)                           // TODO: Consistent logging
 		r.Get("/", GetImageByID)                      // TODO: Consistent logging
+		r.Get("/details", GetImageDetailsByID)        // TODO: Consistent logging
 		r.Get("/status", GetImageStatusByID)          // TODO: Consistent logging
 		r.Get("/repo", GetRepoForImage)               // TODO: Consistent logging
 		r.Get("/metadata", GetMetadataForImage)       // TODO: Consistent logging
@@ -366,6 +367,13 @@ type ImageDetail struct {
 
 // GetImageByID obtains a image from the database for an account
 func GetImageByID(w http.ResponseWriter, r *http.Request) {
+	if image := getImage(w, r); image != nil {
+		json.NewEncoder(w).Encode(image)
+	}
+}
+
+// GetImageByID obtains a image from the database for an account
+func GetImageDetailsByID(w http.ResponseWriter, r *http.Request) {
 	if image := getImage(w, r); image != nil {
 		services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
 

--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -372,7 +372,7 @@ func GetImageByID(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// GetImageByID obtains a image from the database for an account
+// GetImageDetailsByID obtains a image from the database for an account
 func GetImageDetailsByID(w http.ResponseWriter, r *http.Request) {
 	if image := getImage(w, r); image != nil {
 		services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)

--- a/pkg/routes/images_test.go
+++ b/pkg/routes/images_test.go
@@ -146,7 +146,7 @@ type ImageResponse struct {
 	UpdateUpdated      int          `json:"update_updated"`
 }
 
-func TestGetImageById(t *testing.T) {
+func TestGetImageDetailsById(t *testing.T) {
 	req, err := http.NewRequest("GET", "/", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -166,7 +166,7 @@ func TestGetImageById(t *testing.T) {
 		Log:          log.NewEntry(log.StandardLogger()),
 	})
 
-	handler := http.HandlerFunc(GetImageByID)
+	handler := http.HandlerFunc(GetImageDetailsByID)
 	handler.ServeHTTP(rr, req.WithContext(ctx))
 
 	if status := rr.Code; status != http.StatusOK {


### PR DESCRIPTION
# Description

Production broke, but with this fix we can add retrocompatibility to the images/<id> endpoint


## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `go fmt ./...` to check that my code is properly formatted
- [ ] I run `go vet ./...` to check that my code is free of common Go style mistakes