### PR TITLE
Device group delete

### DIFF
--- a/pkg/models/devicegroups.go
+++ b/pkg/models/devicegroups.go
@@ -58,5 +58,5 @@ func (group *DeviceGroup) ValidateRequest() error {
 
 // BeforeDelete is called before deleting a device group, delete the device group devices first
 func (group *DeviceGroup) BeforeDelete(tx *gorm.DB) error {
-	return tx.Where(&Device{Account: group.Account}).Delete(&group.Devices).Error
+	return tx.Model(group).Association("Devices").Delete(&group.Devices)
 }

--- a/pkg/models/devicegroups_test.go
+++ b/pkg/models/devicegroups_test.go
@@ -116,31 +116,25 @@ func TestBeforeDelete(t *testing.T) {
 	if err != nil {
 		t.Error("Error saving device group to DB")
 	}
-	// Check all in DB
-	var deviecsFromDB []Device
-	err = db.DB.Where("account = ?", account).Find(&deviecsFromDB).Error
+	// Get the device group from DB
+	err = db.DB.Where("name = ?", deviceGroupName).Find(&deviceGroup).Error
 	if err != nil {
-		t.Error("Error retrieving devices from DB")
+		t.Error("Error retrieving device group from DB")
 	}
-	if len(deviecsFromDB) != len(devices) {
-		t.Errorf("Expected %d devices but found %d: %v", len(devices), len(deviecsFromDB), deviecsFromDB)
+	if len(deviceGroup.Devices) != 2 {
+		t.Errorf("Expected 2 devices but found %d: %v", len(deviceGroup.Devices), deviceGroup.Devices)
 	}
 	// BeforeDelete the DeviceGroup should delete the Devices and not the DeviceGroup
 	err = deviceGroup.BeforeDelete(db.DB)
 	if err != nil {
 		t.Error("Error running BeforeDelete")
 	}
-	deviecsFromDB = []Device{}
-	err = db.DB.Where("account = ?", account).Find(&deviecsFromDB).Error
-	if err != nil {
-		t.Error("Error retrieving devices from DB")
-	}
-	if len(deviecsFromDB) != 0 {
-		t.Errorf("Expected 0 devices but found %d: %v", len(deviecsFromDB), deviecsFromDB)
-	}
-	var deviceGroupDB DeviceGroup
-	err = db.DB.Where("name = ?", deviceGroupName).Find(&deviceGroupDB).Error
+	// Get the device group from DB
+	err = db.DB.Where("name = ?", deviceGroupName).Find(&deviceGroup).Error
 	if err != nil {
 		t.Error("Error retrieving device group from DB")
+	}
+	if len(deviceGroup.Devices) != 0 {
+		t.Errorf("Expected 0 devices but found %d: %v", len(deviceGroup.Devices), deviceGroup.Devices)
 	}
 }

--- a/pkg/services/devicegroups_test.go
+++ b/pkg/services/devicegroups_test.go
@@ -60,18 +60,8 @@ var _ = Describe("DeviceGroupsService basic functions", func() {
 			Account: account,
 			Devices: devices,
 		}
-		// same account, out of the DeviceGroup
-		outOfGroupDevice := models.Device{
-			Name:    faker.Name(),
-			UUID:    faker.UUIDHyphenated(),
-			Account: account,
-		}
 		It("should create a DeviceGroup", func() {
 			dbResult := db.DB.Create(&deviceGroup).Error
-			Expect(dbResult).To(BeNil())
-		})
-		It("should create out of the device", func() {
-			dbResult := db.DB.Create(&outOfGroupDevice).Error
 			Expect(dbResult).To(BeNil())
 		})
 		It("should get the DeviceGroup ID", func() {
@@ -88,14 +78,10 @@ var _ = Describe("DeviceGroupsService basic functions", func() {
 				dbResult := db.DB.Where("name = ?", deviceGroupName).First(&deviceGroup)
 				Expect(dbResult.Error).NotTo(BeNil())
 			})
-			It("should not find the devices in the DeviceGroup", func() {
+			It("should find the devices in the DB", func() {
 				var devicesFromDB []models.Device
-				db.DB.Where("name in (?)", []string{devices[0].Name, devices[1].Name}).Find(&devicesFromDB)
-				Expect(devicesFromDB).To(BeEmpty())
-			})
-			It("should find the out of the DeviceGroup device", func() {
-				dbResult := db.DB.Where("name = ?", outOfGroupDevice.Name).First(&outOfGroupDevice)
-				Expect(dbResult.Error).To(BeNil())
+				Expect(db.DB.Where("name in (?)", []string{devices[0].Name, devices[1].Name}).Find(&devicesFromDB).Error).To(BeNil())
+				Expect(devicesFromDB).NotTo(BeEmpty())
 			})
 		})
 		It("should fail to delete a DeviceGroup with invalid ID", func() {


### PR DESCRIPTION
# Description

Devices can be shared between groups (many2many), therefore don't remove them from DB. Instead remove them from the associated (joined) table.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
