### PR TITLE
Local upload: clean destination path and add trailing slash

### DIFF
--- a/pkg/services/files/files_suite_test.go
+++ b/pkg/services/files/files_suite_test.go
@@ -1,0 +1,13 @@
+package files_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestFilesSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Services Suite")
+}

--- a/pkg/services/files/uploader.go
+++ b/pkg/services/files/uploader.go
@@ -28,6 +28,7 @@ func NewUploader(log *log.Entry) Uploader {
 	var uploader Uploader
 	uploader = &LocalUploader{
 		BaseDir: "/tmp",
+		log:     log,
 	}
 	if !cfg.Local {
 		uploader = newS3Uploader(log)
@@ -48,6 +49,7 @@ type S3Uploader struct {
 // without S3
 type LocalUploader struct {
 	BaseDir string
+	log     *log.Entry
 }
 
 // UploadRepo just returns the src repo folder
@@ -65,6 +67,7 @@ func (u *LocalUploader) UploadRepo(src string, account string) (string, error) {
 // Allowing offline development without S3 and satisfying the interface
 func (u *LocalUploader) UploadFile(fname string, uploadPath string) (string, error) {
 	destfile := filepath.Clean(u.BaseDir + "/" + uploadPath)
+	u.log.WithFields(log.Fields{"fname": fname, "destfine": destfile}).Debug("Copying fname to destfile")
 	cmd := exec.Command("cp", fname, destfile) //#nosec G204 - This uploadPath variable is actually controlled by the calling method
 	err := cmd.Run()
 	if err != nil {

--- a/pkg/services/files/uploader.go
+++ b/pkg/services/files/uploader.go
@@ -64,7 +64,7 @@ func (u *LocalUploader) UploadRepo(src string, account string) (string, error) {
 // UploadFile basically copies a file to the local server path
 // Allowing offline development without S3 and satisfying the interface
 func (u *LocalUploader) UploadFile(fname string, uploadPath string) (string, error) {
-	destfile := u.BaseDir + uploadPath
+	destfile := filepath.Clean(u.BaseDir + "/" + uploadPath)
 	cmd := exec.Command("cp", fname, destfile) //#nosec G204 - This uploadPath variable is actually controlled by the calling method
 	err := cmd.Run()
 	if err != nil {

--- a/pkg/services/files/uploader_test.go
+++ b/pkg/services/files/uploader_test.go
@@ -2,10 +2,7 @@ package files_test
 
 import (
 	"fmt"
-	"io/fs"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -21,6 +18,7 @@ var _ = Describe("Uploader Test", func() {
 		var uploader files.Uploader
 		BeforeEach(func() {
 			logEntry = log.NewEntry(log.StandardLogger())
+			config.Init()
 			cfg := config.Get()
 			cfg.Local = true
 			account = "000000"
@@ -56,27 +54,27 @@ var _ = Describe("Uploader Test", func() {
 			})
 		})
 		When("upload file", func() {
-			var path, filename, data string
+			var path, filename string
 			BeforeEach(func() {
-				data = "i am a file data"
 				filename = "random-filename.txt"
-				path = fmt.Sprintf("/tmp/random-folder/%s", filename)
+				path = "/tmp"
+				path = fmt.Sprintf("%s/%s", path, filename)
 				f, err := os.Create(path)
 				if err != nil {
 					log.Fatal(err)
 				}
 				defer f.Close()
-				ioutil.WriteFile(path, []byte(data), fs.ModeAppend)
+				os.Create(path)
 			})
 			AfterEach(func() {
 				os.Remove(path)
 			})
-			It("returns error", func() {
-				_, filename := filepath.Split(path)
-				newFilePath, err := uploader.UploadFile(path, filename)
+			It("doesnt returns error", func() {
+				destfile := "random-file.txt"
+				newFilePath, err := uploader.UploadFile(path, destfile)
 
+				Expect(newFilePath).To(Equal(fmt.Sprintf("/tmp/%s", destfile)))
 				Expect(err).ToNot(HaveOccurred())
-				Expect(newFilePath).To(Equal(fmt.Sprintf("/tmp/%s", filename)))
 			})
 		})
 	})


### PR DESCRIPTION
# Description

I realized the local upload wasn't working due to the destination path not having the proper trailing slash. The filepath clean is supposed to make it even safer because it removes extra trailing slashes.
Also, the tests werent running so I fixed that.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
