### PR TITLE
fix exec command for ksfile injection

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -654,7 +654,7 @@ func (s *ImageService) exeInjectionScript(kickstart string, image string, imageI
 	cmd := &exec.Cmd{
 		Path: fleetBashScript,
 		Args: []string{
-			kickstart, image, image, workDir,
+			fleetBashScript, kickstart, image, image, workDir,
 		},
 	}
 	output, err := cmd.Output()


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Fixes a bug with an updated exec.Cmd call for ksfile injection into ISO

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `go fmt ./...` to check that my code is properly formatted
- [ ] I run `go vet ./...` to check that my code is free of common Go style mistakes
