### PR TITLE
Make private Context edge-api services key.

### DIFF
--- a/pkg/dependencies/main.go
+++ b/pkg/dependencies/main.go
@@ -43,16 +43,27 @@ func Init(ctx context.Context) *EdgeAPIServices {
 	}
 }
 
-type key int
+type servicesKeyType int
 
-// Key is the context key for dependencies on the request context
-const Key key = iota
+// servicesKey is the context key for dependencies on the request context
+const servicesKey servicesKeyType = iota
+
+// ContextWithServices add edge apis services to context
+func ContextWithServices(ctx context.Context, services *EdgeAPIServices) context.Context {
+	return context.WithValue(ctx, servicesKey, services)
+}
+
+// ServicesFromContext return the edge api services from context
+func ServicesFromContext(ctx context.Context) (*EdgeAPIServices, bool) {
+	edgeAPIServices, ok := ctx.Value(servicesKey).(*EdgeAPIServices)
+	return edgeAPIServices, ok
+}
 
 // Middleware is the dependencies Middleware that serves all Edge API services on the current request context
 func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		services := Init(r.Context())
-		ctx := context.WithValue(r.Context(), Key, services)
+		edgeAPIServices := Init(r.Context())
+		ctx := ContextWithServices(r.Context(), edgeAPIServices)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/pkg/dependencies/main.go
+++ b/pkg/dependencies/main.go
@@ -43,10 +43,10 @@ func Init(ctx context.Context) *EdgeAPIServices {
 	}
 }
 
-type servicesKeyType int
+type servicesKeyType string
 
 // servicesKey is the context key for dependencies on the request context
-const servicesKey servicesKeyType = iota
+const servicesKey = servicesKeyType("services")
 
 // ContextWithServices add edge apis services to context
 func ContextWithServices(ctx context.Context, services *EdgeAPIServices) context.Context {
@@ -54,9 +54,13 @@ func ContextWithServices(ctx context.Context, services *EdgeAPIServices) context
 }
 
 // ServicesFromContext return the edge api services from context
