### PR TITLE
Add logs to the rest of the image routes

### DIFF
--- a/pkg/routes/images_test.go
+++ b/pkg/routes/images_test.go
@@ -55,6 +55,10 @@ func TestCreateWasCalledWithNameNotSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx := context.WithValue(req.Context(), dependencies.Key, &dependencies.EdgeAPIServices{
+		Log: log.NewEntry(log.StandardLogger()),
+	})
+	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(CreateImage)
 

--- a/pkg/routes/images_test.go
+++ b/pkg/routes/images_test.go
@@ -26,6 +26,10 @@ func TestCreateWasCalledWithWrongBody(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx := context.WithValue(req.Context(), dependencies.Key, &dependencies.EdgeAPIServices{
+		Log: log.NewEntry(log.StandardLogger()),
+	})
+	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(CreateImage)
 


### PR DESCRIPTION
# Description

Add logs to the rest of the image routes, making sure they're using the right service to log the request id and also refactors to remove code duplication. Makes sure every method using ImageByIDCtx checks that the image belongs to the user requesting it. 

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
