### PR TITLE
fix image struct dereference on interrupt update

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -520,7 +520,7 @@ func (s *ImageService) postProcessImage(id uint) {
 	s.log.Debug("Processing image build")
 	// get image data from DB based on image.ID
 	var i *models.Image
-	var currentBuildImage *models.Image
+	//var currentBuildImage *models.Image
 
 	// setup a context and signal for SIGTERM
 	ctx := context.Background()
@@ -555,11 +555,11 @@ func (s *ImageService) postProcessImage(id uint) {
 			// set build status to INTERRUPTED
 			s.SetInterruptedStatusOnImage(nil, currentBuildImage)
 			*/
-			currentBuildImage.ID = id
-			currentBuildImage.Status = models.ImageStatusInterrupted
-			s.log.WithField("status", currentBuildImage.Status).Info("Setting Image to INTERRUPTED in DB")
-			tx := db.DB.Debug().Model(&currentBuildImage).Update("Status", id)
-			s.log.WithField("status", currentBuildImage.Status).Debug("Image updated with interrupted status")
+			//currentBuildImage.ID = id
+			//currentBuildImage.Status = models.ImageStatusInterrupted
+			//s.log.WithField("status", currentBuildImage.Status).Info("Setting Image to INTERRUPTED in DB")
+			tx := db.DB.Debug().Model(&models.Image{}).Where("ID = ?", id).Update("Status", models.ImageStatusInterrupted)
+			s.log.WithField("imageID", id).Debug("Image updated with interrupted status")
 			if tx.Error != nil {
 				s.log.WithField("error", tx.Error.Error()).Error("Error updating image")
 			}


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Changing the update interrupted query to avoid possible dereference

Fixes # (issue) THEEDGE-1874

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
