### PR TITLE
removing redis, due to problem on prod setup

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -150,7 +150,6 @@ objects:
       - "host-inventory"
       - ingress
     featureFlags: true
-    inMemoryDb: true
 
 parameters:
 - description: Cpu limit of service


### PR DESCRIPTION
# Description

Removing inMemoryDB due conflict in prod. Should be reviewed on Arch meeting.

Fixes # ([Origina PR](https://github.com/RedHatInsights/edge-api/pull/644/files))

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
