### PR TITLE
Replace the call to /hosts so we can get the exact device for ID

### DIFF
--- a/pkg/clients/inventory/client.go
+++ b/pkg/clients/inventory/client.go
@@ -157,7 +157,7 @@ func (c *Client) ReturnDevices(parameters *Params) (Response, error) {
 
 // ReturnDevicesByID will return the list of devices by uuid
 func (c *Client) ReturnDevicesByID(deviceID string) (Response, error) {
-	url := fmt.Sprintf("%s/%s%s&hostname_or_id=%s", config.Get().InventoryConfig.URL, inventoryAPI, FilterParams, deviceID)
+	url := fmt.Sprintf("%s/%s/%s", config.Get().InventoryConfig.URL, inventoryAPI, deviceID)
 	c.log.WithFields(log.Fields{
 		"url": url,
 	}).Info("Inventory ReturnDevicesByID Request Started")


### PR DESCRIPTION
# Description

The following API call: /v1/devices/45 doesn't return error 404 as expected (since there is no device with uuid 45). This is also true for `uuid = 4`  as  well as for other numbers. There are numbers that truly return 404 like `uuid = 1`.

The response has only the image-info attribute while all the other attributes are empty it seems like the image-info is taken from the latest device.

Fixes THEEDGE-1617

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
