### PR TITLE
add kafkadev deployment to clowderapp

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -88,6 +88,49 @@ objects:
           requests:
             cpu: 500m
             memory: 512Mi
+    - name: kafkadev
+      minReplicas: 1
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        command:
+        - /usr/bin/edge-api-kafkadev
+        env:
+        - name: CLOWDER_ENABLED
+          value: ${CLOWDER_ENABLED}
+        - name: ENABLE_CLOUDWATCH_LOGGING
+          value: ${ENABLE_CLOUDWATCH_LOGGING}
+        - name: AUTH
+          value: ${ENABLE_RH_IDENTITY_PROCESSING}
+        - name: EDGETARBALLSBUCKET
+          value: ${EDGE_TARBALLS_BUCKET}
+        - name: OPENAPIFILEPATH
+          value: ${OPEN_API_FILEPATH}
+        - name: IMAGEBUILDERURL
+          value: ${IMAGEBUILDER_URL}
+        - name: INVENTORYURL
+          value: ${INVENTORYURL}
+        - name: PLAYBOOKDISPATCHERURL
+          value: ${PLAYBOOKDISPATCHERURL}
+        - name: FDO_HOST_URL
+          value: ${FDO_HOST_URL}
+        - name: FDO_API_VERSION
+          value: ${FDO_API_VERSION}
+        - name: PLAYBOOKDISPATCHERPSK
+          valueFrom:
+            secretKeyRef:
+              key: key
+              name: psk-playbook-dispatcher
+        - name: EDGEAPIBASEURL
+          value: ${EDGEAPIBASEURL}
+        - name: UPLOADWORKERS
+          value: ${UPLOADWORKERS}
+        resources:
+          limits:
+            cpu: ${{CPU_LIMIT}}
+            memory: ${MEMORY_LIMIT}
+          requests:
+            cpu: 500m
+            memory: 512Mi
     objectStore:
     - ${EDGE_TARBALLS_BUCKET}
     database:


### PR DESCRIPTION
* clowderapp.yaml: added a new deployment for kafkadev app
*	it will run alongside edge-api

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Adding kafkadev deployment to Clowder config to spin up related app in edge namespace

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `go fmt ./...` to check that my code is properly formatted
- [ ] I run `go vet ./...` to check that my code is free of common Go style mistakes
