### PR TITLE
Fix ostree path

### DIFF
--- a/pkg/services/repobuilder.go
+++ b/pkg/services/repobuilder.go
@@ -332,14 +332,14 @@ func (rb *RepoBuilder) ExtractVersionRepo(c *models.Commit, tarFileName string, 
 	if c.OSTreeRef == "" {
 		cfg := config.Get()
 		cmd = &exec.Cmd{
-			Path: "ostree",
+			Path: "/usr/bin/ostree",
 			Args: []string{
 				"--repo", "./repo", "commit", cfg.DefaultOSTreeRef, "--add-metadata-string", fmt.Sprintf("version=%s.%d", c.BuildDate, c.BuildNumber),
 			},
 		}
 	} else {
 		cmd = &exec.Cmd{
-			Path: "ostree",
+			Path: "/usr/bin/ostree",
 			Args: []string{
 				"--repo", "./repo", "commit", c.OSTreeRef, "--add-metadata-string", fmt.Sprintf("version=%s.%d", c.BuildDate, c.BuildNumber),
 			},
@@ -375,7 +375,7 @@ func (rb *RepoBuilder) repoPullLocalStaticDeltas(u *models.Commit, o *models.Com
 
 	// pull the local repo at the exact rev (which was HEAD of o.OSTreeRef)
 	cmd := &exec.Cmd{
-		Path: "ostree",
+		Path: "/usr/bin/ostree",
 		Args: []string{
 			"--repo", uprepo, "pull-local", oldrepo, oldRevParse,
 		},
@@ -387,7 +387,7 @@ func (rb *RepoBuilder) repoPullLocalStaticDeltas(u *models.Commit, o *models.Com
 
 	// generate static delta
 	cmd = &exec.Cmd{
-		Path: "ostree",
+		Path: "/usr/bin/ostree",
 		Args: []string{
 			"--repo", uprepo, "static-delta", "generate", "--from", oldRevParse, "--to", updateRevParse,
 		},


### PR DESCRIPTION
# Description

Fixing ostree path to a full path, this will prevent exec from failing.

Fixes THEEDGE-1571

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
