### PR TITLE
refactor kickstart admin user

### DIFF
--- a/pkg/services/templateKickstart.ks
+++ b/pkg/services/templateKickstart.ks
@@ -85,9 +85,12 @@ if [ -e /root/fleet_env.bash ]
 then
 	source /root/fleet_env.bash
 
-	[[ -z $ADMIN_USER ]] && echo "No admin user specified" || useradd -m -G wheel $ADMIN_USER
 	if [ -e /root/fleet_authkeys.txt ]
 	then
+		# Grab the ADMIN_USER from the first line of the authkeys file
+		ADMIN_USER=$(grep ADMIN_USER /root/fleet_authkeys.txt | awk -F= '{print $2}')
+		[[ -z $ADMIN_USER ]] && echo "No admin user specified" || useradd -m -G wheel $ADMIN_USER
+
 		USER_HOME=$(getent passwd $ADMIN_USER | awk -F: '{print $6}')
 		mkdir -p ${USER_HOME}/.ssh
 		chmod 755 ${USER_HOME}/.ssh


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Moved the ADMIN_USER key=value from the RHC creds file to the top of the authkeys file it is associated with.
It makes the rhc creds file specific to RHC auto-reg and the authkeys fle specific to adding a user.
This change to the kickstart reads the ADMIN_USER from the top of the file during install.

Fixes # (issue) N/A

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I run `go fmt ./...` to check that my code is properly formatted
- [ ] I run `go vet ./...` to check that my code is free of common Go style mistakes