### PR TITLE
THEEDGE-1634 Change updates.go fatals to errors

### DIFF
--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -107,7 +107,7 @@ func (s *UpdateService) CreateUpdate(id uint) (*models.UpdateTransaction, error)
 		WaitGroup.Done() // Done with one update (successfully or not)
 		s.log.Debug("Done with one update - successfully or not")
 		if err := recover(); err != nil {
-			s.log.WithField("error", err).Fatal("Error on update")
+			s.log.WithField("error", err).Error("Error on update")
 		}
 	}()
 	go func(update *models.UpdateTransaction) {
@@ -124,7 +124,7 @@ func (s *UpdateService) CreateUpdate(id uint) (*models.UpdateTransaction, error)
 			update.Status = models.UpdateStatusError
 			tx := db.DB.Save(update)
 			if tx.Error != nil {
-				s.log.WithField("error", tx.Error.Error()).Fatal("Error saving update")
+				s.log.WithField("error", tx.Error.Error()).Error("Error saving update")
 			}
 			WaitGroup.Done()
 		}
@@ -340,7 +340,7 @@ func (s *UpdateService) ProcessPlaybookDispatcherRunEvent(message []byte) error 
 		dispatchRecord.Status = models.DispatchRecordStatusRunning
 	} else {
 		dispatchRecord.Status = models.DispatchRecordStatusError
-		s.log.Fatal("Playbook status is not on the json schema for this event")
+		s.log.Error("Playbook status is not on the json schema for this event")
 	}
 	result = db.DB.Save(&dispatchRecord)
 	if result.Error != nil {


### PR DESCRIPTION
# Description

This fix changes Fatal() calls in updates.go to Error() so the pod doesn't crash
Fixes # THEEDGE-1634

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
