### PR TITLE
Device: Return the db device id when listing devices.

### DIFF
--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -313,14 +313,14 @@ func (s *DeviceService) GetDevices(params *inventory.Params) (*models.DeviceDeta
 	if res := db.DB.Where("account = ? AND uuid IN ?", account, devicesUUIDs).Find(&storedDevices); res.Error != nil {
 		return nil, res.Error
 	}
-	mapDdevicesUUIDToID := make(map[string]uint, len(devicesUUIDs))
+	mapDevicesUUIDToID := make(map[string]uint, len(devicesUUIDs))
 	for _, device := range storedDevices {
-		mapDdevicesUUIDToID[device.UUID] = device.ID
+		mapDevicesUUIDToID[device.UUID] = device.ID
 	}
 
 	s.log.Info("Adding Edge Device information...")
 	for i, device := range inventoryDevices.Result {
-		dbDeviceID, ok := mapDdevicesUUIDToID[device.ID]
+		dbDeviceID, ok := mapDevicesUUIDToID[device.ID]
 		if !ok {
 			dbDeviceID = 0
 		}

--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -8,6 +8,7 @@ import (
 	"github.com/redhatinsights/edge-api/pkg/clients/inventory"
 	"github.com/redhatinsights/edge-api/pkg/db"
 	"github.com/redhatinsights/edge-api/pkg/models"
+	"github.com/redhatinsights/edge-api/pkg/routes/common"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm/clause"
 )
@@ -299,11 +300,34 @@ func (s *DeviceService) GetDevices(params *inventory.Params) (*models.DeviceDeta
 	if inventoryDevices.Count == 0 {
 		return list, nil
 	}
+	// Build a map from the received devices UUIDs and the already saved db devices IDs
+	account, err := common.GetAccountFromContext(s.ctx)
+	if err != nil {
+		return nil, err
+	}
+	devicesUUIDs := make([]string, 0, len(inventoryDevices.Result))
+	for _, device := range inventoryDevices.Result {
+		devicesUUIDs = append(devicesUUIDs, device.ID)
+	}
+	var storedDevices []models.Device
+	if res := db.DB.Where("account = ? AND uuid IN ?", account, devicesUUIDs).Find(&storedDevices); res.Error != nil {
+		return nil, res.Error
+	}
+	mapDdevicesUUIDToID := make(map[string]uint, len(devicesUUIDs))
+	for _, device := range storedDevices {
+		mapDdevicesUUIDToID[device.UUID] = device.ID
+	}
+
 	s.log.Info("Adding Edge Device information...")
 	for i, device := range inventoryDevices.Result {
+		dbDeviceID, ok := mapDdevicesUUIDToID[device.ID]
+		if !ok {
+			dbDeviceID = 0
+		}
 		dd := models.DeviceDetails{}
 		dd.Device = models.EdgeDevice{
 			Device: &models.Device{
+				Model:       models.Model{ID: dbDeviceID},
 				UUID:        device.ID,
 				RHCClientID: device.Ostree.RHCClientID,
 				Account:     device.Account,


### PR DESCRIPTION
# Description
When getting devices the id of the device is not listed, we need to have the id, to allow us to add the device to device groups.  


Fixes THEEDGE-1694

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
