### PR TITLE
THEEDGE-1631 Change panic() to logger.LogErrorAndPanic()

### DIFF
--- a/pkg/services/files.go
+++ b/pkg/services/files.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/logger"
 	"github.com/redhatinsights/edge-api/pkg/services/files"
 	log "github.com/sirupsen/logrus"
 )
@@ -84,7 +85,7 @@ func NewFilesService(log *log.Entry) FilesService {
 			Credentials: credentials.NewStaticCredentials(cfg.AccessKey, cfg.SecretKey, ""),
 		})
 		if err != nil {
-			panic(err)
+			logger.LogErrorAndPanic("failure creating new session", err)
 		}
 	}
 	client := s3.New(sess)

--- a/pkg/services/mock_services/devices.go
+++ b/pkg/services/mock_services/devices.go
@@ -5,10 +5,11 @@
 package mock_services
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	inventory "github.com/redhatinsights/edge-api/pkg/clients/inventory"
 	models "github.com/redhatinsights/edge-api/pkg/models"
-	reflect "reflect"
 )
 
 // MockDeviceServiceInterface is a mock of DeviceServiceInterface interface

--- a/pkg/services/mock_services/images.go
+++ b/pkg/services/mock_services/images.go
@@ -5,10 +5,11 @@
 package mock_services
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/redhatinsights/edge-api/pkg/models"
 	services "github.com/redhatinsights/edge-api/pkg/services"
-	reflect "reflect"
 )
 
 // MockImageServiceInterface is a mock of ImageServiceInterface interface

--- a/pkg/services/mock_services/repobuilder.go
+++ b/pkg/services/mock_services/repobuilder.go
@@ -5,9 +5,10 @@
 package mock_services
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/redhatinsights/edge-api/pkg/models"
-	reflect "reflect"
 )
 
 // MockRepoBuilderInterface is a mock of RepoBuilderInterface interface

--- a/pkg/services/mock_services/thirdpartyrepo.go
+++ b/pkg/services/mock_services/thirdpartyrepo.go
@@ -5,9 +5,10 @@
 package mock_services
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/redhatinsights/edge-api/pkg/models"
-	reflect "reflect"
 )
 
 // MockThirdPartyRepoServiceInterface is a mock of ThirdPartyRepoServiceInterface interface

--- a/pkg/services/ownershipvoucher.go
+++ b/pkg/services/ownershipvoucher.go
@@ -5,6 +5,7 @@ package services
 
 import (
 	"context"
+
 	log "github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
# Description

Changes panic() to log error, flush bluffers and panic.

Fixes # THEEEDGE-1631

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