-func ServicesFromContext(ctx context.Context) (*EdgeAPIServices, bool) {
+func ServicesFromContext(ctx context.Context) *EdgeAPIServices {
 	edgeAPIServices, ok := ctx.Value(servicesKey).(*EdgeAPIServices)
-	return edgeAPIServices, ok
+	if !ok {
+		log.Fatal("Could not get EdgeAPIServices from Context")
+	}
+
+	return edgeAPIServices
 }
 
 // Middleware is the dependencies Middleware that serves all Edge API services on the current request context

--- a/pkg/routes/devices.go
+++ b/pkg/routes/devices.go
@@ -63,7 +63,7 @@ func GetUpdateAvailableForDevice(w http.ResponseWriter, r *http.Request) {
 	if dc.DeviceUUID == "" {
 		return // Error set by DeviceCtx method
 	}
-	contextServices, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	contextServices, _ := dependencies.ServicesFromContext(r.Context())
 	result, err := contextServices.DeviceService.GetUpdateAvailableForDeviceByUUID(dc.DeviceUUID)
 	if err == nil {
 		json.NewEncoder(w).Encode(result)
@@ -99,7 +99,7 @@ func GetDeviceImageInfo(w http.ResponseWriter, r *http.Request) {
 	if dc.DeviceUUID == "" {
 		return // Error set by DeviceCtx method
 	}
-	contextServices, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	contextServices, _ := dependencies.ServicesFromContext(r.Context())
 	result, err := contextServices.DeviceService.GetDeviceImageInfo(dc.DeviceUUID)
 	if err == nil {
 		json.NewEncoder(w).Encode(result)
@@ -133,7 +133,7 @@ func GetDevice(w http.ResponseWriter, r *http.Request) {
 	if dc.DeviceUUID == "" {
 		return // Error set by DeviceCtx method
 	}
-	contextServices, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	contextServices, _ := dependencies.ServicesFromContext(r.Context())
 	result, err := contextServices.DeviceService.GetDeviceDetails(dc.DeviceUUID)
 	if err == nil {
 		json.NewEncoder(w).Encode(result)

--- a/pkg/routes/devices.go
+++ b/pkg/routes/devices.go
@@ -63,7 +63,7 @@ func GetUpdateAvailableForDevice(w http.ResponseWriter, r *http.Request) {
 	if dc.DeviceUUID == "" {
 		return // Error set by DeviceCtx method
 	}
-	contextServices, _ := dependencies.ServicesFromContext(r.Context())
+	contextServices := dependencies.ServicesFromContext(r.Context())
 	result, err := contextServices.DeviceService.GetUpdateAvailableForDeviceByUUID(dc.DeviceUUID)
 	if err == nil {
 		json.NewEncoder(w).Encode(result)
@@ -99,7 +99,7 @@ func GetDeviceImageInfo(w http.ResponseWriter, r *http.Request) {
 	if dc.DeviceUUID == "" {
 		return // Error set by DeviceCtx method
 	}
-	contextServices, _ := dependencies.ServicesFromContext(r.Context())
+	contextServices := dependencies.ServicesFromContext(r.Context())
 	result, err := contextServices.DeviceService.GetDeviceImageInfo(dc.DeviceUUID)
 	if err == nil {
 		json.NewEncoder(w).Encode(result)
@@ -133,7 +133,7 @@ func GetDevice(w http.ResponseWriter, r *http.Request) {
 	if dc.DeviceUUID == "" {
 		return // Error set by DeviceCtx method
 	}
-	contextServices, _ := dependencies.ServicesFromContext(r.Context())
+	contextServices := dependencies.ServicesFromContext(r.Context())
 	result, err := contextServices.DeviceService.GetDeviceDetails(dc.DeviceUUID)
 	if err == nil {
 		json.NewEncoder(w).Encode(result)

--- a/pkg/routes/devices_test.go
+++ b/pkg/routes/devices_test.go
@@ -29,7 +29,7 @@ func TestGetAvailableUpdateForDeviceWithEmptyUUID(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDeviceService := mock_services.NewMockDeviceServiceInterface(ctrl)
-	ctx = context.WithValue(ctx, dependencies.Key, &dependencies.EdgeAPIServices{
+	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		DeviceService: mockDeviceService,
 	})
 	req = req.WithContext(ctx)
@@ -61,7 +61,7 @@ func TestGetAvailableUpdateForDeviceWhenDeviceIsNotFound(t *testing.T) {
 
 	mockDeviceService := mock_services.NewMockDeviceServiceInterface(ctrl)
 	mockDeviceService.EXPECT().GetUpdateAvailableForDeviceByUUID(gomock.Eq(dc.DeviceUUID)).Return(nil, new(services.DeviceNotFoundError))
-	ctx = context.WithValue(ctx, dependencies.Key, &dependencies.EdgeAPIServices{
+	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		DeviceService: mockDeviceService,
 	})
 	req = req.WithContext(ctx)
@@ -93,7 +93,7 @@ func TestGetAvailableUpdateForDeviceWhenAUnexpectedErrorHappens(t *testing.T) {
 
 	mockDeviceService := mock_services.NewMockDeviceServiceInterface(ctrl)
 	mockDeviceService.EXPECT().GetUpdateAvailableForDeviceByUUID(gomock.Eq(dc.DeviceUUID)).Return(nil, errors.New("random error"))
-	ctx = context.WithValue(ctx, dependencies.Key, &dependencies.EdgeAPIServices{
+	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		DeviceService: mockDeviceService,
 	})
 	req = req.WithContext(ctx)

--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -55,7 +55,7 @@ var validStatuses = []string{models.ImageStatusCreated, models.ImageStatusBuildi
 // ImageByOSTreeHashCtx is a handler for Images but adds finding images by Ostree Hash
 func ImageByOSTreeHashCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		s, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+		s, _ := dependencies.ServicesFromContext(r.Context())
 		if commitHash := chi.URLParam(r, "ostreeCommitHash"); commitHash != "" {
 			s.Log = s.Log.WithField("ostreeCommitHash", commitHash)
 			image, err := s.ImageService.GetImageByOSTreeCommitHash(commitHash)
@@ -88,7 +88,7 @@ func ImageByOSTreeHashCtx(next http.Handler) http.Handler {
 // ImageByIDCtx is a handler for Image requests
 func ImageByIDCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		s, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+		s, _ := dependencies.ServicesFromContext(r.Context())
 		if imageID := chi.URLParam(r, "imageId"); imageID != "" {
 			s.Log = s.Log.WithField("imageID", imageID)
 			image, err := s.ImageService.GetImageByID(imageID)
@@ -144,7 +144,7 @@ type CreateImageRequest struct {
 // It always creates a commit on Image Builder.
 // Then we create our repo with the ostree commit and if needed, create the installer.
 func CreateImage(w http.ResponseWriter, r *http.Request) {
-	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	services, _ := dependencies.ServicesFromContext(r.Context())
 	defer r.Body.Close()
 	image, err := initImageCreateRequest(w, r)
 	if err != nil {
@@ -179,7 +179,7 @@ func CreateImage(w http.ResponseWriter, r *http.Request) {
 
 // CreateImageUpdate creates an update for an exitent image on hosted image builder.
 func CreateImageUpdate(w http.ResponseWriter, r *http.Request) {
-	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	services, _ := dependencies.ServicesFromContext(r.Context())
 	defer r.Body.Close()
 	image, err := initImageCreateRequest(w, r)
 	if err != nil {
@@ -287,7 +287,7 @@ func validateGetAllImagesSearchParams(next http.Handler) http.Handler {
 
 // GetAllImages image objects from the database for an account
 func GetAllImages(w http.ResponseWriter, r *http.Request) {
-	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	services, _ := dependencies.ServicesFromContext(r.Context())
 	services.Log.Debug("Getting all images")
 	var count int64
 	var images []models.Image
@@ -367,7 +367,7 @@ func GetImageByID(w http.ResponseWriter, r *http.Request) {
 // GetImageDetailsByID obtains a image from the database for an account
 func GetImageDetailsByID(w http.ResponseWriter, r *http.Request) {
 	if image := getImage(w, r); image != nil {
-		services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+		services, _ := dependencies.ServicesFromContext(r.Context())
 		var imgDetail ImageDetail
 		imgDetail.Image = image
 		imgDetail.Packages = len(image.Commit.InstalledPackages)
@@ -400,7 +400,7 @@ func GetImageByOstree(w http.ResponseWriter, r *http.Request) {
 // CreateInstallerForImage creates a installer for a Image
 // It requires a created image and a repo with a successful status
 func CreateInstallerForImage(w http.ResponseWriter, r *http.Request) {
-	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	services, _ := dependencies.ServicesFromContext(r.Context())
 	image := getImage(w, r)
 	if err := json.NewDecoder(r.Body).Decode(&image.Installer); err != nil {
 		services.Log.WithField("error", err).Error("Failed to decode installer")
@@ -427,7 +427,7 @@ func CreateRepoForImage(w http.ResponseWriter, r *http.Request) {
 	image := getImage(w, r)
 
 	go func(id uint, ctx context.Context) {
-		services, _ := ctx.Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+		services, _ := dependencies.ServicesFromContext(r.Context())
 		var i *models.Image
 		db.DB.Joins("Commit").Joins("Installer").First(&i, id)
 		db.DB.First(&i.Commit, i.CommitID)
@@ -440,7 +440,7 @@ func CreateRepoForImage(w http.ResponseWriter, r *http.Request) {
 //GetRepoForImage gets the repository for a Image
 func GetRepoForImage(w http.ResponseWriter, r *http.Request) {
 	if image := getImage(w, r); image != nil {
-		services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+		services, _ := dependencies.ServicesFromContext(r.Context())
 		services.Log = services.Log.WithField("repoID", image.Commit.RepoID)
 		repo, err := services.RepoService.GetRepoByID(image.Commit.RepoID)
 		if err != nil {
@@ -455,7 +455,7 @@ func GetRepoForImage(w http.ResponseWriter, r *http.Request) {
 
 //GetMetadataForImage gets the metadata from image-builder on /metadata endpoint
 func GetMetadataForImage(w http.ResponseWriter, r *http.Request) {
-	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	services, _ := dependencies.ServicesFromContext(r.Context())
 	if image := getImage(w, r); image != nil {
 		meta, err := services.ImageService.GetMetadata(image)
 		if err != nil {
@@ -471,7 +471,7 @@ func GetMetadataForImage(w http.ResponseWriter, r *http.Request) {
 // CreateKickStartForImage creates a kickstart file for an existent image
 func CreateKickStartForImage(w http.ResponseWriter, r *http.Request) {
 	if image := getImage(w, r); image != nil {
-		services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+		services, _ := dependencies.ServicesFromContext(r.Context())
 		err := services.ImageService.AddUserInfo(image)
 		if err != nil {
 			// TODO: Temporary. Handle error better.
@@ -491,7 +491,7 @@ type CheckImageNameResponse struct {
 
 // CheckImageName verifies that ImageName exists
 func CheckImageName(w http.ResponseWriter, r *http.Request) {
-	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	services, _ := dependencies.ServicesFromContext(r.Context())
 	services.Log.Debug("Checking image name")
 	var image *models.Image
 	if err := json.NewDecoder(r.Body).Decode(&image); err != nil {
@@ -531,7 +531,7 @@ func CheckImageName(w http.ResponseWriter, r *http.Request) {
 // RetryCreateImage retries the image creation
 func RetryCreateImage(w http.ResponseWriter, r *http.Request) {
 	if image := getImage(w, r); image != nil {
-		services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+		services, _ := dependencies.ServicesFromContext(r.Context())
 		err := services.ImageService.RetryCreateImage(image)
 		if err != nil {
 			services.Log.WithField("error", err.Error()).Error("Failed to retry to create image")

--- a/pkg/routes/images_test.go
+++ b/pkg/routes/images_test.go
@@ -99,7 +99,7 @@ func TestCreate(t *testing.T) {
 	defer ctrl.Finish()
 	mockImageService := mock_services.NewMockImageServiceInterface(ctrl)
 	mockImageService.EXPECT().CreateImage(gomock.Any(), gomock.Any()).Return(nil)
-	ctx = context.WithValue(ctx, dependencies.Key, &dependencies.EdgeAPIServices{
+	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		ImageService: mockImageService,
 		Log:          log.NewEntry(log.StandardLogger()),
 	})
@@ -169,7 +169,7 @@ func TestGetImageDetailsById(t *testing.T) {
 
 	ctx := context.WithValue(req.Context(), imageKey, &testImage)
 
-	ctx = context.WithValue(ctx, dependencies.Key, &dependencies.EdgeAPIServices{
+	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		ImageService: mockImageService,
 		Log:          log.NewEntry(log.StandardLogger()),
 	})
@@ -299,7 +299,7 @@ func TestGetRepoForImage(t *testing.T) {
 	defer ctrl.Finish()
 	mockRepoService := mock_services.NewMockRepoServiceInterface(ctrl)
 	mockRepoService.EXPECT().GetRepoByID(gomock.Any()).Return(&testRepo, nil)
-	ctx = context.WithValue(ctx, dependencies.Key, &dependencies.EdgeAPIServices{
+	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		RepoService: mockRepoService,
 		Log:         log.NewEntry(log.StandardLogger()),
 	})
@@ -343,7 +343,7 @@ func TestGetRepoForImageWhenNotFound(t *testing.T) {
 	defer ctrl.Finish()
 	mockRepoService := mock_services.NewMockRepoServiceInterface(ctrl)
 	mockRepoService.EXPECT().GetRepoByID(gomock.Any()).Return(nil, errors.New("not found"))
-	ctx = context.WithValue(ctx, dependencies.Key, &dependencies.EdgeAPIServices{
+	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		RepoService: mockRepoService,
 		Log:         log.NewEntry(log.StandardLogger()),
 	})
@@ -418,7 +418,7 @@ func TestPostCheckImageNameAlreadyExist(t *testing.T) {
 	defer ctrl.Finish()
 	mockImageService := mock_services.NewMockImageServiceInterface(ctrl)
 	mockImageService.EXPECT().CheckImageName(gomock.Any(), gomock.Any()).Return(true, nil)
-	ctx = context.WithValue(ctx, dependencies.Key, &dependencies.EdgeAPIServices{
+	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		ImageService: mockImageService,
 		Log:          log.NewEntry(log.StandardLogger()),
 	})
@@ -461,7 +461,7 @@ func TestPostCheckImageNameDoesNotExist(t *testing.T) {
 	defer ctrl.Finish()
 	mockImageService := mock_services.NewMockImageServiceInterface(ctrl)
 	mockImageService.EXPECT().CheckImageName(gomock.Any(), gomock.Any()).Return(false, nil)
-	ctx = context.WithValue(ctx, dependencies.Key, &dependencies.EdgeAPIServices{
+	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		ImageService: mockImageService,
 		Log:          log.NewEntry(log.StandardLogger()),
 	})

--- a/pkg/routes/images_test.go
+++ b/pkg/routes/images_test.go
@@ -26,7 +26,7 @@ func TestCreateWasCalledWithWrongBody(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := context.WithValue(req.Context(), dependencies.Key, &dependencies.EdgeAPIServices{
+	ctx := dependencies.ContextWithServices(req.Context(), &dependencies.EdgeAPIServices{
 		Log: log.NewEntry(log.StandardLogger()),
 	})
 	req = req.WithContext(ctx)
@@ -59,7 +59,7 @@ func TestCreateWasCalledWithNameNotSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := context.WithValue(req.Context(), dependencies.Key, &dependencies.EdgeAPIServices{
+	ctx := dependencies.ContextWithServices(req.Context(), &dependencies.EdgeAPIServices{
 		Log: log.NewEntry(log.StandardLogger()),
 	})
 	req = req.WithContext(ctx)

--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -237,7 +237,7 @@ func GetImageSetsByID(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(&err)
 	}
 
-	s, _ := dependencies.ServicesFromContext(r.Context())
+	s := dependencies.ServicesFromContext(r.Context())
 	Imgs := returnImageDetails(images, s)
 
 	details.ImageSetData = *imageSet

--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -237,7 +237,7 @@ func GetImageSetsByID(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(&err)
 	}
 
-	s, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	s, _ := dependencies.ServicesFromContext(r.Context())
 	Imgs := returnImageDetails(images, s)
 
 	details.ImageSetData = *imageSet

--- a/pkg/routes/imagesets_test.go
+++ b/pkg/routes/imagesets_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/redhatinsights/edge-api/pkg/dependencies"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -58,6 +59,8 @@ func TestGetImageSetByID(t *testing.T) {
 
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
+	ctx = dependencies.ContextWithServices(req.Context(), &dependencies.EdgeAPIServices{})
+	req = req.WithContext(ctx)
 	handler := http.HandlerFunc(GetImageSetsByID)
 
 	handler.ServeHTTP(rr, req.WithContext(ctx))

--- a/pkg/routes/inventory.go
+++ b/pkg/routes/inventory.go
@@ -70,7 +70,7 @@ func GetInventory(w http.ResponseWriter, r *http.Request) {
 // GetUpdateAvailableInfo returns the image information
 func GetUpdateAvailableInfo(param *inventory.Params, r *http.Request, inventoryResp inventory.Response) (IvtResponse []InventoryResponse) {
 	var ivt []InventoryResponse
-	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	services, _ := dependencies.ServicesFromContext(r.Context())
 	deviceService := services.DeviceService
 
 	for _, device := range inventoryResp.Result {

--- a/pkg/routes/inventory.go
+++ b/pkg/routes/inventory.go
@@ -70,7 +70,7 @@ func GetInventory(w http.ResponseWriter, r *http.Request) {
 // GetUpdateAvailableInfo returns the image information
 func GetUpdateAvailableInfo(param *inventory.Params, r *http.Request, inventoryResp inventory.Response) (IvtResponse []InventoryResponse) {
 	var ivt []InventoryResponse
-	services, _ := dependencies.ServicesFromContext(r.Context())
+	services := dependencies.ServicesFromContext(r.Context())
 	deviceService := services.DeviceService
 
 	for _, device := range inventoryResp.Result {

--- a/pkg/routes/ownershipvoucher_active.go
+++ b/pkg/routes/ownershipvoucher_active.go
@@ -28,7 +28,7 @@ func MakeFDORouter(sub chi.Router) {
 
 // CreateOwnershipVouchers creates empty devices for the given ownership vouchers
 func CreateOwnershipVouchers(w http.ResponseWriter, r *http.Request) {
-	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	services, _ := dependencies.ServicesFromContext(r.Context())
 	defer r.Body.Close()
 
 	validationErr := validateUploadRequestHeaders(r)
@@ -63,7 +63,7 @@ func CreateOwnershipVouchers(w http.ResponseWriter, r *http.Request) {
 
 // DeleteOwnershipVouchers deletes devices for the given ownership vouchers GUIDs
 func DeleteOwnershipVouchers(w http.ResponseWriter, r *http.Request) {
-	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	services, _ := dependencies.ServicesFromContext(r.Context())
 	defer r.Body.Close()
 
 	validationErr := validateContentTypeJSONHeader(r)
@@ -101,7 +101,7 @@ func DeleteOwnershipVouchers(w http.ResponseWriter, r *http.Request) {
 
 // ParseOwnershipVouchers parses ownership vouchers from the given cbor binary data
 func ParseOwnershipVouchers(w http.ResponseWriter, r *http.Request) {
-	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	services, _ := dependencies.ServicesFromContext(r.Context())
 	defer r.Body.Close()
 
 	if r.Header.Get("Content-Type") != "application/cbor" {
@@ -122,7 +122,7 @@ func ParseOwnershipVouchers(w http.ResponseWriter, r *http.Request) {
 
 // ConnectDevices connects devices to the given ownership vouchers
 func ConnectDevices(w http.ResponseWriter, r *http.Request) {
-	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	services, _ := dependencies.ServicesFromContext(r.Context())
 	defer r.Body.Close()
 
 	validationErr := validateContentTypeJSONHeader(r)
@@ -186,7 +186,7 @@ func validateMiddleware(next http.Handler) http.Handler {
 			badRequestResponseBuilder(w, errors.NewBadRequest("Accept header must be application/json"), "invalid_header")
 			return
 		}
-		_, ok := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+		_, ok := dependencies.ServicesFromContext(r.Context())
 		if !ok {
 			w.WriteHeader(errors.NewInternalServerError().GetStatus())
 			json.NewEncoder(w).Encode(interface{}("Internal server error"))

--- a/pkg/routes/ownershipvoucher_active.go
+++ b/pkg/routes/ownershipvoucher_active.go
@@ -28,7 +28,7 @@ func MakeFDORouter(sub chi.Router) {
 
 // CreateOwnershipVouchers creates empty devices for the given ownership vouchers
 func CreateOwnershipVouchers(w http.ResponseWriter, r *http.Request) {
-	services, _ := dependencies.ServicesFromContext(r.Context())
+	services := dependencies.ServicesFromContext(r.Context())
 	defer r.Body.Close()
 
 	validationErr := validateUploadRequestHeaders(r)
@@ -63,7 +63,7 @@ func CreateOwnershipVouchers(w http.ResponseWriter, r *http.Request) {
 
 // DeleteOwnershipVouchers deletes devices for the given ownership vouchers GUIDs
 func DeleteOwnershipVouchers(w http.ResponseWriter, r *http.Request) {
-	services, _ := dependencies.ServicesFromContext(r.Context())
+	services := dependencies.ServicesFromContext(r.Context())
 	defer r.Body.Close()
 
 	validationErr := validateContentTypeJSONHeader(r)
@@ -101,7 +101,7 @@ func DeleteOwnershipVouchers(w http.ResponseWriter, r *http.Request) {
 
 // ParseOwnershipVouchers parses ownership vouchers from the given cbor binary data
 func ParseOwnershipVouchers(w http.ResponseWriter, r *http.Request) {
-	services, _ := dependencies.ServicesFromContext(r.Context())
+	services := dependencies.ServicesFromContext(r.Context())
 	defer r.Body.Close()
 
 	if r.Header.Get("Content-Type") != "application/cbor" {
@@ -122,7 +122,7 @@ func ParseOwnershipVouchers(w http.ResponseWriter, r *http.Request) {
 
 // ConnectDevices connects devices to the given ownership vouchers
 func ConnectDevices(w http.ResponseWriter, r *http.Request) {
-	services, _ := dependencies.ServicesFromContext(r.Context())
+	services := dependencies.ServicesFromContext(r.Context())
 	defer r.Body.Close()
 
 	validationErr := validateContentTypeJSONHeader(r)
@@ -186,8 +186,8 @@ func validateMiddleware(next http.Handler) http.Handler {
 			badRequestResponseBuilder(w, errors.NewBadRequest("Accept header must be application/json"), "invalid_header")
 			return
 		}
-		_, ok := dependencies.ServicesFromContext(r.Context())
-		if !ok {
+		services := dependencies.ServicesFromContext(r.Context())
+		if services.OwnershipVoucherService == nil {
 			w.WriteHeader(errors.NewInternalServerError().GetStatus())
 			json.NewEncoder(w).Encode(interface{}("Internal server error"))
 			return

--- a/pkg/routes/ownershipvoucher_test.go
+++ b/pkg/routes/ownershipvoucher_test.go
@@ -285,6 +285,13 @@ var _ = Describe("Ownershipvoucher", func() {
 	Context("bad router", func() {
 		It("should fail", func() {
 			badRouter := chi.NewRouter()
+			badRouter.Use(func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					edgeAPIServices := &dependencies.EdgeAPIServices{}
+					ctx := dependencies.ContextWithServices(r.Context(), edgeAPIServices)
+					next.ServeHTTP(w, r.WithContext(ctx))
+				})
+			})
 			routes.MakeFDORouter(badRouter)
 			req, _ := http.NewRequest(http.MethodPost, "/ownership_voucher/delete", bytes.NewBuffer(fdoUUIDListAsBytes))
 			resRec := httptest.NewRecorder()

--- a/pkg/routes/thirdpartyrepo.go
+++ b/pkg/routes/thirdpartyrepo.go
@@ -70,7 +70,7 @@ func getThirdPartyRepo(w http.ResponseWriter, r *http.Request) *models.Image {
 
 // CreateThirdPartyRepo creates Third Party Repository
 func CreateThirdPartyRepo(w http.ResponseWriter, r *http.Request) {
-	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	services := dependencies.ServicesFromContext(r.Context())
 	defer r.Body.Close()
 	thirdPartyRepo, err := createRequest(w, r)
 	if err != nil {
@@ -104,7 +104,7 @@ func CreateThirdPartyRepo(w http.ResponseWriter, r *http.Request) {
 
 // createRequest validates request to create ThirdPartyRepo.
 func createRequest(w http.ResponseWriter, r *http.Request) (*models.ThirdPartyRepo, error) {
-	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	services := dependencies.ServicesFromContext(r.Context())
 
 	var tprepo *models.ThirdPartyRepo
 	if err := json.NewDecoder(r.Body).Decode(&tprepo); err != nil {
@@ -131,7 +131,7 @@ func createRequest(w http.ResponseWriter, r *http.Request) (*models.ThirdPartyRe
 
 // GetAllThirdPartyRepo return all the ThirdPartyRepo
 func GetAllThirdPartyRepo(w http.ResponseWriter, r *http.Request) {
-	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	services := dependencies.ServicesFromContext(r.Context())
 	var tprepo *[]models.ThirdPartyRepo
 	var count int64
 	result := thirdPartyRepoFilters(r, db.DB)
@@ -190,7 +190,7 @@ func GetAllThirdPartyRepo(w http.ResponseWriter, r *http.Request) {
 // ThirdPartyRepoCtx is a handler to Third Party Repository requests
 func ThirdPartyRepoCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		s, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+		s := dependencies.ServicesFromContext(r.Context())
 
 		if ID := chi.URLParam(r, "ID"); ID != "" {
 			_, err := strconv.Atoi(ID)

--- a/pkg/routes/thirdpartyrepo.go
+++ b/pkg/routes/thirdpartyrepo.go
@@ -250,7 +250,7 @@ func GetThirdPartyRepoByID(w http.ResponseWriter, r *http.Request) {
 // UpdateThirdPartyRepo updates the existing third party repository
 func UpdateThirdPartyRepo(w http.ResponseWriter, r *http.Request) {
 	if oldtprepo := getThirdPartyRepo(w, r); oldtprepo != nil {
-		services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+		services := dependencies.ServicesFromContext(r.Context())
 		defer r.Body.Close()
 		tprepo, err := createRequest(w, r)
 		if err != nil {
@@ -278,7 +278,7 @@ func UpdateThirdPartyRepo(w http.ResponseWriter, r *http.Request) {
 // DeleteThirdPartyRepoByID deletes the third party repository using ID
 func DeleteThirdPartyRepoByID(w http.ResponseWriter, r *http.Request) {
 	if tprepo := getThirdPartyRepo(w, r); tprepo != nil {
-		s, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+		s := dependencies.ServicesFromContext(r.Context())
 
 		tprepo, err := s.ThirdPartyRepoService.DeleteThirdPartyRepoByID(fmt.Sprint(tprepo.ID))
 		if err != nil {

--- a/pkg/routes/thirdpartyrepo_test.go
+++ b/pkg/routes/thirdpartyrepo_test.go
@@ -2,7 +2,6 @@ package routes
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -59,7 +58,7 @@ func TestCreateThirdPartyRepo(t *testing.T) {
 	defer ctrl.Finish()
 	mockThirdPartyRepoService := mock_services.NewMockThirdPartyRepoServiceInterface(ctrl)
 	mockThirdPartyRepoService.EXPECT().CreateThirdPartyRepo(gomock.Any(), gomock.Any()).Return(&tprepo, nil)
-	ctx = context.WithValue(ctx, dependencies.Key, &dependencies.EdgeAPIServices{
+	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		ThirdPartyRepoService: mockThirdPartyRepoService,
 		Log:                   log.NewEntry(log.StandardLogger()),
 	})

--- a/pkg/routes/thirdpartyrepo_test.go
+++ b/pkg/routes/thirdpartyrepo_test.go
@@ -26,7 +26,7 @@ func TestCreateWasCalledWithURLNotSet(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx := req.Context()
-	ctx = context.WithValue(ctx, dependencies.Key, &dependencies.EdgeAPIServices{
+	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		Log: log.NewEntry(log.StandardLogger()),
 	})
 	req = req.WithContext(ctx)
@@ -82,6 +82,8 @@ func TestGetAllThirdPartyRepo(t *testing.T) {
 	}
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(GetAllThirdPartyRepo)
+	ctx := dependencies.ContextWithServices(req.Context(), &dependencies.EdgeAPIServices{})
+	req = req.WithContext(ctx)
 	handler.ServeHTTP(rr, req)
 
 	if status := rr.Code; status != http.StatusOK {

--- a/pkg/routes/updates.go
+++ b/pkg/routes/updates.go
@@ -82,7 +82,7 @@ func GetUpdatePlaybook(w http.ResponseWriter, r *http.Request) {
 	if update == nil {
 		return
 	}
-	services, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+	services, _ := dependencies.ServicesFromContext(r.Context())
 	playbook, err := services.UpdateService.GetUpdatePlaybook(update)
 	if err != nil {
 		err := errors.NewInternalServerError()

--- a/pkg/routes/updates.go
+++ b/pkg/routes/updates.go
@@ -82,7 +82,7 @@ func GetUpdatePlaybook(w http.ResponseWriter, r *http.Request) {
 	if update == nil {
 		return
 	}
-	services, _ := dependencies.ServicesFromContext(r.Context())
+	services := dependencies.ServicesFromContext(r.Context())
 	playbook, err := services.UpdateService.GetUpdatePlaybook(update)
 	if err != nil {
 		err := errors.NewInternalServerError()

--- a/pkg/routes/updates_test.go
+++ b/pkg/routes/updates_test.go
@@ -63,7 +63,7 @@ func TestGetUpdatePlaybook(t *testing.T) {
 	reader := ioutil.NopCloser(strings.NewReader(playbookString))
 	mockUpdateService := mock_services.NewMockUpdateServiceInterface(ctrl)
 	mockUpdateService.EXPECT().GetUpdatePlaybook(gomock.Eq(update)).Return(reader, nil)
-	ctx = context.WithValue(ctx, dependencies.Key, &dependencies.EdgeAPIServices{
+	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		UpdateService: mockUpdateService,
 	})
 	req = req.WithContext(ctx)


### PR DESCRIPTION
# Description
Make the context key of edge api services private, this will prevent future bugs. and simplify code reading.

Fixes possible future bugs.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
