### PR TITLE
Use a method to get image by ostree hash and rollback image

### DIFF
--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -22,8 +22,9 @@ type DeviceServiceInterface interface {
 // NewDeviceService gives a instance of the main implementation of DeviceServiceInterface
 func NewDeviceService(ctx context.Context, log *log.Entry) DeviceServiceInterface {
 	return &DeviceService{
-		updateService: NewUpdateService(ctx, log),
-		inventory:     inventory.InitClient(ctx, log),
+		UpdateService: NewUpdateService(ctx, log),
+		ImageService:  NewImageService(ctx, log),
+		Inventory:     inventory.InitClient(ctx, log),
 		Service:       Service{ctx: ctx, log: log.WithField("service", "image")},
 	}
 }
@@ -31,8 +32,9 @@ func NewDeviceService(ctx context.Context, log *log.Entry) DeviceServiceInterfac
 // DeviceService is the main implementation of a DeviceServiceInterface
 type DeviceService struct {
 	Service
-	updateService UpdateServiceInterface
-	inventory     inventory.ClientInterface
+	UpdateService UpdateServiceInterface
+	ImageService  ImageServiceInterface
+	Inventory     inventory.ClientInterface
 }
 
 // GetDeviceByID receives DeviceID uint and get a *models.Device back
@@ -78,7 +80,7 @@ func (s *DeviceService) GetDeviceDetails(deviceUUID string) (*models.DeviceDetai
 	// In order to have an update transaction for a device it must be a least created
 	var updates *[]models.UpdateTransaction
 	if device != nil {
-		updates, err = s.updateService.GetUpdateTransactionsForDevice(device)
+		updates, err = s.UpdateService.GetUpdateTransactionsForDevice(device)
 		if err != nil {
 			s.log.WithField("error", err.Error()).Error("Could not find information about updates for this device")
 			return nil, err
@@ -97,7 +99,7 @@ func (s *DeviceService) GetUpdateAvailableForDeviceByUUID(deviceUUID string) ([]
 	s.log = s.log.WithField("deviceUUID", deviceUUID)
 	var lastDeployment inventory.OSTree
 	var imageDiff []models.ImageUpdateAvailable
-	device, err := s.inventory.ReturnDevicesByID(deviceUUID)
+	device, err := s.Inventory.ReturnDevicesByID(deviceUUID)
 	if err != nil || device.Total != 1 {
 		return nil, new(DeviceNotFoundError)
 	}
@@ -137,7 +139,7 @@ func (s *DeviceService) GetUpdateAvailableForDeviceByUUID(deviceUUID string) ([]
 		db.DB.Model(&upd.Commit).Association("InstalledPackages").Find(&upd.Commit.InstalledPackages)
 		db.DB.Model(&upd).Association("Packages").Find(&upd.Packages)
 		var delta models.ImageUpdateAvailable
-		diff := getDiffOnUpdate(currentImage, upd)
+		diff := GetDiffOnUpdate(currentImage, upd)
 		upd.Commit.InstalledPackages = nil // otherwise the frontend will get the whole list of installed packages
 		delta.Image = upd
 		delta.PackageDiff = diff
@@ -178,7 +180,7 @@ func getVersionDiff(new, old []models.InstalledPackage) []models.InstalledPackag
 	return diff
 }
 
-func getDiffOnUpdate(oldImg models.Image, newImg models.Image) models.PackageDiff {
+func GetDiffOnUpdate(oldImg models.Image, newImg models.Image) models.PackageDiff {
 	results := models.PackageDiff{
 		Added:    getPackageDiff(newImg.Commit.InstalledPackages, oldImg.Commit.InstalledPackages),
 		Removed:  getPackageDiff(oldImg.Commit.InstalledPackages, newImg.Commit.InstalledPackages),
@@ -191,10 +193,10 @@ func getDiffOnUpdate(oldImg models.Image, newImg models.Image) models.PackageDif
 func (s *DeviceService) GetDeviceImageInfo(deviceUUID string) (*models.ImageInfo, error) {
 	s.log = s.log.WithField("deviceUUID", deviceUUID)
 	var ImageInfo models.ImageInfo
-	var currentImage models.Image
+	var currentImage *models.Image
 	var rollback *models.Image
 	var lastDeployment inventory.OSTree
-	device, err := s.inventory.ReturnDevicesByID(deviceUUID)
+	device, err := s.Inventory.ReturnDevicesByID(deviceUUID)
 	if err != nil || device.Total != 1 {
 		return nil, new(DeviceNotFoundError)
 	}
@@ -208,15 +210,19 @@ func (s *DeviceService) GetDeviceImageInfo(deviceUUID string) (*models.ImageInfo
 		}
 	}
 
-	result := db.DB.Model(&models.Image{}).Joins("Commit").Where("OS_Tree_Commit = ?", lastDeployment.Checksum).First(&currentImage)
-
-	if result.Error != nil || result == nil {
-		s.log.WithField("error", result.Error.Error()).Error("Could not find device image info")
+	currentImage, err = s.ImageService.GetImageByOSTreeCommitHash(lastDeployment.Checksum)
+	if err != nil {
+		s.log.WithField("error", err.Error()).Error("Could not find device image info")
 		return nil, new(ImageNotFoundError)
 	}
-	if currentImage.ImageSetID != nil {
-		db.DB.Where("Image_Set_Id = ? and id < ?", currentImage.ImageSetID, currentImage.ID).Last(&rollback)
+	if currentImage.Version > 1 {
+		rollback, err = s.ImageService.GetRollbackImage(currentImage)
+		if err != nil {
+			s.log.WithField("error", err.Error()).Error("Could not find rollback image info")
+			return nil, new(ImageNotFoundError)
+		}
 	}
+
 	updateAvailable, err := s.GetUpdateAvailableForDeviceByUUID(deviceUUID)
 	if err != nil {
 		s.log.WithField("error", err.Error()).Error("Could not find updates available to get image info")
@@ -225,7 +231,7 @@ func (s *DeviceService) GetDeviceImageInfo(deviceUUID string) (*models.ImageInfo
 		ImageInfo.UpdatesAvailable = &updateAvailable
 	}
 	ImageInfo.Rollback = rollback
-	ImageInfo.Image = currentImage
+	ImageInfo.Image = *currentImage
 
 	return &ImageInfo, nil
 }

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -50,6 +50,7 @@ type ImageServiceInterface interface {
 	SetFinalImageStatus(i *models.Image)
 	CheckIfIsLatestVersion(previousImage *models.Image) error
 	SetBuildingStatusOnImageToRetryBuild(image *models.Image) error
+	GetRollbackImage(image *models.Image) (*models.Image, error)
 }
 
 // NewImageService gives a instance of the main implementation of a ImageServiceInterface
@@ -328,7 +329,7 @@ func (s *ImageService) postProcessImage(id uint) {
 		WaitGroup.Done() // Done with one image (successfully or not)
 		s.log.Debug("Done with one image - successfully or not")
 		if err := recover(); err != nil {
-			s.log.Fatalf("Error recovering post process image goroutine")
+			s.log.WithField("error", err).Fatalf("Error recovering post process image goroutine")
 		}
 	}()
 	go func(i *models.Image) {
@@ -754,21 +755,21 @@ func (s *ImageService) GetImageByID(imageID string) (*models.Image, error) {
 
 // GetImageByOSTreeCommitHash retrieves an image by its ostree commit hash
 func (s *ImageService) GetImageByOSTreeCommitHash(commitHash string) (*models.Image, error) {
-	s.log.Info("Getting image by OSTreeHash")
+	s.log.WithField("ostreeHash", commitHash).Info("Getting image by OSTreeHash")
 	var image models.Image
 	account, err := common.GetAccountFromContext(s.ctx)
 	if err != nil {
 		s.log.Error("Error retreving account")
 		return nil, new(AccountNotSet)
 	}
-	result := db.DB.Where("images.account = ? and os_tree_commit = ?", account, commitHash).Joins("Commit").First(&image)
+	result := db.DB.Where("images.account = ?", account).Joins("JOIN commits ON commits.id = images.commit_id AND commits.os_tree_commit = ?", commitHash).Joins("Installer").Preload("Packages").Preload("Commit.InstalledPackages").Preload("Commit.Repo").First(&image)
 	if result.Error != nil {
 		s.log.WithField("error", result.Error).Error("Error retrieving image by OSTreeHash")
 		return nil, new(ImageNotFoundError)
 	}
 	s.log = s.log.WithField("imageID", image.ID)
 	s.log.Info("Image successfully retrieved by its OSTreeHash")
-	return s.addImageExtraData(&image)
+	return &image, nil
 }
 
 // RetryCreateImage retries the whole post process of the image creation
@@ -872,7 +873,7 @@ func (s *ImageService) GetUpdateInfo(image models.Image) ([]models.ImageUpdateAv
 		db.DB.Model(&upd.Commit).Association("InstalledPackages").Find(&upd.Commit.InstalledPackages)
 		db.DB.Model(&upd).Association("Packages").Find(&upd.Packages)
 		var delta models.ImageUpdateAvailable
-		diff := getDiffOnUpdate(image, upd)
+		diff := GetDiffOnUpdate(image, upd)
 		upd.Commit.InstalledPackages = nil // otherwise the frontend will get the whole list of installed packages
 		delta.Image = upd
 		delta.PackageDiff = diff
@@ -919,4 +920,23 @@ func (s *ImageService) CreateInstallerForImage(image *models.Image) (*models.Ima
 		c <- err
 	}(c)
 	return image, c, nil
+}
+
+// GetRollbackImage returns the previous image from the image set in case of a rollback
+func (s *ImageService) GetRollbackImage(image *models.Image) (*models.Image, error) {
+	s.log.Info("Getting image by OSTreeHash")
+	var rollback models.Image
+	account, err := common.GetAccountFromContext(s.ctx)
+	if err != nil {
+		s.log.Error("Error retreving account")
+		return nil, new(AccountNotSet)
+	}
+	result := db.DB.Joins("Commit").Joins("Installer").Preload("Packages").Preload("Commit.InstalledPackages").Preload("Commit.Repo").Where("images.account = ? and image_set_id = ? and id < ?", account, image.ImageSetID, image.ID).Last(&rollback)
+	if result.Error != nil {
+		s.log.WithField("error", result.Error).Error("Error retrieving image by OSTreeHash")
+		return nil, new(ImageNotFoundError)
+	}
+	s.log = s.log.WithField("imageID", image.ID)
+	s.log.Info("Image successfully retrieved by its OSTreeHash")
+	return &rollback, nil
 }

--- a/pkg/services/mock_services/images.go
+++ b/pkg/services/mock_services/images.go
@@ -5,95 +5,36 @@
 package mock_services
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/redhatinsights/edge-api/pkg/models"
 	services "github.com/redhatinsights/edge-api/pkg/services"
+	reflect "reflect"
 )
 
-// MockImageServiceInterface is a mock of ImageServiceInterface interface.
+// MockImageServiceInterface is a mock of ImageServiceInterface interface
 type MockImageServiceInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockImageServiceInterfaceMockRecorder
 }
 
-// MockImageServiceInterfaceMockRecorder is the mock recorder for MockImageServiceInterface.
+// MockImageServiceInterfaceMockRecorder is the mock recorder for MockImageServiceInterface
 type MockImageServiceInterfaceMockRecorder struct {
 	mock *MockImageServiceInterface
 }
 
-// NewMockImageServiceInterface creates a new mock instance.
+// NewMockImageServiceInterface creates a new mock instance
 func NewMockImageServiceInterface(ctrl *gomock.Controller) *MockImageServiceInterface {
 	mock := &MockImageServiceInterface{ctrl: ctrl}
 	mock.recorder = &MockImageServiceInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockImageServiceInterface) EXPECT() *MockImageServiceInterfaceMockRecorder {
 	return m.recorder
 }
 
-// AddPackageInfo mocks base method.
-func (m *MockImageServiceInterface) AddPackageInfo(image *models.Image) (services.ImageDetail, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddPackageInfo", image)
-	ret0, _ := ret[0].(services.ImageDetail)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AddPackageInfo indicates an expected call of AddPackageInfo.
-func (mr *MockImageServiceInterfaceMockRecorder) AddPackageInfo(image interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPackageInfo", reflect.TypeOf((*MockImageServiceInterface)(nil).AddPackageInfo), image)
-}
-
-// AddUserInfo mocks base method.
-func (m *MockImageServiceInterface) AddUserInfo(image *models.Image) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddUserInfo", image)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AddUserInfo indicates an expected call of AddUserInfo.
-func (mr *MockImageServiceInterfaceMockRecorder) AddUserInfo(image interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUserInfo", reflect.TypeOf((*MockImageServiceInterface)(nil).AddUserInfo), image)
-}
-
-// CheckIfIsLatestVersion mocks base method.
-func (m *MockImageServiceInterface) CheckIfIsLatestVersion(previousImage *models.Image) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckIfIsLatestVersion", previousImage)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CheckIfIsLatestVersion indicates an expected call of CheckIfIsLatestVersion.
-func (mr *MockImageServiceInterfaceMockRecorder) CheckIfIsLatestVersion(previousImage interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckIfIsLatestVersion", reflect.TypeOf((*MockImageServiceInterface)(nil).CheckIfIsLatestVersion), previousImage)
-}
-
-// CheckImageName mocks base method.
-func (m *MockImageServiceInterface) CheckImageName(name, account string) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckImageName", name, account)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CheckImageName indicates an expected call of CheckImageName.
-func (mr *MockImageServiceInterfaceMockRecorder) CheckImageName(name, account interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckImageName", reflect.TypeOf((*MockImageServiceInterface)(nil).CheckImageName), name, account)
-}
-
-// CreateImage mocks base method.
+// CreateImage mocks base method
 func (m *MockImageServiceInterface) CreateImage(image *models.Image, account string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateImage", image, account)
@@ -101,13 +42,83 @@ func (m *MockImageServiceInterface) CreateImage(image *models.Image, account str
 	return ret0
 }
 
-// CreateImage indicates an expected call of CreateImage.
+// CreateImage indicates an expected call of CreateImage
 func (mr *MockImageServiceInterfaceMockRecorder) CreateImage(image, account interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateImage", reflect.TypeOf((*MockImageServiceInterface)(nil).CreateImage), image, account)
 }
 
-// CreateInstallerForImage mocks base method.
+// UpdateImage mocks base method
+func (m *MockImageServiceInterface) UpdateImage(image, previousImage *models.Image) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateImage", image, previousImage)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateImage indicates an expected call of UpdateImage
+func (mr *MockImageServiceInterfaceMockRecorder) UpdateImage(image, previousImage interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateImage", reflect.TypeOf((*MockImageServiceInterface)(nil).UpdateImage), image, previousImage)
+}
+
+// AddUserInfo mocks base method
+func (m *MockImageServiceInterface) AddUserInfo(image *models.Image) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddUserInfo", image)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddUserInfo indicates an expected call of AddUserInfo
+func (mr *MockImageServiceInterfaceMockRecorder) AddUserInfo(image interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUserInfo", reflect.TypeOf((*MockImageServiceInterface)(nil).AddUserInfo), image)
+}
+
+// UpdateImageStatus mocks base method
+func (m *MockImageServiceInterface) UpdateImageStatus(image *models.Image) (*models.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateImageStatus", image)
+	ret0, _ := ret[0].(*models.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateImageStatus indicates an expected call of UpdateImageStatus
+func (mr *MockImageServiceInterfaceMockRecorder) UpdateImageStatus(image interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateImageStatus", reflect.TypeOf((*MockImageServiceInterface)(nil).UpdateImageStatus), image)
+}
+
+// SetErrorStatusOnImage mocks base method
+func (m *MockImageServiceInterface) SetErrorStatusOnImage(err error, i *models.Image) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetErrorStatusOnImage", err, i)
+}
+
+// SetErrorStatusOnImage indicates an expected call of SetErrorStatusOnImage
+func (mr *MockImageServiceInterfaceMockRecorder) SetErrorStatusOnImage(err, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetErrorStatusOnImage", reflect.TypeOf((*MockImageServiceInterface)(nil).SetErrorStatusOnImage), err, i)
+}
+
+// CreateRepoForImage mocks base method
+func (m *MockImageServiceInterface) CreateRepoForImage(i *models.Image) (*models.Repo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRepoForImage", i)
+	ret0, _ := ret[0].(*models.Repo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateRepoForImage indicates an expected call of CreateRepoForImage
+func (mr *MockImageServiceInterfaceMockRecorder) CreateRepoForImage(i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRepoForImage", reflect.TypeOf((*MockImageServiceInterface)(nil).CreateRepoForImage), i)
+}
+
+// CreateInstallerForImage mocks base method
 func (m *MockImageServiceInterface) CreateInstallerForImage(i *models.Image) (*models.Image, chan error, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInstallerForImage", i)
@@ -117,28 +128,13 @@ func (m *MockImageServiceInterface) CreateInstallerForImage(i *models.Image) (*m
 	return ret0, ret1, ret2
 }
 
-// CreateInstallerForImage indicates an expected call of CreateInstallerForImage.
+// CreateInstallerForImage indicates an expected call of CreateInstallerForImage
 func (mr *MockImageServiceInterfaceMockRecorder) CreateInstallerForImage(i interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstallerForImage", reflect.TypeOf((*MockImageServiceInterface)(nil).CreateInstallerForImage), i)
 }
 
-// CreateRepoForImage mocks base method.
-func (m *MockImageServiceInterface) CreateRepoForImage(i *models.Image) (*models.Repo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRepoForImage", i)
-	ret0, _ := ret[0].(*models.Repo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateRepoForImage indicates an expected call of CreateRepoForImage.
-func (mr *MockImageServiceInterfaceMockRecorder) CreateRepoForImage(i interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRepoForImage", reflect.TypeOf((*MockImageServiceInterface)(nil).CreateRepoForImage), i)
-}
-
-// GetImageByID mocks base method.
+// GetImageByID mocks base method
 func (m *MockImageServiceInterface) GetImageByID(id string) (*models.Image, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetImageByID", id)
@@ -147,43 +143,13 @@ func (m *MockImageServiceInterface) GetImageByID(id string) (*models.Image, erro
 	return ret0, ret1
 }
 
-// GetImageByID indicates an expected call of GetImageByID.
+// GetImageByID indicates an expected call of GetImageByID
 func (mr *MockImageServiceInterfaceMockRecorder) GetImageByID(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageByID", reflect.TypeOf((*MockImageServiceInterface)(nil).GetImageByID), id)
 }
 
-// GetImageByOSTreeCommitHash mocks base method.
-func (m *MockImageServiceInterface) GetImageByOSTreeCommitHash(commitHash string) (*models.Image, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetImageByOSTreeCommitHash", commitHash)
-	ret0, _ := ret[0].(*models.Image)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetImageByOSTreeCommitHash indicates an expected call of GetImageByOSTreeCommitHash.
-func (mr *MockImageServiceInterfaceMockRecorder) GetImageByOSTreeCommitHash(commitHash interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageByOSTreeCommitHash", reflect.TypeOf((*MockImageServiceInterface)(nil).GetImageByOSTreeCommitHash), commitHash)
-}
-
-// GetMetadata mocks base method.
-func (m *MockImageServiceInterface) GetMetadata(image *models.Image) (*models.Image, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMetadata", image)
-	ret0, _ := ret[0].(*models.Image)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMetadata indicates an expected call of GetMetadata.
-func (mr *MockImageServiceInterfaceMockRecorder) GetMetadata(image interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockImageServiceInterface)(nil).GetMetadata), image)
-}
-
-// GetUpdateInfo mocks base method.
+// GetUpdateInfo mocks base method
 func (m *MockImageServiceInterface) GetUpdateInfo(image models.Image) ([]models.ImageUpdateAvailable, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUpdateInfo", image)
@@ -192,13 +158,58 @@ func (m *MockImageServiceInterface) GetUpdateInfo(image models.Image) ([]models.
 	return ret0, ret1
 }
 
-// GetUpdateInfo indicates an expected call of GetUpdateInfo.
+// GetUpdateInfo indicates an expected call of GetUpdateInfo
 func (mr *MockImageServiceInterfaceMockRecorder) GetUpdateInfo(image interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdateInfo", reflect.TypeOf((*MockImageServiceInterface)(nil).GetUpdateInfo), image)
 }
 
-// RetryCreateImage mocks base method.
+// AddPackageInfo mocks base method
+func (m *MockImageServiceInterface) AddPackageInfo(image *models.Image) (services.ImageDetail, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddPackageInfo", image)
+	ret0, _ := ret[0].(services.ImageDetail)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddPackageInfo indicates an expected call of AddPackageInfo
+func (mr *MockImageServiceInterfaceMockRecorder) AddPackageInfo(image interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPackageInfo", reflect.TypeOf((*MockImageServiceInterface)(nil).AddPackageInfo), image)
+}
+
+// GetImageByOSTreeCommitHash mocks base method
+func (m *MockImageServiceInterface) GetImageByOSTreeCommitHash(commitHash string) (*models.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImageByOSTreeCommitHash", commitHash)
+	ret0, _ := ret[0].(*models.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImageByOSTreeCommitHash indicates an expected call of GetImageByOSTreeCommitHash
+func (mr *MockImageServiceInterfaceMockRecorder) GetImageByOSTreeCommitHash(commitHash interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageByOSTreeCommitHash", reflect.TypeOf((*MockImageServiceInterface)(nil).GetImageByOSTreeCommitHash), commitHash)
+}
+
+// CheckImageName mocks base method
+func (m *MockImageServiceInterface) CheckImageName(name, account string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckImageName", name, account)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckImageName indicates an expected call of CheckImageName
+func (mr *MockImageServiceInterfaceMockRecorder) CheckImageName(name, account interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckImageName", reflect.TypeOf((*MockImageServiceInterface)(nil).CheckImageName), name, account)
+}
+
+// RetryCreateImage mocks base method
 func (m *MockImageServiceInterface) RetryCreateImage(image *models.Image) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetryCreateImage", image)
@@ -206,13 +217,54 @@ func (m *MockImageServiceInterface) RetryCreateImage(image *models.Image) error 
 	return ret0
 }
 
-// RetryCreateImage indicates an expected call of RetryCreateImage.
+// RetryCreateImage indicates an expected call of RetryCreateImage
 func (mr *MockImageServiceInterfaceMockRecorder) RetryCreateImage(image interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetryCreateImage", reflect.TypeOf((*MockImageServiceInterface)(nil).RetryCreateImage), image)
 }
 
-// SetBuildingStatusOnImageToRetryBuild mocks base method.
+// GetMetadata mocks base method
+func (m *MockImageServiceInterface) GetMetadata(image *models.Image) (*models.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMetadata", image)
+	ret0, _ := ret[0].(*models.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMetadata indicates an expected call of GetMetadata
+func (mr *MockImageServiceInterfaceMockRecorder) GetMetadata(image interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockImageServiceInterface)(nil).GetMetadata), image)
+}
+
+// SetFinalImageStatus mocks base method
+func (m *MockImageServiceInterface) SetFinalImageStatus(i *models.Image) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetFinalImageStatus", i)
+}
+
+// SetFinalImageStatus indicates an expected call of SetFinalImageStatus
+func (mr *MockImageServiceInterfaceMockRecorder) SetFinalImageStatus(i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFinalImageStatus", reflect.TypeOf((*MockImageServiceInterface)(nil).SetFinalImageStatus), i)
+}
+
+// CheckIfIsLatestVersion mocks base method
+func (m *MockImageServiceInterface) CheckIfIsLatestVersion(previousImage *models.Image) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckIfIsLatestVersion", previousImage)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckIfIsLatestVersion indicates an expected call of CheckIfIsLatestVersion
+func (mr *MockImageServiceInterfaceMockRecorder) CheckIfIsLatestVersion(previousImage interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckIfIsLatestVersion", reflect.TypeOf((*MockImageServiceInterface)(nil).CheckIfIsLatestVersion), previousImage)
+}
+
+// SetBuildingStatusOnImageToRetryBuild mocks base method
 func (m *MockImageServiceInterface) SetBuildingStatusOnImageToRetryBuild(image *models.Image) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetBuildingStatusOnImageToRetryBuild", image)
@@ -220,61 +272,23 @@ func (m *MockImageServiceInterface) SetBuildingStatusOnImageToRetryBuild(image *
 	return ret0
 }
 
-// SetBuildingStatusOnImageToRetryBuild indicates an expected call of SetBuildingStatusOnImageToRetryBuild.
+// SetBuildingStatusOnImageToRetryBuild indicates an expected call of SetBuildingStatusOnImageToRetryBuild
 func (mr *MockImageServiceInterfaceMockRecorder) SetBuildingStatusOnImageToRetryBuild(image interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBuildingStatusOnImageToRetryBuild", reflect.TypeOf((*MockImageServiceInterface)(nil).SetBuildingStatusOnImageToRetryBuild), image)
 }
 
-// SetErrorStatusOnImage mocks base method.
-func (m *MockImageServiceInterface) SetErrorStatusOnImage(err error, i *models.Image) {
+// GetRollbackImage mocks base method
+func (m *MockImageServiceInterface) GetRollbackImage(image *models.Image) (*models.Image, error) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetErrorStatusOnImage", err, i)
-}
-
-// SetErrorStatusOnImage indicates an expected call of SetErrorStatusOnImage.
-func (mr *MockImageServiceInterfaceMockRecorder) SetErrorStatusOnImage(err, i interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetErrorStatusOnImage", reflect.TypeOf((*MockImageServiceInterface)(nil).SetErrorStatusOnImage), err, i)
-}
-
-// SetFinalImageStatus mocks base method.
-func (m *MockImageServiceInterface) SetFinalImageStatus(i *models.Image) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetFinalImageStatus", i)
-}
-
-// SetFinalImageStatus indicates an expected call of SetFinalImageStatus.
-func (mr *MockImageServiceInterfaceMockRecorder) SetFinalImageStatus(i interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFinalImageStatus", reflect.TypeOf((*MockImageServiceInterface)(nil).SetFinalImageStatus), i)
-}
-
-// UpdateImage mocks base method.
-func (m *MockImageServiceInterface) UpdateImage(image, previousImage *models.Image) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateImage", image, previousImage)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateImage indicates an expected call of UpdateImage.
-func (mr *MockImageServiceInterfaceMockRecorder) UpdateImage(image, previousImage interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateImage", reflect.TypeOf((*MockImageServiceInterface)(nil).UpdateImage), image, previousImage)
-}
-
-// UpdateImageStatus mocks base method.
-func (m *MockImageServiceInterface) UpdateImageStatus(image *models.Image) (*models.Image, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateImageStatus", image)
+	ret := m.ctrl.Call(m, "GetRollbackImage", image)
 	ret0, _ := ret[0].(*models.Image)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// UpdateImageStatus indicates an expected call of UpdateImageStatus.
-func (mr *MockImageServiceInterfaceMockRecorder) UpdateImageStatus(image interface{}) *gomock.Call {
+// GetRollbackImage indicates an expected call of GetRollbackImage
+func (mr *MockImageServiceInterfaceMockRecorder) GetRollbackImage(image interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateImageStatus", reflect.TypeOf((*MockImageServiceInterface)(nil).UpdateImageStatus), image)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRollbackImage", reflect.TypeOf((*MockImageServiceInterface)(nil).GetRollbackImage), image)
 }


### PR DESCRIPTION
# Description

Use a method to get image by ostree hash and rollback image. Tests pending for the new method, that's why I left on draft.

I did this by centralizing the way we get images by ostree hash and the rollback image, so that I could test both method separately, and making sure we are doing all the joins to retrieve all the documented nested associations.

It has been discussed that we might want to, in the future, review how our API handles that so that we don't cause performance issues by returning all of these objects. We want the docs to reflect these lazy loading associations though, and need to find a way to make openapi spec take that into consideration.

Fixes #THEEDGE-1507

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
