### PR TITLE
add image build consumer

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,6 +146,7 @@ func main() {
 	consumers := []services.ConsumerService{
 		services.NewKafkaConsumerService(cfg.KafkaConfig, "platform.playbook-dispatcher.runs"),
 		services.NewKafkaConsumerService(cfg.KafkaConfig, "platform.inventory.events"),
+		services.NewKafkaConsumerService(cfg.KafkaConfig, "platform.edge.fleetmgmt.image-build"),
 	}
 	webServer := serveWeb(cfg, consumers)
 	metricsServer := serveMetrics(cfg.MetricsPort)


### PR DESCRIPTION
* Adding a consumer for image build messages
* Currently internal to Edge API image builder mimic

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Add a consumer for image build messages.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
