### PR TITLE
THEEDGE-1922: Add temporary indexes to relieve production issue

### DIFF
--- a/pkg/models/devices.go
+++ b/pkg/models/devices.go
@@ -33,14 +33,16 @@ type DeviceDetailsList struct {
 //
 //	Connected refers to the devices Cloud Connector state, 0 is unavailable
 //	and 1 is reachable.
+//
+// THEEDGE-1921 created 2 temporary indexes to address production issue
 type Device struct {
 	Model
-	UUID          string      `json:"UUID"`
+	UUID          string      `gorm:"index" json:"UUID"`
 	AvailableHash string      `json:"AvailableHash,omitempty"`
 	RHCClientID   string      `json:"RHCClientID"`
 	Connected     bool        `gorm:"default:true" json:"Connected"`
 	Name          string      `json:"Name"`
 	LastSeen      EdgeAPITime `json:"LastSeen"`
 	CurrentHash   string      `json:"CurrentHash,omitempty"`
-	Account       string      `json:"Account"`
+	Account       string      `gorm:"index" json:"Account"`
 }

--- a/pkg/models/devices_test.go
+++ b/pkg/models/devices_test.go
@@ -1,0 +1,11 @@
+package models_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	// . "github.com/onsi/gomega"
+	// "github.com/redhatinsights/edge-api/pkg/models"
+)
+
+var _ = Describe("Devices", func() {
+
+})


### PR DESCRIPTION
# Description

Add temporary indexes to devices table to relieve production issue with pegged CPUs.  Index refinement will be addressed later.

Fixes # THEEDGE-1922

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
