### PR TITLE
call notification on image creation; remove temp route; clean code

### DIFF
--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -47,7 +47,6 @@ func MakeImagesRouter(sub chi.Router) {
 		r.Post("/kickstart", CreateKickStartForImage)
 		r.Post("/update", CreateImageUpdate)
 		r.Post("/retry", RetryCreateImage)
-		r.Get("/notify", SendNotificationForImage) //TMP ROUTE TO SEND THE NOTIFICATION
 	})
 }
 
@@ -621,28 +620,6 @@ func RetryCreateImage(w http.ResponseWriter, r *http.Request) {
 		err := services.ImageService.RetryCreateImage(image)
 		if err != nil {
 			services.Log.WithField("error", err.Error()).Error("Failed to retry to create image")
-			err := errors.NewInternalServerError()
-			err.SetTitle("Failed creating image")
-			w.WriteHeader(err.GetStatus())
-			if err := json.NewEncoder(w).Encode(&err); err != nil {
-				services.Log.WithField("error", err.Error()).Error("Error while trying to encode")
-			}
-			return
-		}
-		w.WriteHeader(http.StatusCreated)
-		if err := json.NewEncoder(w).Encode(&image); err != nil {
-			services.Log.WithField("error", image).Error("Error while trying to encode")
-		}
-	}
-}
-
-//SendNotificationForImage TMP route to validate
-func SendNotificationForImage(w http.ResponseWriter, r *http.Request) {
-	if image := getImage(w, r); image != nil {
-		services := dependencies.ServicesFromContext(r.Context())
-		_, err := services.ImageService.SendImageNotification(image)
-		if err != nil {
-			services.Log.WithField("error", err.Error()).Error("Failed to retry to send notification")
 			err := errors.NewInternalServerError()
 			err.SetTitle("Failed creating image")
 			w.WriteHeader(err.GetStatus())

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -104,8 +104,11 @@ func ValidateAllImageReposAreFromAccount(account string, repos []models.ThirdPar
 func (s *ImageService) CreateImage(image *models.Image, account string) error {
 
 	//Send Image creation to notification
-	s.SendImageNotification(image)
+	_, errNotify := s.SendImageNotification(image)
+	if errNotify != nil {
+		s.log.WithField("message", errNotify.Error()).Error("Error to send notification")
 
+	}
 	// Check for existing ImageSet and return if exists
 	// TODO: this routine needs to become a function under imagesets
 	var imageSetExists bool

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -1206,7 +1206,7 @@ func (s *ImageService) SendImageNotification(i *models.Image) (ImageNotification
 
 		recipient.IgnoreUserPreferences = false
 		recipient.OnlyAdmins = false
-		users = append(users, NotificationConfigUseres)
+		users = append(users, NotificationConfigUser)
 		recipient.Users = users
 		recipients = append(recipients, recipient)
 

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -103,7 +103,8 @@ func ValidateAllImageReposAreFromAccount(account string, repos []models.ThirdPar
 // CreateImage creates an Image for an Account on Image Builder and on our database
 func (s *ImageService) CreateImage(image *models.Image, account string) error {
 
-	// s.SendImageNotification(image) SHOULD BE INCLUDED ONCE WE COMPLETE THE NOTIFICATION
+	//Send Image creation to notification
+	s.SendImageNotification(image)
 
 	// Check for existing ImageSet and return if exists
 	// TODO: this routine needs to become a function under imagesets
@@ -1160,8 +1161,7 @@ func (s *ImageService) GetRollbackImage(image *models.Image) (*models.Image, err
 
 // SendImageNotification connects to platform.notifications.ingress on image topic
 func (s *ImageService) SendImageNotification(i *models.Image) (ImageNotification, error) {
-	//the code will be modified due to stage results
-	// s.log.WithField("message", i).Debug("SendImageNotification::Image")
+
 	var notify ImageNotification
 	notify.Version = NotificationConfigVersion
 	notify.Bundle = NotificationConfigBundle
@@ -1177,20 +1177,18 @@ func (s *ImageService) SendImageNotification(i *models.Image) (ImageNotification
 		var recipient RecipientNotification
 		brokers := make([]string, len(clowder.LoadedConfig.Kafka.Brokers))
 
-		fmt.Printf("\nSendImageNotification:brokers %v\n", brokers)
 		for i, b := range clowder.LoadedConfig.Kafka.Brokers {
 			brokers[i] = fmt.Sprintf("%s:%d", b.Hostname, *b.Port)
 			fmt.Println(brokers[i])
 		}
 
 		topic := NotificationTopic
-		fmt.Printf("\nSendImageNotification:topic: %v\n", topic)
+
 		// Create Producer instance
 		p, err := kafka.NewProducer(&kafka.ConfigMap{
-			// "bootstrap.servers": "platform-mq-kafka-bootstrap.platform-mq-stage.svc:9092"})
 			"bootstrap.servers": brokers[0]})
 		if err != nil {
-			fmt.Printf("Failed to create producer: %s", err)
+			s.log.WithField("message", err.Error()).Error("producer")
 			os.Exit(1)
 		}
 
@@ -1208,7 +1206,7 @@ func (s *ImageService) SendImageNotification(i *models.Image) (ImageNotification
 
 		recipient.IgnoreUserPreferences = false
 		recipient.OnlyAdmins = false
-		users = append(users, "anferrei")
+		users = append(users, NotificationConfigUseres)
 		recipient.Users = users
 		recipients = append(recipients, recipient)
 
@@ -1217,30 +1215,24 @@ func (s *ImageService) SendImageNotification(i *models.Image) (ImageNotification
 		notify.Events = events
 		notify.Recipients = recipients
 
-		fmt.Printf("\n ############## notify: ############ %v\n", notify)
-		s.log.WithField("message", notify).Debug("Message to be sent")
-
 		// assemble the message to be sent
-		// TODO: formalize message formats
 		recordKey := "ImageCreationStarts"
 		recordValue, _ := json.Marshal(notify)
-		fmt.Printf("\n ############## recordValue: ############ %v\n", string(recordValue))
-		// s.log.WithField("message", recordKey).Debug("Preparing record for producer")
-		s.log.WithField("message", string(recordValue)).Debug("RecordValue")
+
+		s.log.WithField("message", recordValue).Debug("Preparing record for producer")
+
 		// send the message
 		perr := p.Produce(&kafka.Message{
 			TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: kafka.PartitionAny},
 			Key:            []byte(recordKey),
 			Value:          []byte(recordValue),
 		}, nil)
-		s.log.WithField("message", perr).Debug("after p.Produce")
+
 		if perr != nil {
 			s.log.WithField("message", perr.Error()).Error("Error on produce")
-			fmt.Printf("\nError sending message: %v\n", perr)
 			return notify, err
 		}
 		// Wait for all messages to be delivered
-		p.Flush(15 * 1000)
 		p.Close()
 		return notify, nil
 	}

--- a/pkg/services/notification_config.go
+++ b/pkg/services/notification_config.go
@@ -37,4 +37,6 @@ const (
 	NotificationConfigApplication = "fleet-management"
 	//NotificationConfigEventTypeImage to be used
 	NotificationConfigEventTypeImage = "image-creation"
+	//NotificationConfigUseres to be used
+	NotificationConfigUseres = "fleet-management"
 )

--- a/pkg/services/notification_config.go
+++ b/pkg/services/notification_config.go
@@ -37,6 +37,6 @@ const (
 	NotificationConfigApplication = "fleet-management"
 	//NotificationConfigEventTypeImage to be used
 	NotificationConfigEventTypeImage = "image-creation"
-	//NotificationConfigUseres to be used
+	//NotificationConfigUser to be used
 	NotificationConfigUser = "fleet-management"
 )

--- a/pkg/services/notification_config.go
+++ b/pkg/services/notification_config.go
@@ -38,5 +38,5 @@ const (
 	//NotificationConfigEventTypeImage to be used
 	NotificationConfigEventTypeImage = "image-creation"
 	//NotificationConfigUseres to be used
-	NotificationConfigUseres = "fleet-management"
+	NotificationConfigUser = "fleet-management"
 )


### PR DESCRIPTION
# Description

After tested the notification over the temp route, I'm fixing the call to be fired when we create the image.
Removed tmp route and old coments

Fixes # ([THEEDGE-1439](https://issues.redhat.com/browse/THEEDGE-1439))

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
