### PR TITLE
THEEDGE-1714 interrupted build set to interrupted fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,6 +133,8 @@ func gracefulTermination(server *http.Server, serviceName string) {
 }
 
 func main() {
+	// this only catches interrupts for main
+	// see images for image build interrupt
 	interruptSignal := make(chan os.Signal, 1)
 	signal.Notify(interruptSignal, os.Interrupt, syscall.SIGTERM)
 
@@ -160,11 +162,7 @@ func main() {
 		}
 	}
 
-	// Resume builds running during restart
-	// TODO: refactor this out to ibvents pod
-	imageService := services.NewImageService(context.Background(), log.WithField("service", "image"))
-	imageService.ResumeBuilds()
-
+	// block here and shut things down on interrupt
 	<-interruptSignal
 	log.Info("Shutting down gracefully...")
 	gracefulTermination(webServer, "web")

--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -77,14 +77,16 @@ const (
 	// ImageTypeCommit is the installer image type on Image Builder
 	ImageTypeCommit = "rhel-edge-commit"
 
-	// ImageStatusCreated is for when a image is created
+	// ImageStatusCreated is for when an image is created
 	ImageStatusCreated = "CREATED"
-	// ImageStatusBuilding is for when a image is building
+	// ImageStatusBuilding is for when an image is building
 	ImageStatusBuilding = "BUILDING"
-	// ImageStatusError is for when a image is on a error state
+	// ImageStatusError is for when an image is on a error state
 	ImageStatusError = "ERROR"
-	// ImageStatusSuccess is for when a image is available to the user
+	// ImageStatusSuccess is for when an image is available to the user
 	ImageStatusSuccess = "SUCCESS"
+	// ImageStatusInterrupted is for when an image build is interrupted
+	ImageStatusInterrupted = "INTERRUPTED"
 
 	// MissingInstaller is the error message for not passing an installer in the request
 	MissingInstaller = "installer info must be provided"

--- a/pkg/services/mock_services/images.go
+++ b/pkg/services/mock_services/images.go
@@ -115,6 +115,18 @@ func (mr *MockImageServiceInterfaceMockRecorder) SetErrorStatusOnImage(err, i in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetErrorStatusOnImage", reflect.TypeOf((*MockImageServiceInterface)(nil).SetErrorStatusOnImage), err, i)
 }
 
+// SetInterruptedStatusOnImage mocks base method
+func (m *MockImageServiceInterface) SetInterruptedStatusOnImage(err error, i *models.Image) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetInterruptedStatusOnImage", err, i)
+}
+
+// SetInterruptedStatusOnImage indicates an expected call of SetInterruptedStatusOnImage
+func (mr *MockImageServiceInterfaceMockRecorder) SetInterruptedStatusOnImage(err, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInterruptedStatusOnImage", reflect.TypeOf((*MockImageServiceInterface)(nil).SetInterruptedStatusOnImage), err, i)
+}
+
 // CreateRepoForImage mocks base method
 func (m *MockImageServiceInterface) CreateRepoForImage(i *models.Image) (*models.Repo, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
* Re-added interrupt code to images service using context
* Added an interrupted constant to models
* commented the interrupt in main to distinguish between the two
* minor typo fix (a to an)
* removed ResumeBuilds() call from main
* Added SetInterruptedStatusOnImage function to update database

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Refactored and fixed interrupt routine for images

Fixes # (issue) THEEDGE-1714

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
