### PR TITLE
not return 404 when device not found

### DIFF
--- a/pkg/routes/devices.go
+++ b/pkg/routes/devices.go
@@ -213,7 +213,7 @@ func GetDevices(w http.ResponseWriter, r *http.Request) {
 	services := dependencies.ServicesFromContext(r.Context())
 	params := deviceListFilters(r.URL.Query())
 	inventory, err := services.DeviceService.GetDevices(params)
-	if err != nil || inventory.Count == 0 {
+	if err != nil {
 		err := errors.NewNotFound("No devices found")
 		w.WriteHeader(err.GetStatus())
 		_ = json.NewEncoder(w).Encode(err)

--- a/pkg/routes/devices_test.go
+++ b/pkg/routes/devices_test.go
@@ -89,4 +89,24 @@ var _ = Describe("Devices Router", func() {
 			})
 		})
 	})
+	Context("get list of device", func() {
+
+		When("when device is not found", func() {
+			It("should return 200", func() {
+				req, err := http.NewRequest("GET", "/devices", nil)
+				if err != nil {
+					Expect(err).ToNot(HaveOccurred())
+				}
+				rr := httptest.NewRecorder()
+				handler := http.HandlerFunc(routes.GetDevice)
+				ctx := dependencies.ContextWithServices(req.Context(), &dependencies.EdgeAPIServices{
+					Log: log.NewEntry(log.StandardLogger()),
+				})
+				req = req.WithContext(ctx)
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(http.StatusOK))
+
+			})
+		})
+	})
 })


### PR DESCRIPTION
# Description

Remove 404 when no device was found for an account

Fixes 

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
