### PR TITLE
Revert "Download TAR repo: Return full qualified name for tarfile after download"

### DIFF
--- a/pkg/services/repobuilder.go
+++ b/pkg/services/repobuilder.go
@@ -249,9 +249,8 @@ func (rb *RepoBuilder) DownloadVersionRepo(c *models.Commit, dest string) (strin
 	if c.ImageBuildHash != "" {
 		tarFileName = strings.Join([]string{c.ImageBuildHash, "tar"}, ".")
 	}
-	tarFileName = filepath.Join(dest, tarFileName)
 	log.WithField("tarFileName", tarFileName).Debug("Grabbing tar file")
-	_, err = grab.Get(tarFileName, c.ImageBuildTarURL)
+	_, err = grab.Get(filepath.Join(dest, tarFileName), c.ImageBuildTarURL)
 
 	if err != nil {
 		rb.log.WithField("error", err.Error()).Error("Error grabbing tar file")
@@ -312,11 +311,11 @@ func (rb *RepoBuilder) ExtractVersionRepo(c *models.Commit, tarFileName string, 
 	}
 	rb.log = rb.log.WithField("commitID", c.ID)
 	rb.log.Info("Extracting repo")
-	tarFile, err := os.Open(filepath.Clean(tarFileName))
+	tarFile, err := os.Open(filepath.Clean(filepath.Join(dest, tarFileName)))
 	if err != nil {
 		rb.log.WithFields(log.Fields{
 			"error":    err.Error(),
-			"filepath": tarFileName,
+			"filepath": filepath.Join(dest, tarFileName),
 		}).Error("Failed to open file")
 		return err
 	}
@@ -328,7 +327,7 @@ func (rb *RepoBuilder) ExtractVersionRepo(c *models.Commit, tarFileName string, 
 
 	log.Debugf("Unpacking tarball finished::tarFileName: %#v", tarFileName)
 
-	err = os.Remove(tarFileName)
+	err = os.Remove(filepath.Join(dest, tarFileName))
 	if err != nil {
 		rb.log.WithField("error", err.Error()).Error("Error removing tar file")
 		return err

--- a/pkg/services/repobuilder_test.go
+++ b/pkg/services/repobuilder_test.go
@@ -40,12 +40,9 @@ var _ = Describe("RepoBuilder Service Test", func() {
 
 				os.MkdirAll(filePathExtraction, 0755)
 				testFilePath, _ := createTestFile(filePath)
-				testTarFile = filepath.Join(filePath, testTarFile)
-				err := createTarball(testTarFile, testFilePath)
+				createTarball(filepath.Join(filePath, testTarFile), testFilePath)
 
-				Expect(err).ToNot(HaveOccurred())
-
-				err = service.ExtractVersionRepo(commit, testTarFile, filePath)
+				err := service.ExtractVersionRepo(commit, testTarFile, filePath)
 
 				Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Reverts RedHatInsights/edge-api#648

This might cause an error while trying to update devices.