### PR TITLE
Log error and dont return yet - trying to sanitize path and have more…

### DIFF
--- a/pkg/services/files.go
+++ b/pkg/services/files.go
@@ -54,7 +54,7 @@ func NewFilesService(log *log.Entry) FilesService {
 	return &S3FilesService{
 		Client:     client,
 		Bucket:     cfg.BucketName,
-		extractor:  files.NewExtractor(),
+		extractor:  files.NewExtractor(log),
 		uploader:   files.NewUploader(log),
 		downloader: files.NewDownloader(),
 	}

--- a/pkg/services/files/extractor.go
+++ b/pkg/services/files/extractor.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // Extractor defines methods to extract files to path
@@ -15,12 +17,14 @@ type Extractor interface {
 }
 
 // NewExtractor returns the main extractor used by EdgeAPI
-func NewExtractor() Extractor {
-	return &TARFileExtractor{}
+func NewExtractor(log *log.Entry) Extractor {
+	return &TARFileExtractor{log: log}
 }
 
 // TARFileExtractor implements a method to extract TAR files into a path
-type TARFileExtractor struct{}
+type TARFileExtractor struct {
+	log *log.Entry
+}
 
 // Extract extracts file to destination path
 func (f *TARFileExtractor) Extract(rc io.ReadCloser, dst string) error {
@@ -34,12 +38,13 @@ func (f *TARFileExtractor) Extract(rc io.ReadCloser, dst string) error {
 			return err
 		}
 
-		path := filepath.Join(dst, header.Name)
-		// FIX ME!!! - Rollback previous solution due an error on sanitizeExtractPath
-		// path, err := sanitizeExtractPath(header.Name, dst)
-		// if err != nil {
-		// 	return err
-		// }
+		path, err := sanitizeExtractPath(dst, header.Name)
+		if err != nil {
+			// FIX ME!!! - Rollback previous solution due an error on sanitizeExtractPath
+			// Crawl: log error and dont return since this code is hard to test locally
+			f.log.WithError(err.Error()).Error("Error sanitizing path")
+			// 	return err
+		}
 		info := header.FileInfo()
 		if info.IsDir() {
 			if err = os.MkdirAll(path, info.Mode()); err != nil {
@@ -72,7 +77,7 @@ func (f *TARFileExtractor) Extract(rc io.ReadCloser, dst string) error {
 	return nil
 }
 
-func sanitizeExtractPath(filePath string, destination string) (destpath string, err error) {
+func sanitizeExtractPath(destination string, filePath string) (destpath string, err error) {
 	destpath = filepath.Join(destination, filePath)
 	if !strings.HasPrefix(destpath, filepath.Clean(destination)+string(os.PathSeparator)) {
 		err = fmt.Errorf("%s: illegal file path", filePath)

--- a/pkg/services/files/extractor.go
+++ b/pkg/services/files/extractor.go
@@ -79,8 +79,9 @@ func (f *TARFileExtractor) Extract(rc io.ReadCloser, dst string) error {
 
 func sanitizeExtractPath(destination string, filePath string) (destpath string, err error) {
 	destpath = filepath.Join(destination, filePath)
-	if !strings.HasPrefix(destpath, filepath.Clean(destination)+string(os.PathSeparator)) {
-		err = fmt.Errorf("%s: illegal file path", filePath)
+	prefix := filepath.Clean(destination) + string(os.PathSeparator)
+	if !strings.HasPrefix(destpath, prefix) {
+		err = fmt.Errorf("%s: illegal file path, prefix: %s, destpath: %s", filePath, prefix, destpath)
 	}
 	return
 }

--- a/pkg/services/files/extractor.go
+++ b/pkg/services/files/extractor.go
@@ -42,7 +42,7 @@ func (f *TARFileExtractor) Extract(rc io.ReadCloser, dst string) error {
 		if err != nil {
 			// FIX ME!!! - Rollback previous solution due an error on sanitizeExtractPath
 			// Crawl: log error and dont return since this code is hard to test locally
-			f.log.WithError(err.Error()).Error("Error sanitizing path")
+			f.log.WithField("error", err.Error()).Error("Error sanitizing path")
 			// 	return err
 		}
 		info := header.FileInfo()

--- a/pkg/services/files/extractor_test.go
+++ b/pkg/services/files/extractor_test.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"os"
 	"testing"
+
+	"github.com/sirupsen/logrus"
 )
 
 func TestUntar(t *testing.T) {
@@ -47,7 +49,7 @@ func TestUntar(t *testing.T) {
 		t.Error("Unable to open mock tar file before test")
 	}
 	extractPath := "/tmp/"
-	err := NewExtractor().Extract(unTarFile, extractPath)
+	err := NewExtractor(logrus.NewEntry(logrus.StandardLogger())).Extract(unTarFile, extractPath)
 	if err != nil {
 		t.Error("Unable to extract mock tar file", err)
 	}


### PR DESCRIPTION
… visibility on the error before returning

# Description

This comes back with sanitization, but focus on logging the error instead of returning to gain insights on the problem.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
