### PR TITLE
THEEDGE-1714 add infinite loop for builds with interrupted status

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -89,7 +89,7 @@ objects:
             cpu: 500m
             memory: 512Mi
     - name: ibvents
-      minReplicas: 0
+      minReplicas: 1
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         command:

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -312,13 +312,10 @@ func (s *ImageService) postProcessInstaller(image *models.Image) error {
 			// if clowder is enabled, send an event on Image Build completion
 			// TODO: break this out into its own function
 			if clowder.IsClowderEnabled() {
-				fmt.Printf("Public Port: %d\n", clowder.LoadedConfig.PublicPort)
-
 				// get the list of brokers from the config
 				brokers := make([]string, len(clowder.LoadedConfig.Kafka.Brokers))
 				for i, b := range clowder.LoadedConfig.Kafka.Brokers {
 					brokers[i] = fmt.Sprintf("%s:%d", b.Hostname, *b.Port)
-					fmt.Println(brokers[i])
 				}
 
 				topic := "platform.edge.fleetmgmt.image-build"
@@ -327,7 +324,7 @@ func (s *ImageService) postProcessInstaller(image *models.Image) error {
 				p, err := kafka.NewProducer(&kafka.ConfigMap{
 					"bootstrap.servers": brokers[0]})
 				if err != nil {
-					fmt.Printf("Failed to create producer: %s", err)
+					s.log.WithField("error", err).Error("Failed to create producer")
 					os.Exit(1)
 				}
 
@@ -342,14 +339,14 @@ func (s *ImageService) postProcessInstaller(image *models.Image) error {
 					Value:          []byte(recordValue),
 				}, nil)
 				if perr != nil {
-					fmt.Println("Error sending message")
+					s.log.Error("Error sending message")
 				}
 
 				// Wait for all messages to be delivered
 				p.Flush(15 * 1000)
 				p.Close()
 
-				fmt.Printf("postProcessInstaller message was produced to topic %s!\n", topic)
+				s.log.WithField("topic", topic).Debug("postProcessInstaller message was produced to topic")
 			}
 
 			break
@@ -387,13 +384,10 @@ func (s *ImageService) postProcessCommit(image *models.Image) error {
 			// if clowder is enabled, send an event on Image Build completion
 			// TODO: break this out into its own function
 			if clowder.IsClowderEnabled() {
-				fmt.Printf("Public Port: %d\n", clowder.LoadedConfig.PublicPort)
-
 				// get the list of brokers from the config
 				brokers := make([]string, len(clowder.LoadedConfig.Kafka.Brokers))
 				for i, b := range clowder.LoadedConfig.Kafka.Brokers {
 					brokers[i] = fmt.Sprintf("%s:%d", b.Hostname, *b.Port)
-					fmt.Println(brokers[i])
 				}
 
 				topic := "platform.edge.fleetmgmt.image-build"
@@ -402,7 +396,7 @@ func (s *ImageService) postProcessCommit(image *models.Image) error {
 				p, err := kafka.NewProducer(&kafka.ConfigMap{
 					"bootstrap.servers": brokers[0]})
 				if err != nil {
-					fmt.Printf("Failed to create producer: %s", err)
+					s.log.WithField("error", err).Error("Failed to create producer")
 					os.Exit(1)
 				}
 
@@ -418,14 +412,14 @@ func (s *ImageService) postProcessCommit(image *models.Image) error {
 					Value:          []byte(recordValue),
 				}, nil)
 				if perr != nil {
-					fmt.Println("Error sending message")
+					s.log.Error("Error sending message")
 				}
 
 				// Wait for all messages to be delivered
 				p.Flush(15 * 1000)
 				p.Close()
 
-				fmt.Printf("postProcessCommit Message was produced to topic %s!\n", topic)
+				s.log.WithField("topic", topic).Debug("postProcessCommit message was produced to topic")
 			}
 
 			break


### PR DESCRIPTION
* add infinite loop to ibvents
* query database for interrupted builds
* send kafka events with image ID

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Add interrupted build status infinite loop to invents

Fixes # (issue) THEEDGE-1714

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
