### PR TITLE
add gorm debug to imageset preload join queries

### DIFF
--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -170,7 +170,7 @@ func ListAllImageSets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.URL.Query().Get("sort_by") != "-status" && r.URL.Query().Get("sort_by") != "status" {
-		result = imageSetFilters(r, db.DB.Model(&models.ImageSet{})).
+		result = imageSetFilters(r, db.DB.Debug().Model(&models.ImageSet{})).
 			Limit(pagination.Limit).Offset(pagination.Offset).
 			Preload("Images").
 			Preload("Images.Commit").
@@ -181,7 +181,7 @@ func ListAllImageSets(w http.ResponseWriter, r *http.Request) {
 			Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id AND Images.id = (Select Max(id) from Images where Images.image_set_id = Image_Sets.id)`).
 			Where(`Image_Sets.account = ? `, account).Find(&imageSet)
 	} else {
-		result = imageStatusFilters(r, db.DB.Model(&models.ImageSet{})).Limit(pagination.Limit).Offset(pagination.Offset).
+		result = imageStatusFilters(r, db.DB.Debug().Model(&models.ImageSet{})).Limit(pagination.Limit).Offset(pagination.Offset).
 			Preload("Images", "lower(status) in (?)", strings.ToLower(r.URL.Query().Get("status"))).
 			Preload("Images.Commit").
 			Preload("Images.Installer").


### PR DESCRIPTION
* troubleshooting slow postrgres  SQL responses by exposing SQL in stack
* only adding to the two imageset queries
* will revert when done

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `go fmt ./...` to check that my code is properly formatted
- [ ] I run `go vet ./...` to check that my code is free of common Go style mistakes
