### PR TITLE
Add check if filtering alway return offset 0

### DIFF
--- a/pkg/routes/common/pagination.go
+++ b/pkg/routes/common/pagination.go
@@ -52,13 +52,17 @@ func Paginate(next http.Handler) http.Handler {
 			}
 			pagination.Limit = valInt
 		}
-		if val, ok := r.URL.Query()["offset"]; ok {
-			valInt, err := strconv.Atoi(val[0])
-			if err != nil {
-				errors.NewBadRequest(err.Error())
-				return
+		if r.URL.Query()["name"] != nil {
+			pagination.Offset = 0
+		} else {
+			if val, ok := r.URL.Query()["offset"]; ok {
+				valInt, err := strconv.Atoi(val[0])
+				if err != nil {
+					errors.NewBadRequest(err.Error())
+					return
+				}
+				pagination.Offset = valInt
 			}
-			pagination.Offset = valInt
 		}
 		ctx := context.WithValue(r.Context(), PaginationKey, pagination)
 		next.ServeHTTP(w, r.WithContext(ctx))


### PR DESCRIPTION
# Description

I added a check to paginate func to always return offset of 0 when filtering to avoid the issue described in ticket [THEEDGE-1796](https://issues.redhat.com/browse/THEEDGE-1796)

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `go fmt ./...` to check that my code is properly formatted
- [ ] I run `go vet ./...` to check that my code is free of common Go style mistakes
