### PR TITLE
Add logs to retry create image

### DIFF
--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -584,7 +584,7 @@ func RetryCreateImage(w http.ResponseWriter, r *http.Request) {
 		services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
 		err := services.ImageService.RetryCreateImage(image)
 		if err != nil {
-			log.Error(err)
+			services.Log.WithField("error", err.Error()).Error("Failed to retry to create image")
 			err := errors.NewInternalServerError()
 			err.SetTitle("Failed creating image")
 			w.WriteHeader(err.GetStatus())

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -754,12 +754,12 @@ func (s *ImageService) RetryCreateImage(image *models.Image) error {
 	// recompose commit
 	image, err := s.imageBuilder.ComposeCommit(image)
 	if err != nil {
-		s.log.Error("Failed recomposing commit")
+		s.log.WithField("error", err.Error()).Error("Failed recomposing commit")
 		return err
 	}
 	err = s.setBuildingStatusOnImageToRetryBuild(image)
 	if err != nil {
-		s.log.Error("Failed setting image status")
+		s.log.WithField("error", err.Error()).Error("Failed setting image status")
 		return nil
 	}
 	go s.postProcessImage(image.ID)


### PR DESCRIPTION
# Description

Adds logs on retry create image method. Most of the things were already being logged, so I just made sure to add the errors as an extra field.

Fixes #THEEDGE-1218

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes