### PR TITLE
Add additional data for device groups by id

### DIFF
--- a/pkg/models/devicegroups.go
+++ b/pkg/models/devicegroups.go
@@ -2,8 +2,9 @@ package models
 
 import (
 	"errors"
-	"gorm.io/gorm"
 	"regexp"
+
+	"gorm.io/gorm"
 )
 
 // DeviceGroup is a record of Edge Devices Groups
@@ -15,6 +16,11 @@ type DeviceGroup struct {
 	Name    string   `json:"Name"`
 	Type    string   `json:"Type" gorm:"default:static;<-:create"`
 	Devices []Device `json:"Devices" gorm:"many2many:device_groups_devices;"`
+}
+
+type DeviceGroupDetails struct {
+	DeviceGroup   *DeviceGroup       `json:"Device Group"`
+	DeviceDetails *DeviceDetailsList `json:"Devices" gorm:"many2many:device_groups_devices;"`
 }
 
 var (

--- a/pkg/routes/devicegroups_test.go
+++ b/pkg/routes/devicegroups_test.go
@@ -199,7 +199,9 @@ var _ = Describe("DeviceGroup routes", func() {
 		When("all is valid", func() {
 			It("should add devices to DeviceGroup", func() {
 				ctx := req.Context()
-				ctx = setContextDeviceGroup(ctx, &deviceGroup)
+				ctx = setContextDeviceGroup(ctx, &models.DeviceGroupDetails{
+					DeviceGroup: &deviceGroup,
+				})
 				ctx = dependencies.ContextWithServices(ctx, edgeAPIServices)
 				req = req.WithContext(ctx)
 				rr := httptest.NewRecorder()
@@ -229,7 +231,9 @@ var _ = Describe("DeviceGroup routes", func() {
 			Expect(err).To(BeNil())
 			It("should create DeviceGroup", func() {
 				ctx := req.Context()
-				ctx = setContextDeviceGroup(ctx, deviceGroup)
+				ctx = setContextDeviceGroup(ctx, &models.DeviceGroupDetails{
+					DeviceGroup: deviceGroup,
+				})
 				ctx = dependencies.ContextWithServices(ctx, edgeAPIServices)
 				req = req.WithContext(ctx)
 				rr := httptest.NewRecorder()
@@ -257,7 +261,9 @@ var _ = Describe("DeviceGroup routes", func() {
 			It("should return 400", func() {
 				config.Get().Auth = true // enable auth to avoid default account
 				ctx := req.Context()
-				ctx = setContextDeviceGroup(ctx, deviceGroup)
+				ctx = setContextDeviceGroup(ctx, &models.DeviceGroupDetails{
+					DeviceGroup: deviceGroup,
+				})
 				ctx = dependencies.ContextWithServices(ctx, edgeAPIServices)
 				req = req.WithContext(ctx)
 				rr := httptest.NewRecorder()
@@ -286,7 +292,9 @@ var _ = Describe("DeviceGroup routes", func() {
 		When("all is valid", func() {
 			It("should update DeviceGroup", func() {
 				ctx := req.Context()
-				ctx = setContextDeviceGroup(ctx, deviceGroupUpdated)
+				ctx = setContextDeviceGroup(ctx, &models.DeviceGroupDetails{
+					DeviceGroup: deviceGroupUpdated,
+				})
 				ctx = dependencies.ContextWithServices(ctx, edgeAPIServices)
 				req = req.WithContext(ctx)
 				rr := httptest.NewRecorder()
@@ -338,7 +346,9 @@ var _ = Describe("DeviceGroup routes", func() {
 
 			It("should return status code 200", func() {
 				ctx := req.Context()
-				ctx = setContextDeviceGroup(ctx, deviceGroup)
+				ctx = setContextDeviceGroup(ctx, &models.DeviceGroupDetails{
+					DeviceGroup: deviceGroup,
+				})
 				ctx = dependencies.ContextWithServices(ctx, edgeAPIServices)
 				req = req.WithContext(ctx)
 				rr := httptest.NewRecorder()
@@ -378,12 +388,13 @@ var _ = Describe("DeviceGroup routes", func() {
 
 			It("should return status code 400", func() {
 				ctx := req.Context()
-				ctx = setContextDeviceGroup(ctx, &models.DeviceGroup{
-					Model: models.Model{
-						ID: fakeIDUint,
-					},
-					Account: "",
-				})
+				ctx = setContextDeviceGroup(ctx, &models.DeviceGroupDetails{
+					DeviceGroup: &models.DeviceGroup{
+						Model: models.Model{
+							ID: fakeIDUint,
+						},
+						Account: "",
+					}})
 				ctx = dependencies.ContextWithServices(ctx, edgeAPIServices)
 				req = req.WithContext(ctx)
 				rr := httptest.NewRecorder()
@@ -406,11 +417,12 @@ var _ = Describe("DeviceGroup routes", func() {
 
 			It("should return status code 404", func() {
 				ctx := req.Context()
-				ctx = setContextDeviceGroup(ctx, &models.DeviceGroup{
-					Model: models.Model{
-						ID: fakeIDUint,
-					},
-				})
+				ctx = setContextDeviceGroup(ctx, &models.DeviceGroupDetails{
+					DeviceGroup: &models.DeviceGroup{
+						Model: models.Model{
+							ID: fakeIDUint,
+						},
+					}})
 				ctx = dependencies.ContextWithServices(ctx, edgeAPIServices)
 				req = req.WithContext(ctx)
 				rr := httptest.NewRecorder()
@@ -433,11 +445,12 @@ var _ = Describe("DeviceGroup routes", func() {
 
 			It("should return status code 500", func() {
 				ctx := req.Context()
-				ctx = setContextDeviceGroup(ctx, &models.DeviceGroup{
-					Model: models.Model{
-						ID: fakeIDUint,
-					},
-				})
+				ctx = setContextDeviceGroup(ctx, &models.DeviceGroupDetails{
+					DeviceGroup: &models.DeviceGroup{
+						Model: models.Model{
+							ID: fakeIDUint,
+						},
+					}})
 				ctx = dependencies.ContextWithServices(ctx, edgeAPIServices)
 				req = req.WithContext(ctx)
 				rr := httptest.NewRecorder()
@@ -500,7 +513,9 @@ var _ = Describe("DeviceGroup routes", func() {
 				Expect(err).To(BeNil())
 
 				ctx := req.Context()
-				ctx = setContextDeviceGroup(ctx, &deviceGroup)
+				ctx = setContextDeviceGroup(ctx, &models.DeviceGroupDetails{
+					DeviceGroup: &deviceGroup,
+				})
 				ctx = setContextDeviceGroupDevice(ctx, &devicesToRemove[0])
 				ctx = dependencies.ContextWithServices(ctx, edgeAPIServices)
 				req = req.WithContext(ctx)
@@ -523,7 +538,9 @@ var _ = Describe("DeviceGroup routes", func() {
 				Expect(err).To(BeNil())
 
 				ctx := req.Context()
-				ctx = setContextDeviceGroup(ctx, &deviceGroup)
+				ctx = setContextDeviceGroup(ctx, &models.DeviceGroupDetails{
+					DeviceGroup: &deviceGroup,
+				})
 				ctx = dependencies.ContextWithServices(ctx, edgeAPIServices)
 				req = req.WithContext(ctx)
 				rr := httptest.NewRecorder()
@@ -542,7 +559,9 @@ var _ = Describe("DeviceGroup routes", func() {
 				Expect(err).To(BeNil())
 
 				ctx := req.Context()
-				ctx = setContextDeviceGroup(ctx, &deviceGroup)
+				ctx = setContextDeviceGroup(ctx, &models.DeviceGroupDetails{
+					DeviceGroup: &deviceGroup,
+				})
 				ctx = dependencies.ContextWithServices(ctx, edgeAPIServices)
 				req = req.WithContext(ctx)
 				rr := httptest.NewRecorder()

--- a/pkg/services/devicegroups.go
+++ b/pkg/services/devicegroups.go
@@ -6,6 +6,7 @@ import (
 
 	"gorm.io/gorm"
 
+	"github.com/redhatinsights/edge-api/pkg/clients/inventory"
 	"github.com/redhatinsights/edge-api/pkg/db"
 	"github.com/redhatinsights/edge-api/pkg/models"
 	"github.com/redhatinsights/edge-api/pkg/routes/common"
@@ -27,7 +28,7 @@ type DeviceGroupsServiceInterface interface {
 	CreateDeviceGroup(deviceGroup *models.DeviceGroup) (*models.DeviceGroup, error)
 	GetDeviceGroups(account string, limit int, offset int, tx *gorm.DB) (*[]models.DeviceGroup, error)
 	GetDeviceGroupsCount(account string, tx *gorm.DB) (int64, error)
-	GetDeviceGroupByID(ID string) (*models.DeviceGroup, error)
+	GetDeviceGroupByID(ID string) (*models.DeviceGroupDetails, error)
 	DeleteDeviceGroupByID(ID string) error
 	UpdateDeviceGroup(deviceGroup *models.DeviceGroup, account string, ID string) error
 	GetDeviceGroupDeviceByID(account string, deviceGroupID uint, deviceID uint) (*models.Device, error)
@@ -38,12 +39,14 @@ type DeviceGroupsServiceInterface interface {
 // DeviceGroupsService is the main implementation of a DeviceGroupsServiceInterface
 type DeviceGroupsService struct {
 	Service
+	DeviceService DeviceServiceInterface
 }
 
 // NewDeviceGroupsService return an instance of the main implementation of a DeviceGroupsServiceInterface
 func NewDeviceGroupsService(ctx context.Context, log *log.Entry) DeviceGroupsServiceInterface {
 	return &DeviceGroupsService{
-		Service: Service{ctx: ctx, log: log.WithField("service", "device-groups")},
+		Service:       Service{ctx: ctx, log: log.WithField("service", "device-groups")},
+		DeviceService: NewDeviceService(ctx, log),
 	}
 }
 
@@ -141,17 +144,38 @@ func (s *DeviceGroupsService) CreateDeviceGroup(deviceGroup *models.DeviceGroup)
 }
 
 // GetDeviceGroupByID gets the device group by ID from the database
-func (s *DeviceGroupsService) GetDeviceGroupByID(ID string) (*models.DeviceGroup, error) {
-	var deviceGroup models.DeviceGroup
+func (s *DeviceGroupsService) GetDeviceGroupByID(ID string) (*models.DeviceGroupDetails, error) {
+	//var deviceGroup models.DeviceGroup
+	var deviceGroupDetails models.DeviceGroupDetails
 	account, err := common.GetAccountFromContext(s.ctx)
 	if err != nil {
-		return nil, new(AccountNotSet)
+		fmt.Printf("\n Error account %v \n", err)
 	}
-	result := db.DB.Where("account = ? and id = ?", account, ID).Preload("Devices").First(&deviceGroup)
+	result := db.DB.Where("account = ? and id = ?", account, ID).Preload("Devices").First(&deviceGroupDetails.DeviceGroup)
 	if result.Error != nil {
 		return nil, new(DeviceGroupNotFound)
 	}
-	return &deviceGroup, nil
+
+	if len(deviceGroupDetails.DeviceGroup.Devices) > 0 {
+		var devices models.DeviceDetailsList
+		for _, device := range deviceGroupDetails.DeviceGroup.Devices {
+			param := new(inventory.Params)
+			param.HostnameOrID = device.UUID
+			inventoryDevice, err := s.DeviceService.GetDevices(param)
+			if err != nil {
+				fmt.Printf("\n ERROR %v", err)
+			}
+			if len(inventoryDevice.Devices) > 0 {
+				devices.Total = devices.Total + 1
+				devices.Count = devices.Count + 1
+				devices.Devices = append(devices.Devices, inventoryDevice.Devices...)
+			}
+		}
+
+		deviceGroupDetails.DeviceDetails = &devices
+	}
+
+	return &deviceGroupDetails, nil
 }
 
 // UpdateDeviceGroup update an existent group
@@ -161,9 +185,9 @@ func (s *DeviceGroupsService) UpdateDeviceGroup(deviceGroup *models.DeviceGroup,
 	if err != nil {
 		s.log.WithField("error", err.Error()).Error("Error retrieving device group")
 	}
-	if groupDetails.Name != "" {
-		groupDetails.Name = deviceGroup.Name
-		deviceGroupExists, err := deviceGroupNameExists(groupDetails.Account, groupDetails.Name)
+	if groupDetails.DeviceGroup.Name != "" {
+		groupDetails.DeviceGroup.Name = deviceGroup.Name
+		deviceGroupExists, err := deviceGroupNameExists(groupDetails.DeviceGroup.Account, groupDetails.DeviceGroup.Name)
 		if err != nil {
 			s.log.WithField("error", err.Error()).Error("Error when checking if device group exists")
 			return err

--- a/pkg/services/mock_services/devicegroups.go
+++ b/pkg/services/mock_services/devicegroups.go
@@ -80,10 +80,10 @@ func (mr *MockDeviceGroupsServiceInterfaceMockRecorder) GetDeviceGroupsCount(acc
 }
 
 // GetDeviceGroupByID mocks base method
-func (m *MockDeviceGroupsServiceInterface) GetDeviceGroupByID(ID string) (*models.DeviceGroup, error) {
+func (m *MockDeviceGroupsServiceInterface) GetDeviceGroupByID(ID string) (*models.DeviceGroupDetails, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDeviceGroupByID", ID)
-	ret0, _ := ret[0].(*models.DeviceGroup)
+	ret0, _ := ret[0].(*models.DeviceGroupDetails)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
# Description

Add additional data for the device property for /device-groups/{id} to match the data that is returned for /devices so the UI can display a list for devices that belong to a device-group.

Fixes # ([THEEDGE-1831](https://issues.redhat.com/browse/THEEDGE-1831))

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
