### PR TITLE
remove extra count imageset query

### DIFF
--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -156,19 +156,6 @@ func ListAllImageSets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	countResult := imageSetFilters(r, db.DB.Model(&models.ImageSet{})).
-		Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id AND Images.id = (Select Max(id) from Images where Images.image_set_id = Image_Sets.id)`).
-		Where(`Image_Sets.account = ? `, account).Count(&count)
-	if countResult.Error != nil {
-		s.Log.WithField("error", countResult.Error.Error()).Error("Error counting results for image sets list")
-		countErr := errors.NewInternalServerError()
-		w.WriteHeader(countErr.GetStatus())
-		if err := json.NewEncoder(w).Encode(&countErr); err != nil {
-			s.Log.WithField("error", countErr.Error()).Error("Error while trying to encode")
-		}
-		return
-	}
-
 	if r.URL.Query().Get("sort_by") != "-status" && r.URL.Query().Get("sort_by") != "status" {
 		result = imageSetFilters(r, db.DB.Debug().Model(&models.ImageSet{})).
 			Limit(pagination.Limit).Offset(pagination.Offset).


### PR DESCRIPTION
* remove count imageset query to cut backend time in half

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Removing extra imageset count query to cut backend time in half (currently 4 extra seconds)

Fixes # (issue) THEEDGE-1800

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
