### PR TITLE
resume builds after application restart

### DIFF
--- a/main.go
+++ b/main.go
@@ -159,6 +159,11 @@ func main() {
 			}
 		}
 	}
+
+	// Resume builds running during restart
+	imageService := services.NewImageService(context.Background(), log.WithField("service", "image"))
+	imageService.ResumeBuilds()
+
 	<-interruptSignal
 	log.Info("Shutting down gracefully...")
 	gracefulTermination(webServer, "web")

--- a/pkg/services/mock_services/images.go
+++ b/pkg/services/mock_services/images.go
@@ -48,6 +48,18 @@ func (mr *MockImageServiceInterfaceMockRecorder) CreateImage(image, account inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateImage", reflect.TypeOf((*MockImageServiceInterface)(nil).CreateImage), image, account)
 }
 
+// ResumeBuilds mocks base method
+func (m *MockImageServiceInterface) ResumeBuilds() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ResumeBuilds")
+}
+
+// ResumeBuilds indicates an expected call of ResumeBuilds
+func (mr *MockImageServiceInterfaceMockRecorder) ResumeBuilds() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResumeBuilds", reflect.TypeOf((*MockImageServiceInterface)(nil).ResumeBuilds))
+}
+
 // UpdateImage mocks base method
 func (m *MockImageServiceInterface) UpdateImage(image, previousImage *models.Image) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
* Added resume call to main()
* Added ResumeBuilds to ImageService
* Removed WatchGroup/interrupts setting status to Error

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Added resume build after restart of application

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
