### PR TITLE
add kafka placeholder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ RUN go build -o /go/bin/edge-api-wipe cmd/db/wipe.go
 # Run the doc binary
 RUN go run cmd/spec/main.go
 
+# Build the kafka binary
+RUN go build -o /go/bin/edge-api-kafkadev cmd/kafka/main.go
+
 ######################################
 # STEP 2: build the dependencies image
 ######################################
@@ -68,6 +71,7 @@ ENV EDGE_API_WORKSPACE /src/github.com/RedHatInsights/edge-api
 COPY --from=edge-builder /go/bin/edge-api /usr/bin
 COPY --from=edge-builder /go/bin/edge-api-migrate /usr/bin
 COPY --from=edge-builder /go/bin/edge-api-wipe /usr/bin
+COPY --from=edge-builder /go/bin/edge-api-kafkadev /usr/bin
 COPY --from=edge-builder ${EDGE_API_WORKSPACE}/cmd/spec/openapi.json /var/tmp
 
 # kickstart inject requirements

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -31,6 +31,14 @@ podman build -f Dockerfile -t "${IMAGE}:${IMAGE_TAG}" .
 podman push "${IMAGE}:${IMAGE_TAG}"
 
 TAGS="latest main qa"
+# check if a change is under cmd/kafka directory and tag accordingly
+num_files=$(git log --raw -n 1 --no-merges | egrep "^:.*" | wc -l)
+num_kafka_files=$(git log --raw -n 1 --no-merges | egrep "^:.*cmd/kafka" | wc -l)
+# if all changes are under cmd/kafka then only tag kafka
+if [[ $num_kafka_files -gt 0 ]]; then
+    [[ num_files -eq num_kafka_files ]] && TAGS="kafka" || TAGS="$TAGS kafka"
+fi
+
 for tag in $(echo $TAGS); do
     podman tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${tag}"
     podman push "${IMAGE}:${tag}"

--- a/cmd/kafka/main.go
+++ b/cmd/kafka/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+
+	for {
+		fmt.Println("Sleeping 300...")
+		time.Sleep(300 * time.Second)
+	}
+}


### PR DESCRIPTION
* add a placeholder for dev'ing out kafka consumers/producers
    and running them in a separate pod
* will create the deployment in separate PRs

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Adding a placeholder for kafka consumer/producers in the same repo as the main app.
These will run in separate pod(s) and only bounce the kafka pod(s) when a change is made to kafka code.
When finished, the edge-api pods will remain undisturbed.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
