### PR TITLE
THEEDGE-1940 test fix for init container error versus interrupt status

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -33,40 +33,43 @@ func main() {
 	}).Info("Configuration Values:")
 	db.InitDB()
 
-	// If there any image builds in progress, in the current architecture, we need to set them as errors because this is a brand new deployment
-	var images []models.Image
-	db.DB.Where(&models.Image{Status: models.ImageStatusBuilding}).Find(&images)
-	for _, image := range images {
-		log.WithField("imageID", image.ID).Debug("Found image with building status")
-		image.Status = models.ImageStatusError
-		if image.Commit != nil {
-			image.Commit.Status = models.ImageStatusError
-			if image.Commit.Repo != nil {
-				image.Commit.Repo.Status = models.RepoStatusError
-				db.DB.Save(image.Commit.Repo)
+	/*
+		// FIXME: this can create issues when only one out of many replicas evicts
+		// If there any image builds in progress, in the current architecture, we need to set them as errors because this is a brand new deployment
+		var images []models.Image
+		db.DB.Where(&models.Image{Status: models.ImageStatusBuilding}).Find(&images)
+		for _, image := range images {
+			log.WithField("imageID", image.ID).Debug("Found image with building status")
+			image.Status = models.ImageStatusError
+			if image.Commit != nil {
+				image.Commit.Status = models.ImageStatusError
+				if image.Commit.Repo != nil {
+					image.Commit.Repo.Status = models.RepoStatusError
+					db.DB.Save(image.Commit.Repo)
+				}
+				db.DB.Save(image.Commit)
 			}
-			db.DB.Save(image.Commit)
+			if image.Installer != nil {
+				image.Installer.Status = models.ImageStatusError
+				db.DB.Save(image.Installer)
+			}
+			db.DB.Save(image)
 		}
-		if image.Installer != nil {
-			image.Installer.Status = models.ImageStatusError
-			db.DB.Save(image.Installer)
-		}
-		db.DB.Save(image)
-	}
 
-	// If there any updates in progress, in the current architecture, we need to set them as errors because this is a brand new deployment
-	var updates []models.UpdateTransaction
-	db.DB.Where(&models.UpdateTransaction{Status: models.UpdateStatusBuilding}).Or(&models.UpdateTransaction{Status: models.UpdateStatusCreated}).Find(&updates)
-	for _, update := range updates {
-		log.WithField("updateID", update.ID).Debug("Found update with building status")
-		update.Status = models.UpdateStatusError
-		if update.Repo != nil {
-			update.Repo.Status = models.RepoStatusError
-			db.DB.Save(update.Repo)
+		// FIXME: this runs into an issue when only one of many pods is evicted and restarts...
+		// If there any updates in progress, in the current architecture, we need to set them as errors because this is a brand new deployment
+		var updates []models.UpdateTransaction
+		db.DB.Where(&models.UpdateTransaction{Status: models.UpdateStatusBuilding}).Or(&models.UpdateTransaction{Status: models.UpdateStatusCreated}).Find(&updates)
+		for _, update := range updates {
+			log.WithField("updateID", update.ID).Debug("Found update with building status")
+			update.Status = models.UpdateStatusError
+			if update.Repo != nil {
+				update.Repo.Status = models.RepoStatusError
+				db.DB.Save(update.Repo)
+			}
+			db.DB.Save(update)
 		}
-		db.DB.Save(update)
-	}
-
+	*/
 	// Automigration
 	err := db.DB.AutoMigrate(&models.ImageSet{},
 		&models.Commit{}, &models.UpdateTransaction{},


### PR DESCRIPTION
* two issues:
* 	1. problems if only one pod of many restarts
* 	2. they restart in a staggered manner...
*		so this steps on status set to INTERRUPTED

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

The init container starts in each pod so setting BUILDING to ERROR at start
  can error out valid builds running on other pods.
Second issue is related to when all pods are restarting gracefully, they do not
  stop and start at the same time. There is a cascade, so BUILDING status can
  be wiped before being set to INTERRUPTED.

Fixes # (issue) THEEDGE-1940

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
