### PR TITLE
add a line to test kafka tag only

### DIFF
--- a/cmd/kafka/main.go
+++ b/cmd/kafka/main.go
@@ -6,7 +6,7 @@ import (
 )
 
 func main() {
-
+	fmt.Println("Entering an infinite loop...")
 	for {
 		fmt.Println("Sleeping 300...")
 		time.Sleep(300 * time.Second)


### PR DESCRIPTION
* just adding a line to a file in cmd/kafka to test tagging logic

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Just adding a line to cmd/kafka/main.go to test the logic for only tagging kafka for changes in the subdir

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
