### PR TITLE
Feat: Add logs to devices routes

### DIFF
--- a/pkg/dependencies/main.go
+++ b/pkg/dependencies/main.go
@@ -36,8 +36,8 @@ func Init(ctx context.Context) *EdgeAPIServices {
 		RepoService:             services.NewRepoService(ctx, log),
 		ImageSetService:         services.NewImageSetsService(ctx),
 		UpdateService:           services.NewUpdateService(ctx),
-		DeviceService:           services.NewDeviceService(ctx),
 		ThirdPartyRepoService:   services.NewThirdPartyRepoService(ctx, log),
+		DeviceService:           services.NewDeviceService(ctx, log),
 		OwnershipVoucherService: services.NewOwnershipVoucherService(ctx, log),
 		Log:                     log,
 	}

--- a/pkg/routes/devices.go
+++ b/pkg/routes/devices.go
@@ -57,7 +57,7 @@ func DeviceCtx(next http.Handler) http.Handler {
 func getDevice(w http.ResponseWriter, r *http.Request) *models.Device {
 	ctx := r.Context()
 	dc, ok := ctx.Value(DeviceContextKey).(*DeviceContext)
-	if dc.DeviceUUID == "" {
+	if dc == nil || dc.DeviceUUID == "" {
 		return nil // Error set by DeviceCtx method
 	}
 	if !ok {

--- a/pkg/routes/devices.go
+++ b/pkg/routes/devices.go
@@ -39,20 +39,17 @@ type DeviceContext struct {
 // DeviceCtx is a handler for Device requests
 func DeviceCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var uCtx DeviceContext
-		uCtx.DeviceUUID = chi.URLParam(r, "DeviceUUID")
-		if uCtx.DeviceUUID == "" {
+		var dc DeviceContext
+		dc.DeviceUUID = chi.URLParam(r, "DeviceUUID")
+		if dc.DeviceUUID == "" {
 			err := errors.NewBadRequest("DeviceUUID must be sent")
 			w.WriteHeader(err.GetStatus())
 			json.NewEncoder(w).Encode(&err)
 			return
 		}
 		// TODO: Implement devices by tag
-		// uCtx.Tag = chi.URLParam(r, "Tag")
-		log.Debugf("UpdateCtx::uCtx: %#v", uCtx)
-		ctx := context.WithValue(r.Context(), DeviceContextKey, uCtx)
-		log.Debugf("UpdateCtx::ctx: %#v", ctx)
-
+		// dc.Tag = chi.URLParam(r, "Tag")
+		ctx := context.WithValue(r.Context(), DeviceContextKey, dc)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/pkg/routes/devices.go
+++ b/pkg/routes/devices.go
@@ -8,14 +8,14 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/redhatinsights/edge-api/pkg/dependencies"
 	"github.com/redhatinsights/edge-api/pkg/errors"
+	"github.com/redhatinsights/edge-api/pkg/models"
 	"github.com/redhatinsights/edge-api/pkg/services"
-	"github.com/redhatinsights/platform-go-middlewares/request_id"
 	log "github.com/sirupsen/logrus"
 )
 
 // MakeDevicesRouter adds support for operations on update
 func MakeDevicesRouter(sub chi.Router) {
-	sub.Get("/", GetInventory)
+	sub.Get("/", GetInventory) // TODO: Still a proof-of-concept and needs to be refactored in the future
 	sub.Route("/{DeviceUUID}", func(r chi.Router) {
 		r.Use(DeviceCtx)
 		r.Get("/", GetDevice)
@@ -57,70 +57,84 @@ func DeviceCtx(next http.Handler) http.Handler {
 	})
 }
 
-// GetUpdateAvailableForDevice returns if exists update for the current image at the device.
-func GetUpdateAvailableForDevice(w http.ResponseWriter, r *http.Request) {
-	dc := r.Context().Value(DeviceContextKey).(DeviceContext)
+func getDevice(w http.ResponseWriter, r *http.Request) *models.Device {
+	ctx := r.Context()
+	dc, ok := ctx.Value(DeviceContextKey).(*DeviceContext)
 	if dc.DeviceUUID == "" {
-		return // Error set by DeviceCtx method
+		return nil // Error set by DeviceCtx method
 	}
-	contextServices := dependencies.ServicesFromContext(r.Context())
-	result, err := contextServices.DeviceService.GetUpdateAvailableForDeviceByUUID(dc.DeviceUUID)
-	if err == nil {
-		json.NewEncoder(w).Encode(result)
-		return
+	if !ok {
+		err := errors.NewBadRequest("Must pass device identifier")
+		w.WriteHeader(err.GetStatus())
+		json.NewEncoder(w).Encode(&err)
+		return nil
 	}
+	s := dependencies.ServicesFromContext(r.Context())
+	s.Log = s.Log.WithField("UUID", dc.DeviceUUID)
+	device, err := s.DeviceService.GetDeviceByUUID(dc.DeviceUUID)
 	if _, ok := err.(*services.DeviceNotFoundError); ok {
 		err := errors.NewNotFound("Could not find device")
 		w.WriteHeader(err.GetStatus())
 		json.NewEncoder(w).Encode(&err)
-		return
+		return nil
 	}
-	if _, ok := err.(*services.UpdateNotFoundError); ok {
-		err := errors.NewNotFound("Could not find update")
-		w.WriteHeader(err.GetStatus())
+	return device
+}
+
+// GetUpdateAvailableForDevice returns if exists update for the current image at the device.
+func GetUpdateAvailableForDevice(w http.ResponseWriter, r *http.Request) {
+	if device := getDevice(w, r); device != nil {
+		s, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+		result, err := s.DeviceService.GetUpdateAvailableForDeviceByUUID(device.UUID)
+		if err == nil {
+			json.NewEncoder(w).Encode(result)
+			return
+		}
+		if _, ok := err.(*services.DeviceNotFoundError); ok {
+			err := errors.NewNotFound("Could not find device")
+			w.WriteHeader(err.GetStatus())
+			json.NewEncoder(w).Encode(&err)
+			return
+		}
+		if _, ok := err.(*services.UpdateNotFoundError); ok {
+			err := errors.NewNotFound("Could not find update")
+			w.WriteHeader(err.GetStatus())
+			json.NewEncoder(w).Encode(&err)
+			return
+		}
+		apierr := errors.NewInternalServerError()
+		w.WriteHeader(apierr.GetStatus())
+		s.Log.WithFields(log.Fields{
+			"statusCode": apierr.GetStatus(),
+			"error":      apierr.Error(),
+		}).Error("Error retrieving updates for device")
 		json.NewEncoder(w).Encode(&err)
-		return
 	}
-	log.WithFields(log.Fields{
-		"requestId": request_id.GetReqID(r.Context()),
-	}).Error(err)
-	apierr := errors.NewInternalServerError()
-	w.WriteHeader(apierr.GetStatus())
-	log.WithFields(log.Fields{
-		"requestId":  request_id.GetReqID(r.Context()),
-		"statusCode": apierr.GetStatus(),
-	}).Error(apierr)
-	json.NewEncoder(w).Encode(&err)
 }
 
 // GetDeviceImageInfo returns the information of a running image for a device
 func GetDeviceImageInfo(w http.ResponseWriter, r *http.Request) {
-	dc := r.Context().Value(DeviceContextKey).(DeviceContext)
-	if dc.DeviceUUID == "" {
-		return // Error set by DeviceCtx method
-	}
-	contextServices := dependencies.ServicesFromContext(r.Context())
-	result, err := contextServices.DeviceService.GetDeviceImageInfo(dc.DeviceUUID)
-	if err == nil {
-		json.NewEncoder(w).Encode(result)
-		return
-	}
-	if _, ok := err.(*services.DeviceNotFoundError); ok {
-		err := errors.NewNotFound("Could not find device")
-		w.WriteHeader(err.GetStatus())
+	if device := getDevice(w, r); device != nil {
+		s := dependencies.ServicesFromContext(r.Context())
+		result, err := s.DeviceService.GetDeviceImageInfo(device.UUID)
+		if err == nil {
+			json.NewEncoder(w).Encode(result)
+			return
+		}
+		if _, ok := err.(*services.DeviceNotFoundError); ok {
+			err := errors.NewNotFound("Could not find device")
+			w.WriteHeader(err.GetStatus())
+			json.NewEncoder(w).Encode(&err)
+			return
+		}
+		apierr := errors.NewInternalServerError()
+		w.WriteHeader(apierr.GetStatus())
+		s.Log.WithFields(log.Fields{
+			"statusCode": apierr.GetStatus(),
+			"error":      apierr.Error(),
+		}).Error("Error getting image info for device")
 		json.NewEncoder(w).Encode(&err)
-		return
 	}
-	log.WithFields(log.Fields{
-		"requestId": request_id.GetReqID(r.Context()),
-	}).Error(err)
-	apierr := errors.NewInternalServerError()
-	w.WriteHeader(apierr.GetStatus())
-	log.WithFields(log.Fields{
-		"requestId":  request_id.GetReqID(r.Context()),
-		"statusCode": apierr.GetStatus(),
-	}).Error(apierr)
-	json.NewEncoder(w).Encode(&err)
 }
 
 // GetDevice returns all available information that edge api has about a device
@@ -129,36 +143,31 @@ func GetDeviceImageInfo(w http.ResponseWriter, r *http.Request) {
 // Returns updates available to a device.
 // Returns updates transactions for that device, if any.
 func GetDevice(w http.ResponseWriter, r *http.Request) {
-	dc := r.Context().Value(DeviceContextKey).(DeviceContext)
-	if dc.DeviceUUID == "" {
-		return // Error set by DeviceCtx method
-	}
-	contextServices := dependencies.ServicesFromContext(r.Context())
-	result, err := contextServices.DeviceService.GetDeviceDetails(dc.DeviceUUID)
-	if err == nil {
-		json.NewEncoder(w).Encode(result)
-		return
-	}
-	if _, ok := err.(*services.ImageNotFoundError); ok {
-		err := errors.NewNotFound("Could not find image")
-		w.WriteHeader(err.GetStatus())
+	if device := getDevice(w, r); device != nil {
+		s := dependencies.ServicesFromContext(r.Context())
+		result, err := s.DeviceService.GetDeviceDetails(device.UUID)
+		if err == nil {
+			json.NewEncoder(w).Encode(result)
+			return
+		}
+		if _, ok := err.(*services.ImageNotFoundError); ok {
+			err := errors.NewNotFound("Could not find image")
+			w.WriteHeader(err.GetStatus())
+			json.NewEncoder(w).Encode(&err)
+			return
+		}
+		if _, ok := err.(*services.DeviceNotFoundError); ok {
+			err := errors.NewNotFound("Could not find device")
+			w.WriteHeader(err.GetStatus())
+			json.NewEncoder(w).Encode(&err)
+			return
+		}
+		apierr := errors.NewInternalServerError()
+		w.WriteHeader(apierr.GetStatus())
+		s.Log.WithFields(log.Fields{
+			"statusCode": apierr.GetStatus(),
+			"error":      apierr.Error(),
+		}).Error("Error retrieving updates for device")
 		json.NewEncoder(w).Encode(&err)
-		return
 	}
-	if _, ok := err.(*services.DeviceNotFoundError); ok {
-		err := errors.NewNotFound("Could not find device")
-		w.WriteHeader(err.GetStatus())
-		json.NewEncoder(w).Encode(&err)
-		return
-	}
-	log.WithFields(log.Fields{
-		"requestId": request_id.GetReqID(r.Context()),
-	}).Error(err)
-	apierr := errors.NewInternalServerError()
-	w.WriteHeader(apierr.GetStatus())
-	log.WithFields(log.Fields{
-		"requestId":  request_id.GetReqID(r.Context()),
-		"statusCode": apierr.GetStatus(),
-	}).Error(apierr)
-	json.NewEncoder(w).Encode(&err)
 }

--- a/pkg/routes/devices.go
+++ b/pkg/routes/devices.go
@@ -56,8 +56,8 @@ func DeviceCtx(next http.Handler) http.Handler {
 
 func getDevice(w http.ResponseWriter, r *http.Request) *models.Device {
 	ctx := r.Context()
-	dc, ok := ctx.Value(DeviceContextKey).(*DeviceContext)
-	if dc == nil || dc.DeviceUUID == "" {
+	dc, ok := ctx.Value(DeviceContextKey).(DeviceContext)
+	if dc.DeviceUUID == "" {
 		return nil // Error set by DeviceCtx method
 	}
 	if !ok {

--- a/pkg/routes/devices.go
+++ b/pkg/routes/devices.go
@@ -81,7 +81,7 @@ func getDevice(w http.ResponseWriter, r *http.Request) *models.Device {
 // GetUpdateAvailableForDevice returns if exists update for the current image at the device.
 func GetUpdateAvailableForDevice(w http.ResponseWriter, r *http.Request) {
 	if device := getDevice(w, r); device != nil {
-		s, _ := r.Context().Value(dependencies.Key).(*dependencies.EdgeAPIServices)
+		s := dependencies.ServicesFromContext(r.Context())
 		result, err := s.DeviceService.GetUpdateAvailableForDeviceByUUID(device.UUID)
 		if err == nil {
 			json.NewEncoder(w).Encode(result)

--- a/pkg/routes/devices_test.go
+++ b/pkg/routes/devices_test.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/redhatinsights/edge-api/pkg/dependencies"
+	"github.com/redhatinsights/edge-api/pkg/models"
 	"github.com/redhatinsights/edge-api/pkg/services"
 	"github.com/redhatinsights/edge-api/pkg/services/mock_services"
 )
@@ -57,12 +58,13 @@ func TestGetAvailableUpdateForDeviceWhenDeviceIsNotFound(t *testing.T) {
 	dc := DeviceContext{
 		DeviceUUID: faker.UUIDHyphenated(),
 	}
-	ctx := context.WithValue(req.Context(), DeviceContextKey, dc)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockDeviceService := mock_services.NewMockDeviceServiceInterface(ctrl)
+	mockDeviceService.EXPECT().GetDeviceByUUID(gomock.Eq(dc.DeviceUUID)).Return(&models.Device{UUID: dc.DeviceUUID}, nil)
 	mockDeviceService.EXPECT().GetUpdateAvailableForDeviceByUUID(gomock.Eq(dc.DeviceUUID)).Return(nil, new(services.DeviceNotFoundError))
+	ctx := context.WithValue(req.Context(), DeviceContextKey, dc)
 	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		DeviceService: mockDeviceService,
 		Log:           log.NewEntry(log.StandardLogger()),
@@ -95,6 +97,7 @@ func TestGetAvailableUpdateForDeviceWhenAUnexpectedErrorHappens(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDeviceService := mock_services.NewMockDeviceServiceInterface(ctrl)
+	mockDeviceService.EXPECT().GetDeviceByUUID(gomock.Eq(dc.DeviceUUID)).Return(&models.Device{UUID: dc.DeviceUUID}, nil)
 	mockDeviceService.EXPECT().GetUpdateAvailableForDeviceByUUID(gomock.Eq(dc.DeviceUUID)).Return(nil, errors.New("random error"))
 	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		DeviceService: mockDeviceService,

--- a/pkg/routes/devices_test.go
+++ b/pkg/routes/devices_test.go
@@ -9,6 +9,7 @@ import (
 
 	faker "github.com/bxcodec/faker/v3"
 	"github.com/golang/mock/gomock"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/redhatinsights/edge-api/pkg/dependencies"
 	"github.com/redhatinsights/edge-api/pkg/services"
@@ -31,6 +32,7 @@ func TestGetAvailableUpdateForDeviceWithEmptyUUID(t *testing.T) {
 	mockDeviceService := mock_services.NewMockDeviceServiceInterface(ctrl)
 	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		DeviceService: mockDeviceService,
+		Log:           log.NewEntry(log.StandardLogger()),
 	})
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -63,6 +65,7 @@ func TestGetAvailableUpdateForDeviceWhenDeviceIsNotFound(t *testing.T) {
 	mockDeviceService.EXPECT().GetUpdateAvailableForDeviceByUUID(gomock.Eq(dc.DeviceUUID)).Return(nil, new(services.DeviceNotFoundError))
 	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		DeviceService: mockDeviceService,
+		Log:           log.NewEntry(log.StandardLogger()),
 	})
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -95,6 +98,7 @@ func TestGetAvailableUpdateForDeviceWhenAUnexpectedErrorHappens(t *testing.T) {
 	mockDeviceService.EXPECT().GetUpdateAvailableForDeviceByUUID(gomock.Eq(dc.DeviceUUID)).Return(nil, errors.New("random error"))
 	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		DeviceService: mockDeviceService,
+		Log:           log.NewEntry(log.StandardLogger()),
 	})
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()

--- a/pkg/routes/updates.go
+++ b/pkg/routes/updates.go
@@ -218,7 +218,7 @@ func updateFromHTTP(w http.ResponseWriter, r *http.Request) (*models.UpdateTrans
 	for _, device := range inventory.Result {
 		//  Check for the existence of a Repo that already has this commit and don't duplicate
 		var updateDevice *models.Device
-		deviceService := services.NewDeviceService(r.Context())
+		deviceService := services.NewDeviceService(r.Context(), log.NewEntry(log.StandardLogger()))
 		updateDevice, err = deviceService.GetDeviceByUUID(device.ID)
 		if err != nil {
 			if !(err.Error() == "record not found") {

--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -238,7 +238,7 @@ func (s *DeviceService) GetDeviceImageInfo(deviceUUID string) (*ImageInfo, error
 	result := db.DB.Model(&models.Image{}).Joins("Commit").Where("OS_Tree_Commit = ?", lastDeployment.Checksum).First(&currentImage)
 
 	if result.Error != nil || result == nil {
-		s.log.WithField("error", err.Error()).Error("Could not find device image info")
+		s.log.WithField("error", result.Error.Error()).Error("Could not find device image info")
 		return nil, new(ImageNotFoundError)
 	}
 	if currentImage.ImageSetID != nil {

--- a/pkg/services/devices_test.go
+++ b/pkg/services/devices_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/redhatinsights/edge-api/pkg/clients/inventory/mock_inventory"
 	"github.com/redhatinsights/edge-api/pkg/db"
 	"github.com/redhatinsights/edge-api/pkg/models"
+	log "github.com/sirupsen/logrus"
 )
 
 func TestGetUpdateAvailableForDeviceByUUIDWhenErrorOnInventoryAPI(t *testing.T) {
@@ -24,7 +25,10 @@ func TestGetUpdateAvailableForDeviceByUUIDWhenErrorOnInventoryAPI(t *testing.T) 
 	mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(inventory.Response{}, errors.New("error on inventory api"))
 
 	deviceService := DeviceService{
-		ctx:       context.Background(),
+		Service: Service{
+			ctx: context.Background(),
+			log: log.NewEntry(log.StandardLogger()),
+		},
 		inventory: mockInventoryClient,
 	}
 
@@ -48,7 +52,10 @@ func TestGetUpdateAvailableForDeviceByUUIDWhenDeviceIsNotFoundOnInventoryAPI(t *
 	mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
 
 	deviceService := DeviceService{
-		ctx:       context.Background(),
+		Service: Service{
+			ctx: context.Background(),
+			log: log.NewEntry(log.StandardLogger()),
+		},
 		inventory: mockInventoryClient,
 	}
 
@@ -80,7 +87,10 @@ func TestGetUpdateAvailableForDeviceByUUID(t *testing.T) {
 	mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
 
 	deviceService := DeviceService{
-		ctx:       context.Background(),
+		Service: Service{
+			ctx: context.Background(),
+			log: log.NewEntry(log.StandardLogger()),
+		},
 		inventory: mockInventoryClient,
 	}
 
@@ -177,7 +187,10 @@ func TestGetUpdateAvailableForDeviceByUUIDWhenNoUpdateIsAvailable(t *testing.T) 
 	mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
 
 	deviceService := DeviceService{
-		ctx:       context.Background(),
+		Service: Service{
+			ctx: context.Background(),
+			log: log.NewEntry(log.StandardLogger()),
+		},
 		inventory: mockInventoryClient,
 	}
 
@@ -218,7 +231,10 @@ func TestGetUpdateAvailableForDeviceByUUIDWhenNoChecksumIsFound(t *testing.T) {
 	mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
 
 	deviceService := DeviceService{
-		ctx:       context.Background(),
+		Service: Service{
+			ctx: context.Background(),
+			log: log.NewEntry(log.StandardLogger()),
+		},
 		inventory: mockInventoryClient,
 	}
 	updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid)
@@ -305,7 +321,10 @@ func TestGetImageForDeviceByUUID(t *testing.T) {
 	mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil).Times(2)
 
 	deviceService := DeviceService{
-		ctx:       context.Background(),
+		Service: Service{
+			ctx: context.Background(),
+			log: log.NewEntry(log.StandardLogger()),
+		},
 		inventory: mockInventoryClient,
 	}
 	imageSet := &models.ImageSet{
@@ -365,7 +384,10 @@ func TestGetNoImageForDeviceByUUID(t *testing.T) {
 	mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
 
 	deviceService := DeviceService{
-		ctx:       context.Background(),
+		Service: Service{
+			ctx: context.Background(),
+			log: log.NewEntry(log.StandardLogger()),
+		},
 		inventory: mockInventoryClient,
 	}
 


### PR DESCRIPTION
# Description

Adds logs to devices routes and their respective service, to put them in the same pattern as the API and make it easier to find logs.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
