### PR TITLE
spin up a kafkadev replica set to 1

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -89,7 +89,7 @@ objects:
             cpu: 500m
             memory: 512Mi
     - name: kafkadev
-      minReplicas: 0
+      minReplicas: 1
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         command:


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description
Spinning up a kafkadev pod by setting replica to 1 in Clowder config.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `go fmt ./...` to check that my code is properly formatted
- [ ] I run `go vet ./...` to check that my code is free of common Go style mistakes
