### PR TITLE
change image internal ksfile to common fleet.ks

### DIFF
--- a/scripts/fleetkick.sh
+++ b/scripts/fleetkick.sh
@@ -25,7 +25,7 @@ ISOCFG="${WORKDIR}/isolinux/isolinux.cfg"
 EFICFG="${WORKDIR}/EFI/BOOT/grub.cfg"
 EFI_DIR="${WORKDIR}/EFI/BOOT"
 EFI_IMAGEPATH="${WORKDIR}/images/efiboot.img"
-KSFILE=`basename "$KS_FQPATH"`
+KSFILE="fleet.ks"
 
 
 validate_kickstart() {
@@ -163,7 +163,7 @@ validate_kickstart "$KS_FQPATH"
 VOLID=$(get_iso_volid "$ISO_IN")
 echo "VOLID: $VOLID"
 explode_iso "$ISO_IN" $WORKDIR
-insert_kickstart "$KS_FQPATH" $WORKDIR
+insert_kickstart "$KS_FQPATH" "${WORKDIR}/${KSFILE}"
 edit_isolinux $ISOCFG $VOLID "$KSFILE"
 edit_efiboot $EFICFG $VOLID "$KSFILE"
 modify_efiboot_image $EFICFG $EFI_IMAGEPATH


### PR DESCRIPTION
Makes the kickstart filename the same across all images.
Makes it predictable for testing and customization.

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Copies the updated kickstart file to a common name (fleet.ks) in all images.
This makes it predictable for testing and customization.
It does not impact the unique name when the kickstart file is created from template.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `go fmt ./...` to check that my code is properly formatted
- [ ] I run `go vet ./...` to check that my code is free of common Go style mistakes
