### PR TITLE
remove close file due to duplicity once extract already close it

### DIFF
--- a/pkg/services/repobuilder.go
+++ b/pkg/services/repobuilder.go
@@ -319,10 +319,7 @@ func (rb *RepoBuilder) ExtractVersionRepo(c *models.Commit, tarFileName string, 
 		rb.log.WithField("error", err.Error()).Error("Error extracting tar file")
 		return err
 	}
-	if err := tarFile.Close(); err != nil {
-		rb.log.WithField("error", err.Error()).Error("Error closing tar file")
-		return err
-	}
+
 	log.Debugf("Unpacking tarball finished::tarFileName: %#v", tarFileName)
 
 	err = os.Remove(filepath.Join(dest, tarFileName))


### PR DESCRIPTION
# Description

Remove code to close file once extractor already close the file and when we try to close it again it's failing

Fixes # (THEEDGE-1571)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
