### PR TITLE
Fix bug that returned twice the amount of devices and refactors tests

### DIFF
--- a/pkg/services/consumers.go
+++ b/pkg/services/consumers.go
@@ -95,7 +95,6 @@ func (s *KafkaConsumerService) ConsumePlaybookDispatcherRuns() error {
 		} else {
 			log.Debug("Skipping message - it is not from edge service")
 		}
-
 	}
 }
 

--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -260,7 +260,7 @@ func (s *DeviceService) GetDevices(params *inventory.Params) (*models.DeviceDeta
 		Total:   inventoryDevices.Total,
 	}
 	s.log.Info("Adding Edge Device information...")
-	for _, device := range inventoryDevices.Result {
+	for i, device := range inventoryDevices.Result {
 		dd := models.DeviceDetails{}
 		dd.Device = models.EdgeDevice{
 			Device: &models.Device{
@@ -286,7 +286,7 @@ func (s *DeviceService) GetDevices(params *inventory.Params) (*models.DeviceDeta
 		// 	} else if params.DeviceStatus == "" {
 		// 		list.Devices = append(list.Devices, dd)
 		// 	}
-		list.Devices = append(list.Devices, dd)
+		list.Devices[i] = dd
 	}
 	return list, nil
 }

--- a/pkg/services/devices_test.go
+++ b/pkg/services/devices_test.go
@@ -20,184 +20,172 @@ import (
 )
 
 var _ = Describe("DeviceService", func() {
+	var mockInventoryClient *mock_inventory.MockClientInterface
+	var deviceService services.DeviceService
+	var mockImageService *mock_services.MockImageServiceInterface
+	var uuid string
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		defer ctrl.Finish()
+		uuid = faker.UUIDHyphenated()
+		mockInventoryClient = mock_inventory.NewMockClientInterface(ctrl)
+		mockImageService = mock_services.NewMockImageServiceInterface(ctrl)
+
+		deviceService = services.DeviceService{
+			Service:      services.NewService(context.Background(), log.NewEntry(log.StandardLogger())),
+			Inventory:    mockInventoryClient,
+			ImageService: mockImageService,
+		}
+	})
 	Context("GetUpdateAvailableForDeviceByUUID", func() {
 		When("error on InventoryAPI", func() {
-			ctrl := gomock.NewController(GinkgoT())
-			defer ctrl.Finish()
-			uuid := faker.UUIDHyphenated()
-			mockInventoryClient := mock_inventory.NewMockClientInterface(ctrl)
-			mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(inventory.Response{}, errors.New("error on inventory api"))
-			deviceService := services.DeviceService{
-				Service:   services.NewService(context.Background(), log.NewEntry(log.StandardLogger())),
-				Inventory: mockInventoryClient,
-			}
+			It("should return error and no updates available", func() {
+				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(inventory.Response{}, errors.New("error on inventory api"))
 
-			updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid)
-			Expect(updatesAvailable).To(BeNil())
-			Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
+				updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid)
+				Expect(updatesAvailable).To(BeNil())
+				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
+			})
 		})
 		When("device is not found on InventoryAPI", func() {
-			ctrl := gomock.NewController(GinkgoT())
-			defer ctrl.Finish()
-			uuid := faker.UUIDHyphenated()
-			resp := inventory.Response{}
-			mockInventoryClient := mock_inventory.NewMockClientInterface(ctrl)
-			mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
+			It("should not return error and zero updates available", func() {
+				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(inventory.Response{}, nil)
 
-			deviceService := services.DeviceService{
-				Service:   services.NewService(context.Background(), log.NewEntry(log.StandardLogger())),
-				Inventory: mockInventoryClient,
-			}
+				deviceService := services.DeviceService{
+					Service:   services.NewService(context.Background(), log.NewEntry(log.StandardLogger())),
+					Inventory: mockInventoryClient,
+				}
 
-			updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid)
-			Expect(updatesAvailable).To(BeNil())
-			Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
+				updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid)
+				Expect(updatesAvailable).To(BeNil())
+				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
+			})
 		})
 		When("everything is okay", func() {
-			ctrl := gomock.NewController(GinkgoT())
-			defer ctrl.Finish()
-			uuid := faker.UUIDHyphenated()
-			checksum := "fake-checksum"
-			resp := inventory.Response{Total: 1, Count: 1, Result: []inventory.Device{
-				{ID: uuid, Ostree: inventory.SystemProfile{
-					RHCClientID: faker.UUIDHyphenated(),
-					RpmOstreeDeployments: []inventory.OSTree{
-						{Checksum: checksum, Booted: true},
-					},
-				}},
-			}}
-			mockInventoryClient := mock_inventory.NewMockClientInterface(ctrl)
-			mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
-
-			deviceService := services.DeviceService{
-				Service:   services.NewService(context.Background(), log.NewEntry(log.StandardLogger())),
-				Inventory: mockInventoryClient,
-			}
-
-			imageSet := &models.ImageSet{
-				Name:    "test",
-				Version: 1,
-			}
-			db.DB.Create(imageSet)
-			oldImage := &models.Image{
-				Commit: &models.Commit{
-					OSTreeCommit: checksum,
-					InstalledPackages: []models.InstalledPackage{
-						{
-							Name:    "ansible",
-							Version: "1.0.0",
+			It("should return updates", func() {
+				checksum := "fake-checksum"
+				resp := inventory.Response{Total: 1, Count: 1, Result: []inventory.Device{
+					{ID: uuid, Ostree: inventory.SystemProfile{
+						RHCClientID: faker.UUIDHyphenated(),
+						RpmOstreeDeployments: []inventory.OSTree{
+							{Checksum: checksum, Booted: true},
 						},
-						{
-							Name:    "yum",
-							Version: "2:6.0-1",
+					}},
+				}}
+				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
+
+				imageSet := &models.ImageSet{
+					Name:    "test",
+					Version: 1,
+				}
+				db.DB.Create(imageSet)
+				oldImage := &models.Image{
+					Commit: &models.Commit{
+						OSTreeCommit: checksum,
+						InstalledPackages: []models.InstalledPackage{
+							{
+								Name:    "ansible",
+								Version: "1.0.0",
+							},
+							{
+								Name:    "yum",
+								Version: "2:6.0-1",
+							},
 						},
 					},
-				},
-				Status:     models.ImageStatusSuccess,
-				ImageSetID: &imageSet.ID,
-			}
-			db.DB.Create(oldImage.Commit)
-			db.DB.Create(oldImage)
-			newImage := &models.Image{
-				Commit: &models.Commit{
-					OSTreeCommit: fmt.Sprintf("a-new-%s", checksum),
-					InstalledPackages: []models.InstalledPackage{
-						{
-							Name:    "yum",
-							Version: "3:6.0-1",
-						},
-						{
-							Name:    "vim",
-							Version: "2.0.0",
+					Status:     models.ImageStatusSuccess,
+					ImageSetID: &imageSet.ID,
+				}
+				db.DB.Create(oldImage.Commit)
+				db.DB.Create(oldImage)
+				newImage := &models.Image{
+					Commit: &models.Commit{
+						OSTreeCommit: fmt.Sprintf("a-new-%s", checksum),
+						InstalledPackages: []models.InstalledPackage{
+							{
+								Name:    "yum",
+								Version: "3:6.0-1",
+							},
+							{
+								Name:    "vim",
+								Version: "2.0.0",
+							},
 						},
 					},
-				},
-				Status:     models.ImageStatusSuccess,
-				ImageSetID: &imageSet.ID,
-			}
-			db.DB.Create(newImage.Commit)
-			db.DB.Create(newImage)
-			updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid)
+					Status:     models.ImageStatusSuccess,
+					ImageSetID: &imageSet.ID,
+				}
+				db.DB.Create(newImage.Commit)
+				db.DB.Create(newImage)
 
-			Expect(err).To(BeNil())
-			Expect(updatesAvailable).To(HaveLen(1))
-			newUpdate := updatesAvailable[0]
-			Expect(newUpdate.Image.ID).To(Equal(newImage.ID))
-			Expect(newUpdate.PackageDiff.Upgraded).To(HaveLen(1))
-			Expect(newUpdate.PackageDiff.Added).To(HaveLen(1))
-			Expect(newUpdate.PackageDiff.Removed).To(HaveLen(1))
+				updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid)
+
+				Expect(err).To(BeNil())
+				Expect(updatesAvailable).To(HaveLen(1))
+				newUpdate := updatesAvailable[0]
+				Expect(newUpdate.Image.ID).To(Equal(newImage.ID))
+				Expect(newUpdate.PackageDiff.Upgraded).To(HaveLen(1))
+				Expect(newUpdate.PackageDiff.Added).To(HaveLen(1))
+				Expect(newUpdate.PackageDiff.Removed).To(HaveLen(1))
+			})
 		})
 		When("no update is available", func() {
-			ctrl := gomock.NewController(GinkgoT())
-			defer ctrl.Finish()
-			uuid := faker.UUIDHyphenated()
-			checksum := "fake-checksum-2"
-			resp := inventory.Response{
-				Total: 1,
-				Count: 1,
-				Result: []inventory.Device{
-					{
-						ID: uuid,
-						Ostree: inventory.SystemProfile{
-							RHCClientID: faker.UUIDHyphenated(),
-							RpmOstreeDeployments: []inventory.OSTree{
-								{
-									Checksum: checksum,
-									Booted:   true,
+			It("should not return updates", func() {
+				uuid := faker.UUIDHyphenated()
+				checksum := "fake-checksum-2"
+				resp := inventory.Response{
+					Total: 1,
+					Count: 1,
+					Result: []inventory.Device{
+						{
+							ID: uuid,
+							Ostree: inventory.SystemProfile{
+								RHCClientID: faker.UUIDHyphenated(),
+								RpmOstreeDeployments: []inventory.OSTree{
+									{
+										Checksum: checksum,
+										Booted:   true,
+									},
 								},
-							},
-						}},
-				},
-			}
-			mockInventoryClient := mock_inventory.NewMockClientInterface(ctrl)
-			mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
+							}},
+					},
+				}
+				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
 
-			deviceService := services.DeviceService{
-				Service:   services.NewService(context.Background(), log.NewEntry(log.StandardLogger())),
-				Inventory: mockInventoryClient,
-			}
+				oldImage := &models.Image{
+					Commit: &models.Commit{
+						OSTreeCommit: checksum,
+					},
+					Status: models.ImageStatusSuccess,
+				}
+				db.DB.Create(oldImage)
 
-			oldImage := &models.Image{
-				Commit: &models.Commit{
-					OSTreeCommit: checksum,
-				},
-				Status: models.ImageStatusSuccess,
-			}
-			db.DB.Create(oldImage)
-
-			updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid)
-			Expect(updatesAvailable).To(BeNil())
-			Expect(err).To(BeNil())
+				updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid)
+				Expect(updatesAvailable).To(BeNil())
+				Expect(err).To(BeNil())
+			})
 		})
 		When("no checksum is found", func() {
-			ctrl := gomock.NewController(GinkgoT())
-			defer ctrl.Finish()
-			uuid := faker.UUIDHyphenated()
-			checksum := "fake-checksum-3"
-			resp := inventory.Response{Total: 1, Count: 1, Result: []inventory.Device{
-				{ID: uuid, Ostree: inventory.SystemProfile{
-					RHCClientID: faker.UUIDHyphenated(),
-					RpmOstreeDeployments: []inventory.OSTree{
-						{Checksum: checksum, Booted: true},
-					},
-				}},
-			}}
-			mockInventoryClient := mock_inventory.NewMockClientInterface(ctrl)
-			mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
+			It("should return device not found", func() {
+				checksum := "fake-checksum-3"
+				resp := inventory.Response{Total: 1, Count: 1, Result: []inventory.Device{
+					{ID: uuid, Ostree: inventory.SystemProfile{
+						RHCClientID: faker.UUIDHyphenated(),
+						RpmOstreeDeployments: []inventory.OSTree{
+							{Checksum: checksum, Booted: true},
+						},
+					}},
+				}}
+				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
 
-			deviceService := services.DeviceService{
-				Service:   services.NewService(context.Background(), log.NewEntry(log.StandardLogger())),
-				Inventory: mockInventoryClient,
-			}
-
-			updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid)
-			Expect(updatesAvailable).To(BeNil())
-			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
+				updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid)
+				Expect(updatesAvailable).To(BeNil())
+				Expect(err).ToNot(BeNil())
+				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
+			})
 		})
 	})
 	Context("GetDiffOnUpdate", func() {
-
 		oldImage := models.Image{
 			Commit: &models.Commit{
 				InstalledPackages: []models.InstalledPackage{
@@ -238,157 +226,133 @@ var _ = Describe("DeviceService", func() {
 				},
 			},
 		}
-		deltaDiff := services.GetDiffOnUpdate(oldImage, newImage)
-		Expect(deltaDiff.Added).To(HaveLen(1))
-		Expect(deltaDiff.Removed).To(HaveLen(2))
-		Expect(deltaDiff.Upgraded).To(HaveLen(1))
+		It("should return diff", func() {
+			deltaDiff := services.GetDiffOnUpdate(oldImage, newImage)
+			Expect(deltaDiff.Added).To(HaveLen(1))
+			Expect(deltaDiff.Removed).To(HaveLen(2))
+			Expect(deltaDiff.Upgraded).To(HaveLen(1))
+		})
 	})
 	Context("GetImageForDeviceByUUID", func() {
 		When("Image is found", func() {
-			ctrl := gomock.NewController(GinkgoT())
-			defer ctrl.Finish()
-
-			uuid := faker.UUIDHyphenated()
-			checksum := "fake-checksum"
-			resp := inventory.Response{Total: 1, Count: 1, Result: []inventory.Device{
-				{ID: uuid, Ostree: inventory.SystemProfile{
-					RHCClientID: faker.UUIDHyphenated(),
-					RpmOstreeDeployments: []inventory.OSTree{
-						{Checksum: checksum, Booted: true},
+			It("should return image", func() {
+				checksum := "fake-checksum"
+				resp := inventory.Response{Total: 1, Count: 1, Result: []inventory.Device{
+					{ID: uuid, Ostree: inventory.SystemProfile{
+						RHCClientID: faker.UUIDHyphenated(),
+						RpmOstreeDeployments: []inventory.OSTree{
+							{Checksum: checksum, Booted: true},
+						},
+					}},
+				}}
+				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil).Times(2)
+				imageSet := &models.ImageSet{
+					Name:    "test",
+					Version: 2,
+				}
+				db.DB.Create(imageSet)
+				oldImage := &models.Image{
+					Commit: &models.Commit{
+						OSTreeCommit: fmt.Sprintf("a-old-%s", checksum),
 					},
-				}},
-			}}
-			mockInventoryClient := mock_inventory.NewMockClientInterface(ctrl)
-			mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil).Times(2)
-			mockImageService := mock_services.NewMockImageServiceInterface(ctrl)
+					Status:     models.ImageStatusSuccess,
+					ImageSetID: &imageSet.ID,
+					Version:    1,
+				}
+				db.DB.Create(oldImage.Commit)
+				db.DB.Create(oldImage)
+				fmt.Printf("Old image was created with id %d\n", oldImage.ID)
+				newImage := &models.Image{
+					Commit: &models.Commit{
+						OSTreeCommit: checksum,
+					},
+					Status:     models.ImageStatusSuccess,
+					ImageSetID: &imageSet.ID,
+					Version:    2,
+				}
+				db.DB.Create(newImage.Commit)
+				db.DB.Create(newImage)
+				fmt.Printf("New image was created with id %d\n", newImage.ID)
+				fmt.Printf("New image was created with image set id %d\n", *newImage.ImageSetID)
 
-			deviceService := services.DeviceService{
-				Service:      services.NewService(context.Background(), log.NewEntry(log.StandardLogger())),
-				Inventory:    mockInventoryClient,
-				ImageService: mockImageService,
-			}
+				mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(newImage, nil)
+				mockImageService.EXPECT().GetRollbackImage(gomock.Eq(newImage)).Return(oldImage, nil)
 
-			imageSet := &models.ImageSet{
-				Name:    "test",
-				Version: 2,
-			}
-			db.DB.Create(imageSet)
-			oldImage := &models.Image{
-				Commit: &models.Commit{
-					OSTreeCommit: fmt.Sprintf("a-old-%s", checksum),
-				},
-				Status:     models.ImageStatusSuccess,
-				ImageSetID: &imageSet.ID,
-				Version:    1,
-			}
-			db.DB.Create(oldImage.Commit)
-			db.DB.Create(oldImage)
-			fmt.Printf("Old image was created with id %d\n", oldImage.ID)
-			newImage := &models.Image{
-				Commit: &models.Commit{
-					OSTreeCommit: checksum,
-				},
-				Status:     models.ImageStatusSuccess,
-				ImageSetID: &imageSet.ID,
-				Version:    2,
-			}
-			db.DB.Create(newImage.Commit)
-			db.DB.Create(newImage)
-			fmt.Printf("New image was created with id %d\n", newImage.ID)
-			fmt.Printf("New image was created with image set id %d\n", *newImage.ImageSetID)
-
-			mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(newImage, nil)
-			mockImageService.EXPECT().GetRollbackImage(gomock.Eq(newImage)).Return(oldImage, nil)
-
-			imageInfo, err := deviceService.GetDeviceImageInfo(uuid)
-			Expect(err).ToNot(BeNil())
-			Expect(oldImage.Commit.OSTreeCommit).To(Equal(imageInfo.Rollback.Commit.OSTreeCommit))
-			Expect(newImage.Commit.OSTreeCommit).To(Equal(imageInfo.Image.Commit.OSTreeCommit))
+				imageInfo, err := deviceService.GetDeviceImageInfo(uuid)
+				Expect(err).To(BeNil())
+				Expect(oldImage.Commit.OSTreeCommit).To(Equal(imageInfo.Rollback.Commit.OSTreeCommit))
+				Expect(newImage.Commit.OSTreeCommit).To(Equal(imageInfo.Image.Commit.OSTreeCommit))
+			})
 		})
 		When("Image is not found", func() {
-			ctrl := gomock.NewController(GinkgoT())
-			defer ctrl.Finish()
+			It("should return image not found", func() {
+				checksum := "123"
+				resp := inventory.Response{Total: 1, Count: 1, Result: []inventory.Device{
+					{ID: uuid, Ostree: inventory.SystemProfile{
+						RHCClientID: faker.UUIDHyphenated(),
+						RpmOstreeDeployments: []inventory.OSTree{
+							{Checksum: checksum, Booted: true},
+						},
+					}},
+				}}
+				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
+				mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(nil, errors.New("Not found"))
 
-			uuid := faker.UUIDHyphenated()
-			checksum := "123"
-			resp := inventory.Response{Total: 1, Count: 1, Result: []inventory.Device{
-				{ID: uuid, Ostree: inventory.SystemProfile{
-					RHCClientID: faker.UUIDHyphenated(),
-					RpmOstreeDeployments: []inventory.OSTree{
-						{Checksum: checksum, Booted: true},
-					},
-				}},
-			}}
-			mockInventoryClient := mock_inventory.NewMockClientInterface(ctrl)
-			mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
-			mockImageService := mock_services.NewMockImageServiceInterface(ctrl)
-			mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(nil, errors.New("Not found"))
-
-			deviceService := services.DeviceService{
-				Service:      services.NewService(context.Background(), log.NewEntry(log.StandardLogger())),
-				Inventory:    mockInventoryClient,
-				ImageService: mockImageService,
-			}
-
-			_, err := deviceService.GetDeviceImageInfo(uuid)
-			Expect(err).To(MatchError(new(services.ImageNotFoundError)))
+				_, err := deviceService.GetDeviceImageInfo(uuid)
+				Expect(err).To(MatchError(new(services.ImageNotFoundError)))
+			})
 		})
 	})
 	Context("GetDevices", func() {
 		When("no devices are returned from InventoryAPI", func() {
-			ctrl := gomock.NewController(GinkgoT())
-			defer ctrl.Finish()
-			params := new(inventory.Params)
-			mockInventoryClient := mock_inventory.NewMockClientInterface(ctrl)
-			mockInventoryClient.EXPECT().ReturnDevices(gomock.Eq(params)).Return(inventory.Response{
-				Total: 0,
-				Count: 0,
-			}, nil)
-			deviceService := services.DeviceService{
-				Service:   services.NewService(context.Background(), log.NewEntry(log.StandardLogger())),
-				Inventory: mockInventoryClient,
-			}
-
-			devices, err := deviceService.GetDevices(params)
-			Expect(devices).ToNot(BeNil())
-			Expect(devices.Devices).To(HaveLen(1))
-			Expect(devices.Count).To(Equal(0))
-			Expect(devices.Total).To(Equal(0))
-			Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
+			It("should return zero devices", func() {
+				params := new(inventory.Params)
+				resp := inventory.Response{
+					Total: 0,
+					Count: 0,
+				}
+				mockInventoryClient.EXPECT().ReturnDevices(gomock.Any()).Return(resp, nil)
+				devices, err := deviceService.GetDevices(params)
+				Expect(devices).ToNot(BeNil())
+				Expect(devices.Devices).To(HaveLen(0))
+				Expect(devices.Count).To(Equal(0))
+				Expect(devices.Total).To(Equal(0))
+				Expect(err).To(BeNil())
+			})
 		})
 		When("devices are returned from InventoryAPI", func() {
-			ctrl := gomock.NewController(GinkgoT())
-			defer ctrl.Finish()
-			params := new(inventory.Params)
-			deviceWithImage := models.Device{}
-			deviceWithNoImage := models.Device{}
-			mockInventoryClient := mock_inventory.NewMockClientInterface(ctrl)
-			mockInventoryClient.EXPECT().ReturnDevices(gomock.Eq(params)).Return(inventory.Response{
-				Total: 2,
-				Count: 2,
-				Result: []inventory.Device{{
-					ID:          deviceWithImage.UUID,
-					DisplayName: "oi",
-					LastSeen:    "b",
-					Ostree:      inventory.SystemProfile{RHCClientID: "", RpmOstreeDeployments: []inventory.OSTree{}},
-				}, {
-					ID:          deviceWithNoImage.UUID,
-					DisplayName: "oi",
-					LastSeen:    "b",
-					Ostree:      inventory.SystemProfile{RHCClientID: "", RpmOstreeDeployments: []inventory.OSTree{}},
-				}},
-			}, nil)
-			deviceService := services.DeviceService{
-				Service:   services.NewService(context.Background(), log.NewEntry(log.StandardLogger())),
-				Inventory: mockInventoryClient,
-			}
+			It("should return devices", func() {
+				params := new(inventory.Params)
+				deviceWithImage := models.Device{}
+				deviceWithNoImage := models.Device{}
+				mockInventoryClient.EXPECT().ReturnDevices(gomock.Eq(params)).Return(inventory.Response{
+					Total: 2,
+					Count: 2,
+					Result: []inventory.Device{{
+						ID:          deviceWithImage.UUID,
+						DisplayName: "oi",
+						LastSeen:    "b",
+						Ostree:      inventory.SystemProfile{RHCClientID: "", RpmOstreeDeployments: []inventory.OSTree{}},
+					}, {
+						ID:          deviceWithNoImage.UUID,
+						DisplayName: "oi",
+						LastSeen:    "b",
+						Ostree:      inventory.SystemProfile{RHCClientID: "", RpmOstreeDeployments: []inventory.OSTree{}},
+					}},
+				}, nil)
+				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Any()).AnyTimes().Return(inventory.Response{}, new(services.DeviceNotFoundError))
+				deviceService := services.DeviceService{
+					Service:   services.NewService(context.Background(), log.NewEntry(log.StandardLogger())),
+					Inventory: mockInventoryClient,
+				}
 
-			devices, err := deviceService.GetDevices(params)
-			Expect(devices).ToNot(BeNil())
-			Expect(devices.Devices).To(HaveLen(1))
-			Expect(devices.Count).To(Equal(0))
-			Expect(devices.Total).To(Equal(0))
-			Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
+				devices, err := deviceService.GetDevices(params)
+				Expect(devices).ToNot(BeNil())
+				Expect(devices.Devices).To(HaveLen(2))
+				Expect(devices.Count).To(Equal(2))
+				Expect(devices.Total).To(Equal(2))
+				Expect(err).To(BeNil())
+			})
 		})
 	})
 })

--- a/pkg/services/services_suite_test.go
+++ b/pkg/services/services_suite_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestServiceSuite(t *testing.T) {
-	defer GinkgoRecover()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Services Suite")
 }


### PR DESCRIPTION
# Description

Fix bug that returned twice the amount of devices and refactors tests. 

The bug was happening due to the creation of a list with fixed size then appending devices to it.

Fixes #THEEDGE-1551

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
