### PR TITLE
Use gomock.Any() to avoid timestamp failure

### DIFF
--- a/pkg/routes/devicegroups_test.go
+++ b/pkg/routes/devicegroups_test.go
@@ -205,7 +205,7 @@ var _ = Describe("DeviceGroup routes", func() {
 				rr := httptest.NewRecorder()
 
 				// setup mock for DeviceGroupsService
-				mockDeviceGroupsService.EXPECT().AddDeviceGroupDevices(account, deviceGroup.ID, devices).Return(&devices, nil)
+				mockDeviceGroupsService.EXPECT().AddDeviceGroupDevices(account, deviceGroup.ID, gomock.Any()).Return(&devices, nil)
 
 				handler := http.HandlerFunc(AddDeviceGroupDevices)
 				handler.ServeHTTP(rr, req)
@@ -529,7 +529,7 @@ var _ = Describe("DeviceGroup routes", func() {
 				req = req.WithContext(ctx)
 				rr := httptest.NewRecorder()
 
-				mockDeviceGroupsService.EXPECT().DeleteDeviceGroupDevices(account, deviceGroup.ID, devicesToRemove).Return(&devicesToRemove, nil)
+				mockDeviceGroupsService.EXPECT().DeleteDeviceGroupDevices(account, deviceGroup.ID, gomock.Any()).Return(&devicesToRemove, nil)
 				handler := http.HandlerFunc(DeleteDeviceGroupManyDevices)
 				handler.ServeHTTP(rr, req)
 


### PR DESCRIPTION
# Description

Running this suite, there are diff in timestamps.
For example:
	Got: `{2022-03-03 06:47:25.067629969 -0500 EST true}`
	Want: `{2022-03-03 06:47:25.067629969 -0500 -0500 true}`
Depends on location.

Since mock is not testing the service logic, we can defiantly avoid it's result and use gomock.Any().

Fixes `make test-no-fdo` & testing outside of container scope.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `go fmt ./...` to check that my code is properly formatted
- [ ] I run `go vet ./...` to check that my code is free of common Go style mistakes
