### PR TITLE
Move create installer to service, refactor to avoid codedup

### DIFF
--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -410,64 +410,26 @@ func GetImageByOstree(w http.ResponseWriter, r *http.Request) {
 }
 
 // CreateInstallerForImage creates a installer for a Image
-// It requires a created image and an update for the commit
+// It requires a created image and a repo with a successful status
 func CreateInstallerForImage(w http.ResponseWriter, r *http.Request) {
 	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
 	image := getImage(w, r)
-	var imageInstaller *models.Installer
-	if err := json.NewDecoder(r.Body).Decode(&imageInstaller); err != nil {
-		log.Error(err)
+	if err := json.NewDecoder(r.Body).Decode(&image.Installer); err != nil {
+		log.WithField("error", err).Error("Failed to decode installer")
 		err := errors.NewInternalServerError()
 		w.WriteHeader(err.GetStatus())
 		json.NewEncoder(w).Encode(&err)
 		return
 	}
-	image.ImageType = models.ImageTypeInstaller
-	image.Installer = imageInstaller
-
-	tx := db.DB.Save(&image)
-	if tx.Error != nil {
-		log.Fatal(tx.Error)
-		err := errors.NewInternalServerError()
-		err.SetTitle("Failed saving image status")
-		w.WriteHeader(err.GetStatus())
-		json.NewEncoder(w).Encode(&err)
-		return
-	}
-	client := imagebuilder.InitClient(r.Context(), services.Log)
-	image, err := client.ComposeInstaller(image)
+	image, err := services.ImageService.CreateInstallerForImage(image)
 	if err != nil {
-		log.Error(err)
+		log.WithField("error", err).Error("Failed to create installer")
 		err := errors.NewInternalServerError()
+		err.SetTitle("Failed to create installer")
 		w.WriteHeader(err.GetStatus())
 		json.NewEncoder(w).Encode(&err)
 		return
 	}
-
-	go func(id uint, ctx context.Context) {
-
-		services, _ := ctx.Value(dependencies.Key).(*dependencies.EdgeAPIServices)
-		var i *models.Image
-		db.DB.Joins("Commit").Joins("Installer").First(&i, id)
-		for {
-			i, err := services.ImageService.UpdateImageStatus(i)
-			if err != nil {
-				services.ImageService.SetErrorStatusOnImage(err, i)
-			}
-			if i.Installer.Status != models.ImageStatusBuilding {
-				break
-			}
-			time.Sleep(1 * time.Minute)
-		}
-		if i.Installer.Status == models.ImageStatusSuccess {
-			err = services.ImageService.AddUserInfo(image)
-			if err != nil {
-				// TODO: Temporary. Handle error better.
-				log.Errorf("Kickstart file injection failed %s", err.Error())
-			}
-		}
-	}(image.ID, r.Context())
-
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(&image)
 }

--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/go-chi/chi"
-	"github.com/redhatinsights/edge-api/pkg/clients/imagebuilder"
 	"github.com/redhatinsights/edge-api/pkg/db"
 	"github.com/redhatinsights/edge-api/pkg/dependencies"
 	"github.com/redhatinsights/edge-api/pkg/errors"

--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -420,7 +420,7 @@ func CreateInstallerForImage(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(&err)
 		return
 	}
-	image, err := services.ImageService.CreateInstallerForImage(image)
+	image, err, _ := services.ImageService.CreateInstallerForImage(image)
 	if err != nil {
 		log.WithField("error", err).Error("Failed to create installer")
 		err := errors.NewInternalServerError()

--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -420,7 +420,7 @@ func CreateInstallerForImage(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(&err)
 		return
 	}
-	image, err, _ := services.ImageService.CreateInstallerForImage(image)
+	image, _, err := services.ImageService.CreateInstallerForImage(image)
 	if err != nil {
 		log.WithField("error", err).Error("Failed to create installer")
 		err := errors.NewInternalServerError()

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -39,7 +39,7 @@ type ImageServiceInterface interface {
 	UpdateImageStatus(image *models.Image) (*models.Image, error)
 	SetErrorStatusOnImage(err error, i *models.Image)
 	CreateRepoForImage(i *models.Image) (*models.Repo, error)
-	CreateInstallerForImage(i *models.Image) (*models.Image, error)
+	CreateInstallerForImage(i *models.Image) (*models.Image, error, chan error)
 	GetImageByID(id string) (*models.Image, error)
 	GetUpdateInfo(image models.Image) ([]ImageUpdateAvailable, error)
 	AddPackageInfo(image *models.Image) (ImageDetail, error)

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -118,7 +118,7 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 	if previousImage == nil {
 		return new(ImageNotFoundError)
 	}
-	err := s.checkForDuplicateImageVersion(previousImage)
+	err := s.checkIfIsLatestVersion(previousImage)
 	if err != nil {
 		return errors.NewBadRequest("only the latest updated image can be modified")
 	}
@@ -803,8 +803,8 @@ func uploadTarRepo(account, imageName string, repoID int) (string, error) {
 	return url, nil
 }
 
-// checkForDuplicateImageVersion make sure that there is no same image version present
-func (s *ImageService) checkForDuplicateImageVersion(previousImage *models.Image) error {
+// checkIfIsLatestVersion make sure that there is no same image version present
+func (s *ImageService) checkIfIsLatestVersion(previousImage *models.Image) error {
 	/*
 		nowImage is the version of current Image which we are updating i.e if we are updating image1 to image 2 then image1 is the nowImage.
 		currentHighestImageVersion is the latest version present in the DB of image we're updating.

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -39,6 +39,7 @@ type ImageServiceInterface interface {
 	UpdateImageStatus(image *models.Image) (*models.Image, error)
 	SetErrorStatusOnImage(err error, i *models.Image)
 	CreateRepoForImage(i *models.Image) (*models.Repo, error)
+	CreateInstallerForImage(i *models.Image) (*models.Image, error)
 	GetImageByID(id string) (*models.Image, error)
 	GetUpdateInfo(image models.Image) ([]ImageUpdateAvailable, error)
 	AddPackageInfo(image *models.Image) (ImageDetail, error)
@@ -195,20 +196,10 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 	return nil
 }
 
-func (s *ImageService) postProcessInstaller(i *models.Image) error {
+func (s *ImageService) postProcessInstaller(image *models.Image) error {
 	s.log.Debug("Post processing installer")
-	i, err := s.imageBuilder.ComposeInstaller(i)
-	if err != nil {
-		return err
-	}
-	i.Installer.Status = models.ImageStatusBuilding
-	tx := db.DB.Save(&i.Installer)
-	if tx.Error != nil {
-		s.log.WithField("error", err.Error()).Error("Error setting installer building status")
-		return err
-	}
 	for {
-		i, err := s.UpdateImageStatus(i)
+		i, err := s.UpdateImageStatus(image)
 		if err != nil {
 			s.log.WithField("error", err.Error()).Error("Update image status error")
 			return err
@@ -219,16 +210,20 @@ func (s *ImageService) postProcessInstaller(i *models.Image) error {
 		time.Sleep(1 * time.Minute)
 	}
 
-	if i.Installer.Status == models.ImageStatusSuccess {
-		err = s.AddUserInfo(i)
+	if image.Installer.Status == models.ImageStatusSuccess {
+		err := s.AddUserInfo(image)
 		if err != nil {
 			s.log.WithField("error", err.Error()).Error("Kickstart file injection failed")
 			return err
 		}
 	}
+	// Regardless of the status, call this method to make sure the status will be updated
+	// It updates the status across the image and not just the installer
+	s.log.Debug("Setting final image status")
+	s.setFinalImageStatus(image)
+	s.log.Debug("Post processing image with installer is done")
 	return nil
 }
-
 func (s *ImageService) postProcessCommit(image *models.Image) error {
 	s.log.Debug("Post processing commit")
 	for {
@@ -257,10 +252,17 @@ func (s *ImageService) postProcessCommit(image *models.Image) error {
 			return err
 		}
 	}
+	if !image.HasOutputType(models.ImageTypeInstaller) {
+		image.Installer = nil
+		s.log.Debug("Setting final image status - no installer to create")
+		s.setFinalImageStatus(image)
+		s.log.Debug("Post processing image is done - no installer to create")
+	}
+	s.log.Debug("Post processing commit is done")
 	return nil
 }
 
-func (s *ImageService) setFinalImageStatus(i *models.Image) error {
+func (s *ImageService) setFinalImageStatus(i *models.Image) {
 	// image status can be success if all output types are successful
 	// if any status are not final (success/error) then sets to error
 	// image status is error if any output status is error
@@ -295,7 +297,9 @@ func (s *ImageService) setFinalImageStatus(i *models.Image) error {
 	}
 
 	tx := db.DB.Save(i)
-	return tx.Error
+	if tx.Error != nil {
+		s.log.WithField("error", tx.Error.Error()).Fatal("Couldn't set final image status")
+	}
 }
 
 // Every log message in this method already has commit id and image id injected
@@ -333,24 +337,14 @@ func (s *ImageService) postProcessImage(id uint) {
 
 	if i.Commit.Status == models.ImageStatusSuccess {
 		s.log.Debug("Commit is successful")
-		// TODO: We need to discuss this whole thing post-July deliverable
 		if i.HasOutputType(models.ImageTypeInstaller) {
-			err = s.postProcessInstaller(i)
+			i, err = s.CreateInstallerForImage(i)
 			if err != nil {
 				s.SetErrorStatusOnImage(err, i)
 				s.log.WithField("error", err.Error()).Fatal("Failed creating installer for image")
 			}
-		} else {
-			// Cleaning up possible non nil installers if doesnt have output type installer
-			i.Installer = nil
 		}
 	}
-	s.log.Debug("Setting final image status")
-	err = s.setFinalImageStatus(i)
-	if err != nil {
-		s.log.WithField("error", err.Error()).Fatal("Couldn't set final image status")
-	}
-	s.log.Debug("Post processing image is done")
 }
 
 // CreateRepoForImage creates the OSTree repo to host that image
@@ -878,5 +872,28 @@ func (s *ImageService) GetMetadata(image *models.Image) (*models.Image, error) {
 		return nil, err
 	}
 	s.log.Debug("Metadata retrieved successfully")
+	return image, nil
+}
+
+// CreateInstallerForImage creates a installer given an existent iamge
+func (s *ImageService) CreateInstallerForImage(image *models.Image) (*models.Image, error) {
+	s.log.Debug("Creating installer for image")
+	image.ImageType = models.ImageTypeInstaller
+	image.Installer.Status = models.ImageStatusBuilding
+	tx := db.DB.Save(&image)
+	if tx.Error != nil {
+		s.log.WithField("error", tx.Error.Error()).Error("Error saving image")
+		return nil, tx.Error
+	}
+	tx = db.DB.Save(&image.Installer)
+	if tx.Error != nil {
+		s.log.WithField("error", tx.Error.Error()).Error("Error saving installer")
+		return nil, tx.Error
+	}
+	image, err := s.imageBuilder.ComposeInstaller(image)
+	if err != nil {
+		return nil, err
+	}
+	go s.postProcessInstaller(image)
 	return image, nil
 }

--- a/pkg/services/images_test.go
+++ b/pkg/services/images_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/redhatinsights/edge-api/pkg/clients/imagebuilder/mock_imagebuilder"
+	"github.com/redhatinsights/edge-api/pkg/db"
 	"github.com/redhatinsights/edge-api/pkg/models"
 	log "github.com/sirupsen/logrus"
 )
@@ -232,10 +233,12 @@ var _ = Describe("Image Service Test", func() {
 				Expect(image.Installer.Status).To(Equal(models.ImageStatusCreated))
 			})
 		})
-		Context("when trying to update a image whose version already exists", func() {
-			It("should set status to building", func() {
-				image := &models.Image{}
-				err := service.checkForDuplicateImageVersion(image)
+		Context("when checking if the image version we are trying to create is duplicate", func() {
+			It("shouldnt be able to", func() {
+				image := &models.Image{Version: 1, Name: "image-same-name"}
+				db.DB.Save(image)
+				db.DB.Save(&models.Image{Version: 2, Name: "image-same-name"})
+				err := service.checkIfIsLatestVersion(image)
 
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(new(ImageVersionAlreadyExists)))

--- a/pkg/services/images_test.go
+++ b/pkg/services/images_test.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"testing"
 
 	"github.com/bxcodec/faker/v3"
 	"github.com/golang/mock/gomock"
@@ -102,9 +101,8 @@ var _ = Describe("Image Service Test", func() {
 					},
 					OutputTypes: []string{models.ImageTypeCommit},
 				}
-				err := service.setFinalImageStatus(image)
+				service.setFinalImageStatus(image)
 
-				Expect(err).ToNot(HaveOccurred())
 				Expect(image.Status).To(Equal(models.ImageStatusSuccess))
 			})
 			It("should set status to error when error", func() {
@@ -114,9 +112,8 @@ var _ = Describe("Image Service Test", func() {
 					},
 					OutputTypes: []string{models.ImageTypeCommit},
 				}
-				err := service.setFinalImageStatus(image)
+				service.setFinalImageStatus(image)
 
-				Expect(err).ToNot(HaveOccurred())
 				Expect(image.Status).To(Equal(models.ImageStatusError))
 			})
 			It("should set status as error when building", func() {
@@ -126,9 +123,8 @@ var _ = Describe("Image Service Test", func() {
 					},
 					OutputTypes: []string{models.ImageTypeCommit},
 				}
-				err := service.setFinalImageStatus(image)
+				service.setFinalImageStatus(image)
 
-				Expect(err).ToNot(HaveOccurred())
 				Expect(image.Commit.Status).To(Equal(models.ImageStatusError))
 				Expect(image.Status).To(Equal(models.ImageStatusError))
 			})
@@ -141,9 +137,8 @@ var _ = Describe("Image Service Test", func() {
 					},
 					OutputTypes: []string{models.ImageTypeInstaller},
 				}
-				err := service.setFinalImageStatus(image)
+				service.setFinalImageStatus(image)
 
-				Expect(err).ToNot(HaveOccurred())
 				Expect(image.Status).To(Equal(models.ImageStatusSuccess))
 			})
 			It("should set status to error when error", func() {
@@ -153,9 +148,8 @@ var _ = Describe("Image Service Test", func() {
 					},
 					OutputTypes: []string{models.ImageTypeInstaller},
 				}
-				err := service.setFinalImageStatus(image)
+				service.setFinalImageStatus(image)
 
-				Expect(err).ToNot(HaveOccurred())
 				Expect(image.Status).To(Equal(models.ImageStatusError))
 			})
 			It("should set status as error when building", func() {
@@ -165,9 +159,8 @@ var _ = Describe("Image Service Test", func() {
 					},
 					OutputTypes: []string{models.ImageTypeInstaller},
 				}
-				err := service.setFinalImageStatus(image)
+				service.setFinalImageStatus(image)
 
-				Expect(err).ToNot(HaveOccurred())
 				Expect(image.Installer.Status).To(Equal(models.ImageStatusError))
 				Expect(image.Status).To(Equal(models.ImageStatusError))
 			})
@@ -184,9 +177,8 @@ var _ = Describe("Image Service Test", func() {
 					},
 					OutputTypes: []string{models.ImageTypeInstaller, models.ImageTypeCommit},
 				}
-				err := service.setFinalImageStatus(image)
+				service.setFinalImageStatus(image)
 
-				Expect(err).ToNot(HaveOccurred())
 				Expect(image.Status).To(Equal(models.ImageStatusSuccess))
 			})
 			It("should set status to error when error", func() {
@@ -199,9 +191,8 @@ var _ = Describe("Image Service Test", func() {
 					},
 					OutputTypes: []string{models.ImageTypeInstaller, models.ImageTypeCommit},
 				}
-				err := service.setFinalImageStatus(image)
+				service.setFinalImageStatus(image)
 
-				Expect(err).ToNot(HaveOccurred())
 				Expect(image.Status).To(Equal(models.ImageStatusError))
 			})
 			It("should set status as error when building", func() {
@@ -214,9 +205,8 @@ var _ = Describe("Image Service Test", func() {
 					},
 					OutputTypes: []string{models.ImageTypeInstaller, models.ImageTypeCommit},
 				}
-				err := service.setFinalImageStatus(image)
+				service.setFinalImageStatus(image)
 
-				Expect(err).ToNot(HaveOccurred())
 				Expect(image.Installer.Status).To(Equal(models.ImageStatusError))
 				Expect(image.Status).To(Equal(models.ImageStatusError))
 			})
@@ -242,13 +232,14 @@ var _ = Describe("Image Service Test", func() {
 				Expect(image.Installer.Status).To(Equal(models.ImageStatusCreated))
 			})
 		})
+		Context("when trying to update a image whose version already exists", func() {
+			It("should set status to building", func() {
+				image := &models.Image{}
+				err := service.checkForDuplicateImageVersion(image)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(new(ImageVersionAlreadyExists)))
+			})
+		})
 	})
 })
-
-func TestUpdateImageHasVersionAlreadyExists(t *testing.T) {
-	var service ImageService
-	image := &models.Image{}
-	if service.checkForDuplicateImageVersion(image) == new(ImageVersionAlreadyExists) {
-		t.Error("image version for updated image already exists")
-	}
-}

--- a/pkg/services/mock_services/images.go
+++ b/pkg/services/mock_services/images.go
@@ -94,12 +94,13 @@ func (mr *MockImageServiceInterfaceMockRecorder) CreateImage(image, account inte
 }
 
 // CreateInstallerForImage mocks base method.
-func (m *MockImageServiceInterface) CreateInstallerForImage(i *models.Image) (*models.Image, error) {
+func (m *MockImageServiceInterface) CreateInstallerForImage(i *models.Image) (*models.Image, error, chan error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInstallerForImage", i)
 	ret0, _ := ret[0].(*models.Image)
 	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret2, _ := ret[2].(chan error)
+	return ret0, ret1, ret2
 }
 
 // CreateInstallerForImage indicates an expected call of CreateInstallerForImage.

--- a/pkg/services/mock_services/images.go
+++ b/pkg/services/mock_services/images.go
@@ -93,6 +93,21 @@ func (mr *MockImageServiceInterfaceMockRecorder) CreateImage(image, account inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateImage", reflect.TypeOf((*MockImageServiceInterface)(nil).CreateImage), image, account)
 }
 
+// CreateInstallerForImage mocks base method.
+func (m *MockImageServiceInterface) CreateInstallerForImage(i *models.Image) (*models.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateInstallerForImage", i)
+	ret0, _ := ret[0].(*models.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateInstallerForImage indicates an expected call of CreateInstallerForImage.
+func (mr *MockImageServiceInterfaceMockRecorder) CreateInstallerForImage(i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstallerForImage", reflect.TypeOf((*MockImageServiceInterface)(nil).CreateInstallerForImage), i)
+}
+
 // CreateRepoForImage mocks base method.
 func (m *MockImageServiceInterface) CreateRepoForImage(i *models.Image) (*models.Repo, error) {
 	m.ctrl.T.Helper()

--- a/pkg/services/mock_services/images.go
+++ b/pkg/services/mock_services/images.go
@@ -94,12 +94,12 @@ func (mr *MockImageServiceInterfaceMockRecorder) CreateImage(image, account inte
 }
 
 // CreateInstallerForImage mocks base method.
-func (m *MockImageServiceInterface) CreateInstallerForImage(i *models.Image) (*models.Image, error, chan error) {
+func (m *MockImageServiceInterface) CreateInstallerForImage(i *models.Image) (*models.Image, chan error, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInstallerForImage", i)
 	ret0, _ := ret[0].(*models.Image)
-	ret1, _ := ret[1].(error)
-	ret2, _ := ret[2].(chan error)
+	ret1, _ := ret[1].(chan error)
+	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 


### PR DESCRIPTION
# Description

Adds logs to create installer method, moves code to service & refactor to avoid the code duplication that was going on 

Fixes #THEEDGE-1218

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes