### PR TITLE
fix openapi.json permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ COPY --from=edge-builder /go/bin/edge-api /usr/bin
 COPY --from=edge-builder /go/bin/edge-api-migrate /usr/bin
 COPY --from=edge-builder /go/bin/edge-api-wipe /usr/bin
 COPY --from=edge-builder /src/github.com/RedHatInsights/edge-api/cmd/spec/openapi.json /var/tmp
+RUN chmod 0644 /var/tmp/openapi.json
 
 # kickstart inject requirements
 COPY --from=edge-builder /src/github.com/RedHatInsights/edge-api/scripts/fleetkick.sh /usr/local/bin


### PR DESCRIPTION
Dockerfile: added chmod command for /var/tmp/openapi.json

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

API doc erroring on GET of openapi.json file.
Updated Dockerfile with a chmod command.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `go fmt ./...` to check that my code is properly formatted
- [ ] I run `go vet ./...` to check that my code is free of common Go style mistakes
