### PR TITLE
Fix THEEDGE-1477

### DIFF
--- a/pkg/routes/devices.go
+++ b/pkg/routes/devices.go
@@ -139,6 +139,12 @@ func GetDevice(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(result)
 		return
 	}
+	if _, ok := err.(*services.ImageNotFoundError); ok {
+		err := errors.NewNotFound("Could not find image")
+		w.WriteHeader(err.GetStatus())
+		json.NewEncoder(w).Encode(&err)
+		return
+	}
 	if _, ok := err.(*services.DeviceNotFoundError); ok {
 		err := errors.NewNotFound("Could not find device")
 		w.WriteHeader(err.GetStatus())


### PR DESCRIPTION
# Description

`ImageNotFoundError` wasn't handled which cause 500 status code, while it should be 404.

Fixes THEEDGE-1477

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `go fmt ./...` to check that my code is properly formatted
- [ ] I run `go vet ./...` to check that my code is free of common Go style mistakes
