### PR TITLE
add device name to device creation based on display name

### DIFF
--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"encoding/json"
+
 	version "github.com/knqyf263/go-rpm-version"
 	"github.com/redhatinsights/edge-api/pkg/clients/inventory"
 	"github.com/redhatinsights/edge-api/pkg/db"
@@ -45,6 +46,7 @@ type PlatformInsightsCreateUpdateEventPayload struct {
 	Type string `json:"type"`
 	Host struct {
 		ID            string `json:"id"`
+		Name          string `json:"display_name"`
 		Account       string `json:"account"`
 		InsightsID    string `json:"insights_id"`
 		SystemProfile struct {
@@ -419,6 +421,7 @@ func (s *DeviceService) ProcessPlatformInventoryUpdatedEvent(message []byte) err
 	}
 	deviceUUID := eventData.Host.ID
 	deviceAccount := eventData.Host.Account
+	deviceName := eventData.Host.Name
 	device, err := s.GetDeviceByUUID(deviceUUID)
 	if err != nil {
 		// create a new device if it does not exist.
@@ -426,6 +429,7 @@ func (s *DeviceService) ProcessPlatformInventoryUpdatedEvent(message []byte) err
 			UUID:        deviceUUID,
 			RHCClientID: eventData.Host.InsightsID,
 			Account:     deviceAccount,
+			Name:        deviceName,
 		}
 		if result := db.DB.Create(&newDevice); result.Error != nil {
 			s.log.WithFields(log.Fields{"host_id": deviceUUID, "error": result.Error}).Error("Error creating device")


### PR DESCRIPTION
# Description

The current action to create a device is not registering the device name and we need to display this info at the UI.
I've added the code to read and insert the value, we must check the old data.

Fixes # ([issue](https://issues.redhat.com/browse/THEEDGE-1839))

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
