### PR TITLE
THEEDGE-1633 Convert .Fatal() calls to LogErrorAndPanic() and ginkgo …

### DIFF
--- a/edge_api_suite_test.go
+++ b/edge_api_suite_test.go
@@ -1,0 +1,13 @@
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEdgeApi(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "EdgeApi Suite")
+}

--- a/main.go
+++ b/main.go
@@ -121,10 +121,10 @@ func main() {
 		<-sigint
 		log.Info("Shutting down gracefully...")
 		if err := srv.Shutdown(context.Background()); err != nil {
-			log.WithFields(log.Fields{"error": err}).Fatal("HTTP Server Shutdown failed")
+			l.LogErrorAndPanic("HTTP server (web port) shutdown failed", err)
 		}
 		if err := msrv.Shutdown(context.Background()); err != nil {
-			log.WithFields(log.Fields{"error": err}).Fatal("HTTP Server Shutdown failed")
+			l.LogErrorAndPanic("HTTP server (metrics port) shutdown failed", err)
 		}
 		services.WaitGroup.Wait()
 		close(gracefulStop)
@@ -132,7 +132,7 @@ func main() {
 
 	go func() {
 		if err := msrv.ListenAndServe(); err != http.ErrServerClosed {
-			log.WithFields(log.Fields{"error": err}).Fatal("Metrics Service Stopped")
+			l.LogErrorAndPanic("metrics service stopped unexpectedly", err)
 		}
 	}()
 	if cfg.KafkaConfig != nil {
@@ -147,7 +147,7 @@ func main() {
 	}
 
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
-		log.WithFields(log.Fields{"error": err}).Fatal("Service Stopped")
+		l.LogErrorAndPanic("web service stopped unexpectedly", err)
 	}
 
 	<-gracefulStop

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,11 @@
+package main_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	//	. "github.com/onsi/gomega"
+	//	"github.com/redhatinsights/edge-api"
+)
+
+var _ = Describe("Main", func() {
+
+})


### PR DESCRIPTION
…stub files

# Description

Changed *.Fatal() calls to log errors, flush buffers, then panic in a consistent way [LogErrorAndPanic()]
Added stub ginkgo (BDD) files

Fixes # THEEDGE-1633

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
