### PR TITLE
Set the boundaries for the random number generator

### DIFF
--- a/pkg/services/devicegroups_test.go
+++ b/pkg/services/devicegroups_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 var _ = Describe("DeviceGroupsService basic functions", func() {
+	faker.SetRandomNumberBoundaries(1000, 100000) // set the boundaries for the random number generator - avoids collisions
 	var (
 		ctx                 context.Context
 		deviceGroupsService services.DeviceGroupsServiceInterface


### PR DESCRIPTION
# Description

Avoid collisions by setting the boundaries for the random number generator

Fixes `UNIQUE constraint failed`

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
