### PR TITLE
remove directory from ksfile path in insert func

### DIFF
--- a/scripts/fleetkick.sh
+++ b/scripts/fleetkick.sh
@@ -60,7 +60,7 @@ insert_kickstart() {
     DIR=$2
 
     echo "Copying ks file $KS to $DIR"
-    [[ -e $KS ]] && [[ -e $DIR ]] && cp $KS $DIR || (echo "ERROR: no kickstart file" && exit 1)
+    [[ -e $KS ]] && cp $KS $DIR || (echo "ERROR: no kickstart file" && exit 1)
 }
 
 


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Path switched from dir to file.
Removed the check for the directory.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `go fmt ./...` to check that my code is properly formatted
- [ ] I run `go vet ./...` to check that my code is free of common Go style mistakes
