### PR TITLE
Refactor code to avoid duplicate calls to ReturnDeviceByID on inventoryAPI

### DIFF
--- a/pkg/clients/inventory/client.go
+++ b/pkg/clients/inventory/client.go
@@ -114,7 +114,6 @@ func (c *Client) BuildURL(parameters *Params) string {
 
 // ReturnDevices will return the list of devices without filter by tag or uuid
 func (c *Client) ReturnDevices(parameters *Params) (Response, error) {
-
 	url := c.BuildURL(parameters)
 	c.log.WithFields(log.Fields{
 		"url": url,
@@ -130,8 +129,7 @@ func (c *Client) ReturnDevices(parameters *Params) (Response, error) {
 	res, err := client.Do(req)
 	if err != nil {
 		c.log.WithFields(log.Fields{
-			"statusCode": res.StatusCode,
-			"error":      err,
+			"error": err,
 		}).Error("Inventory ReturnDevices Request Error")
 		return Response{}, err
 	}
@@ -171,8 +169,7 @@ func (c *Client) ReturnDevicesByID(deviceID string) (Response, error) {
 
 	if err != nil {
 		c.log.WithFields(log.Fields{
-			"statusCode": res.StatusCode,
-			"error":      err,
+			"error": err,
 		}).Error("Inventory ReturnDevicesByID Request Error")
 		return Response{}, err
 	}
@@ -217,8 +214,7 @@ func (c *Client) ReturnDevicesByTag(tag string) (Response, error) {
 
 	if err != nil {
 		c.log.WithFields(log.Fields{
-			"statusCode": res.StatusCode,
-			"error":      err,
+			"error": err,
 		}).Error("Inventory ReturnDevicesByTag Request Error")
 		return Response{}, err
 	}

--- a/pkg/routes/devices.go
+++ b/pkg/routes/devices.go
@@ -107,7 +107,7 @@ func GetDeviceImageInfo(w http.ResponseWriter, r *http.Request) {
 	if dc.DeviceUUID == "" || !ok {
 		return // Error set by DeviceCtx method
 	}
-	result, err := s.DeviceService.GetDeviceImageInfo(dc.DeviceUUID)
+	result, err := s.DeviceService.GetDeviceImageInfoByUUID(dc.DeviceUUID)
 	if err == nil {
 		if err := json.NewEncoder(w).Encode(result); err != nil {
 			s.Log.WithField("error", result).Error("Error while trying to encode")
@@ -144,7 +144,7 @@ func GetDevice(w http.ResponseWriter, r *http.Request) {
 	if dc.DeviceUUID == "" || !ok {
 		return // Error set by DeviceCtx method
 	}
-	result, err := s.DeviceService.GetDeviceDetails(dc.DeviceUUID)
+	result, err := s.DeviceService.GetDeviceDetailsByUUID(dc.DeviceUUID)
 	if err == nil {
 		if err := json.NewEncoder(w).Encode(result); err != nil {
 			s.Log.WithField("error", result).Error("Error while trying to encode")

--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -235,6 +235,7 @@ func (s *DeviceService) GetDeviceImageInfo(device inventory.Device) (*models.Ima
 	var lastDeployment *inventory.OSTree
 
 	for _, rpmOstree := range device.Ostree.RpmOstreeDeployments {
+		rpmOstree := rpmOstree
 		if rpmOstree.Booted {
 			lastDeployment = &rpmOstree
 			break

--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -12,12 +12,17 @@ import (
 
 // DeviceServiceInterface defines the interface to handle the business logic of RHEL for Edge Devices
 type DeviceServiceInterface interface {
+	GetDevices(params *inventory.Params) (*models.DeviceDetailsList, error)
 	GetDeviceByID(deviceID uint) (*models.Device, error)
 	GetDeviceByUUID(deviceUUID string) (*models.Device, error)
+	// Device by UUID methods
+	GetDeviceDetailsByUUID(deviceUUID string) (*models.DeviceDetails, error)
 	GetUpdateAvailableForDeviceByUUID(deviceUUID string) ([]models.ImageUpdateAvailable, error)
-	GetDeviceImageInfo(deviceUUID string) (*models.ImageInfo, error)
-	GetDeviceDetails(deviceUUID string) (*models.DeviceDetails, error)
-	GetDevices(params *inventory.Params) (*models.DeviceDetailsList, error)
+	GetDeviceImageInfoByUUID(deviceUUID string) (*models.ImageInfo, error)
+	// Device Object Methods
+	GetDeviceDetails(device inventory.Device) (*models.DeviceDetails, error)
+	GetUpdateAvailableForDevice(device inventory.Device) ([]models.ImageUpdateAvailable, error)
+	GetDeviceImageInfo(device inventory.Device) (*models.ImageInfo, error)
 	GetDeviceLastDeployment(device inventory.Device) *inventory.OSTree
 	GetDeviceLastBootedDeployment(device inventory.Device) *inventory.OSTree
 }
@@ -66,52 +71,66 @@ func (s *DeviceService) GetDeviceByUUID(deviceUUID string) (*models.Device, erro
 	return &device, nil
 }
 
-// GetDeviceDetails provides details for a given Device UUID by going to inventory API and trying to also merge with the information on our database
-func (s *DeviceService) GetDeviceDetails(deviceUUID string) (*models.DeviceDetails, error) {
-	s.log = s.log.WithField("deviceUUID", deviceUUID)
+// GetDeviceDetails provides details for a given Device by going to inventory API and trying to also merge with the information on our database
+func (s *DeviceService) GetDeviceDetails(device inventory.Device) (*models.DeviceDetails, error) {
+	s.log = s.log.WithField("deviceUUID", device.ID)
 	s.log.Info("Get device by uuid")
 
-	imageInfo, err := s.GetDeviceImageInfo(deviceUUID)
+	// Get device's running image
+	imageInfo, err := s.GetDeviceImageInfo(device)
 	if err != nil {
 		s.log.WithField("error", err.Error()).Error("Could not find information about the running image on the device")
 		return nil, err
 	}
-	device, err := s.GetDeviceByUUID(deviceUUID)
+	// Get device on Edge API, not on inventory
+	databaseDevice, err := s.GetDeviceByUUID(device.ID)
 	if err != nil {
 		s.log.Info("Could not find device on the devices table yet - returning just the data from inventory")
 	}
 	// In order to have an update transaction for a device it must be a least created
 	var updates *[]models.UpdateTransaction
-	if device != nil {
-		updates, err = s.UpdateService.GetUpdateTransactionsForDevice(device)
+	if databaseDevice != nil {
+		updates, err = s.UpdateService.GetUpdateTransactionsForDevice(databaseDevice)
 		if err != nil {
 			s.log.WithField("error", err.Error()).Error("Could not find information about updates for this device")
 			return nil, err
 		}
 	}
 	details := &models.DeviceDetails{
-		Device:             models.EdgeDevice{Device: device},
+		Device:             models.EdgeDevice{Device: databaseDevice},
 		Image:              imageInfo,
 		UpdateTransactions: updates,
 	}
 	return details, nil
 }
 
-// GetUpdateAvailableForDeviceByUUID returns if exists update for the current image at the device.
-func (s *DeviceService) GetUpdateAvailableForDeviceByUUID(deviceUUID string) ([]models.ImageUpdateAvailable, error) {
+// GetDeviceDetailsByUUID provides details for a given Device UUID by going to inventory API and trying to also merge with the information on our database
+func (s *DeviceService) GetDeviceDetailsByUUID(deviceUUID string) (*models.DeviceDetails, error) {
 	s.log = s.log.WithField("deviceUUID", deviceUUID)
-	var imageDiff []models.ImageUpdateAvailable
-	device, err := s.Inventory.ReturnDevicesByID(deviceUUID)
-	if err != nil || device.Total != 1 {
+	resp, err := s.Inventory.ReturnDevicesByID(deviceUUID)
+	if err != nil || resp.Total != 1 {
 		return nil, new(DeviceNotFoundError)
 	}
+	return s.GetDeviceDetails(resp.Result[len(resp.Result)-1])
+}
 
-	lastDevice := device.Result[len(device.Result)-1]
-	lastDeployment := s.GetDeviceLastBootedDeployment(lastDevice)
+// GetUpdateAvailableForDeviceByUUID returns if it exists an update for the current image at the device given its UUID.
+func (s *DeviceService) GetUpdateAvailableForDeviceByUUID(deviceUUID string) ([]models.ImageUpdateAvailable, error) {
+	s.log = s.log.WithField("deviceUUID", deviceUUID)
+	resp, err := s.Inventory.ReturnDevicesByID(deviceUUID)
+	if err != nil || resp.Total != 1 {
+		return nil, new(DeviceNotFoundError)
+	}
+	return s.GetUpdateAvailableForDevice(resp.Result[len(resp.Result)-1])
+}
+
+// GetUpdateAvailableForDevice returns if it exists an update for the current image at the device.
+func (s *DeviceService) GetUpdateAvailableForDevice(device inventory.Device) ([]models.ImageUpdateAvailable, error) {
+	var imageDiff []models.ImageUpdateAvailable
+	lastDeployment := s.GetDeviceLastBootedDeployment(device)
 	if lastDeployment == nil {
 		return nil, new(DeviceNotFoundError)
 	}
-
 	var images []models.Image
 	var currentImage models.Image
 	result := db.DB.Model(&models.Image{}).Joins("Commit").Where("OS_Tree_Commit = ?", lastDeployment.Checksum).First(&currentImage)
@@ -120,7 +139,7 @@ func (s *DeviceService) GetUpdateAvailableForDeviceByUUID(deviceUUID string) ([]
 		return nil, new(DeviceNotFoundError)
 	}
 
-	err = db.DB.Model(&currentImage.Commit).Association("InstalledPackages").Find(&currentImage.Commit.InstalledPackages)
+	err := db.DB.Model(&currentImage.Commit).Association("InstalledPackages").Find(&currentImage.Commit.InstalledPackages)
 	if err != nil {
 		s.log.WithField("error", err.Error()).Error("Could not find device")
 		return nil, new(DeviceNotFoundError)
@@ -198,28 +217,31 @@ func GetDiffOnUpdate(oldImg models.Image, newImg models.Image) models.PackageDif
 	return results
 }
 
-// GetDeviceImageInfo returns the information of a running image for a device
-func (s *DeviceService) GetDeviceImageInfo(deviceUUID string) (*models.ImageInfo, error) {
+// GetDeviceImageInfoByUUID returns the information of a running image for a device given its UUID
+func (s *DeviceService) GetDeviceImageInfoByUUID(deviceUUID string) (*models.ImageInfo, error) {
 	s.log = s.log.WithField("deviceUUID", deviceUUID)
+	resp, err := s.Inventory.ReturnDevicesByID(deviceUUID)
+	if err != nil || resp.Total != 1 {
+		return nil, new(DeviceNotFoundError)
+	}
+	return s.GetDeviceImageInfo(resp.Result[len(resp.Result)-1])
+}
+
+// GetDeviceImageInfo returns the information of a the running image for a device
+func (s *DeviceService) GetDeviceImageInfo(device inventory.Device) (*models.ImageInfo, error) {
 	var ImageInfo models.ImageInfo
 	var currentImage *models.Image
 	var rollback *models.Image
 	var lastDeployment inventory.OSTree
-	device, err := s.Inventory.ReturnDevicesByID(deviceUUID)
-	if err != nil || device.Total != 1 {
-		return nil, new(DeviceNotFoundError)
-	}
 
-	lastDevice := device.Result[len(device.Result)-1]
-
-	for _, rpmOstree := range lastDevice.Ostree.RpmOstreeDeployments {
+	for _, rpmOstree := range device.Ostree.RpmOstreeDeployments {
 		if rpmOstree.Booted {
 			lastDeployment = rpmOstree
 			break
 		}
 	}
 
-	currentImage, err = s.ImageService.GetImageByOSTreeCommitHash(lastDeployment.Checksum)
+	currentImage, err := s.ImageService.GetImageByOSTreeCommitHash(lastDeployment.Checksum)
 	if err != nil {
 		s.log.WithField("error", err.Error()).Error("Could not find device image info")
 		return nil, new(ImageNotFoundError)
@@ -232,7 +254,7 @@ func (s *DeviceService) GetDeviceImageInfo(deviceUUID string) (*models.ImageInfo
 		}
 	}
 
-	updateAvailable, err := s.GetUpdateAvailableForDeviceByUUID(deviceUUID)
+	updateAvailable, err := s.GetUpdateAvailableForDevice(device)
 	if err != nil {
 		s.log.WithField("error", err.Error()).Error("Could not find updates available to get image info")
 		return nil, err
@@ -275,7 +297,7 @@ func (s *DeviceService) GetDevices(params *inventory.Params) (*models.DeviceDeta
 			dd.Device.Booted = lastDeployment.Booted
 		}
 		s.log.WithField("deviceID", device.ID).Info("Getting image info for device...")
-		imageInfo, err := s.GetDeviceImageInfo(device.ID)
+		imageInfo, err := s.GetDeviceImageInfo(device)
 		if err != nil {
 			dd.Image = nil
 		} else if imageInfo != nil {

--- a/pkg/services/devices_test.go
+++ b/pkg/services/devices_test.go
@@ -383,7 +383,7 @@ var _ = Describe("DeviceService", func() {
 				mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(newImage, nil)
 				mockImageService.EXPECT().GetRollbackImage(gomock.Eq(newImage)).Return(oldImage, nil)
 
-				imageInfo, err := deviceService.GetDeviceImageInfo(uuid)
+				imageInfo, err := deviceService.GetDeviceImageInfoByUUID(uuid)
 				Expect(err).To(BeNil())
 				Expect(oldImage.Commit.OSTreeCommit).To(Equal(imageInfo.Rollback.Commit.OSTreeCommit))
 				Expect(newImage.Commit.OSTreeCommit).To(Equal(imageInfo.Image.Commit.OSTreeCommit))
@@ -403,7 +403,7 @@ var _ = Describe("DeviceService", func() {
 				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
 				mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(nil, errors.New("Not found"))
 
-				_, err := deviceService.GetDeviceImageInfo(uuid)
+				_, err := deviceService.GetDeviceImageInfoByUUID(uuid)
 				Expect(err).To(MatchError(new(services.ImageNotFoundError)))
 			})
 		})

--- a/pkg/services/mock_services/devices.go
+++ b/pkg/services/mock_services/devices.go
@@ -34,6 +34,21 @@ func (m *MockDeviceServiceInterface) EXPECT() *MockDeviceServiceInterfaceMockRec
 	return m.recorder
 }
 
+// GetDevices mocks base method
+func (m *MockDeviceServiceInterface) GetDevices(params *inventory.Params) (*models.DeviceDetailsList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDevices", params)
+	ret0, _ := ret[0].(*models.DeviceDetailsList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDevices indicates an expected call of GetDevices
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetDevices(params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDevices", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDevices), params)
+}
+
 // GetDeviceByID mocks base method
 func (m *MockDeviceServiceInterface) GetDeviceByID(deviceID uint) (*models.Device, error) {
 	m.ctrl.T.Helper()
@@ -64,6 +79,21 @@ func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceByUUID(deviceUUID int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceByUUID", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceByUUID), deviceUUID)
 }
 
+// GetDeviceDetailsByUUID mocks base method
+func (m *MockDeviceServiceInterface) GetDeviceDetailsByUUID(deviceUUID string) (*models.DeviceDetails, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeviceDetailsByUUID", deviceUUID)
+	ret0, _ := ret[0].(*models.DeviceDetails)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeviceDetailsByUUID indicates an expected call of GetDeviceDetailsByUUID
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceDetailsByUUID(deviceUUID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceDetailsByUUID", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceDetailsByUUID), deviceUUID)
+}
+
 // GetUpdateAvailableForDeviceByUUID mocks base method
 func (m *MockDeviceServiceInterface) GetUpdateAvailableForDeviceByUUID(deviceUUID string) ([]models.ImageUpdateAvailable, error) {
 	m.ctrl.T.Helper()
@@ -79,49 +109,64 @@ func (mr *MockDeviceServiceInterfaceMockRecorder) GetUpdateAvailableForDeviceByU
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdateAvailableForDeviceByUUID", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetUpdateAvailableForDeviceByUUID), deviceUUID)
 }
 
-// GetDeviceImageInfo mocks base method
-func (m *MockDeviceServiceInterface) GetDeviceImageInfo(deviceUUID string) (*models.ImageInfo, error) {
+// GetDeviceImageInfoByUUID mocks base method
+func (m *MockDeviceServiceInterface) GetDeviceImageInfoByUUID(deviceUUID string) (*models.ImageInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeviceImageInfo", deviceUUID)
+	ret := m.ctrl.Call(m, "GetDeviceImageInfoByUUID", deviceUUID)
 	ret0, _ := ret[0].(*models.ImageInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetDeviceImageInfo indicates an expected call of GetDeviceImageInfo
-func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceImageInfo(deviceUUID interface{}) *gomock.Call {
+// GetDeviceImageInfoByUUID indicates an expected call of GetDeviceImageInfoByUUID
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceImageInfoByUUID(deviceUUID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceImageInfo", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceImageInfo), deviceUUID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceImageInfoByUUID", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceImageInfoByUUID), deviceUUID)
 }
 
 // GetDeviceDetails mocks base method
-func (m *MockDeviceServiceInterface) GetDeviceDetails(deviceUUID string) (*models.DeviceDetails, error) {
+func (m *MockDeviceServiceInterface) GetDeviceDetails(device inventory.Device) (*models.DeviceDetails, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeviceDetails", deviceUUID)
+	ret := m.ctrl.Call(m, "GetDeviceDetails", device)
 	ret0, _ := ret[0].(*models.DeviceDetails)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDeviceDetails indicates an expected call of GetDeviceDetails
-func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceDetails(deviceUUID interface{}) *gomock.Call {
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceDetails(device interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceDetails", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceDetails), deviceUUID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceDetails", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceDetails), device)
 }
 
-// GetDevices mocks base method
-func (m *MockDeviceServiceInterface) GetDevices(params *inventory.Params) (*models.DeviceDetailsList, error) {
+// GetUpdateAvailableForDevice mocks base method
+func (m *MockDeviceServiceInterface) GetUpdateAvailableForDevice(device inventory.Device) ([]models.ImageUpdateAvailable, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDevices", params)
-	ret0, _ := ret[0].(*models.DeviceDetailsList)
+	ret := m.ctrl.Call(m, "GetUpdateAvailableForDevice", device)
+	ret0, _ := ret[0].([]models.ImageUpdateAvailable)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetDevices indicates an expected call of GetDevices
-func (mr *MockDeviceServiceInterfaceMockRecorder) GetDevices(params interface{}) *gomock.Call {
+// GetUpdateAvailableForDevice indicates an expected call of GetUpdateAvailableForDevice
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetUpdateAvailableForDevice(device interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDevices", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDevices), params)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdateAvailableForDevice", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetUpdateAvailableForDevice), device)
+}
+
+// GetDeviceImageInfo mocks base method
+func (m *MockDeviceServiceInterface) GetDeviceImageInfo(device inventory.Device) (*models.ImageInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeviceImageInfo", device)
+	ret0, _ := ret[0].(*models.ImageInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeviceImageInfo indicates an expected call of GetDeviceImageInfo
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceImageInfo(device interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceImageInfo", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceImageInfo), device)
 }
 
 // GetDeviceLastDeployment mocks base method


### PR DESCRIPTION
# Description

After @matoval  pointed out that the call to /devices was giving a error 500, we got together and realized that the reason why it was giving an error was because the system_profile was not being returned.

We realized together that the /hosts/<id> endpoint by inventory API doesn't return the system profile and another call is needed for that (/hosts/<id>/system_profile). We started calling /hosts/<id> in #582  and that fixed another bug.

The /devices endpoint  didn't need to call that endpoint - this PR removes the need to call /hosts/<id> on the /devices endpoint.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x]  New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
