### PR TITLE
GetDevice: Fix account info.

### DIFF
--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -124,6 +124,7 @@ func (s *DeviceService) GetDeviceDetails(device inventory.Device) (*models.Devic
 			Device:     databaseDevice,
 			DeviceName: device.DisplayName,
 			LastSeen:   device.LastSeen,
+			Account:    device.Account,
 		},
 		Image:              imageInfo,
 		UpdateTransactions: updates,


### PR DESCRIPTION
FIX account info, even if device  account is defined, we are going to have the EdgeDevice account that is by default always undefined. 

Fixes # THEEDGE-1737

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
