### PR TITLE
THEEDGE-1714 connect the dots and resume builds from message

### DIFF
--- a/pkg/services/consumers.go
+++ b/pkg/services/consumers.go
@@ -200,7 +200,8 @@ func (s *KafkaConsumerService) ConsumeImageBuildEvents() error {
 		if eventErr != nil {
 			log.WithField("error", eventErr).Debug("Error unmarshaling event. This is not the event you're looking for")
 		} else {
-			log.WithField("imageID", eventMessage.ImageID).Debug("Retrieved an event ID from the message")
+			log.WithField("imageID", eventMessage.ImageID).Debug("Resuming image ID from event on " + string(m.Topic))
+			go s.ImageService.ResumeCreateImage(eventMessage.ImageID)
 		}
 	}
 }

--- a/pkg/services/mock_services/images.go
+++ b/pkg/services/mock_services/images.go
@@ -48,18 +48,6 @@ func (mr *MockImageServiceInterfaceMockRecorder) CreateImage(image, account inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateImage", reflect.TypeOf((*MockImageServiceInterface)(nil).CreateImage), image, account)
 }
 
-// ResumeBuilds mocks base method
-func (m *MockImageServiceInterface) ResumeBuilds() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ResumeBuilds")
-}
-
-// ResumeBuilds indicates an expected call of ResumeBuilds
-func (mr *MockImageServiceInterfaceMockRecorder) ResumeBuilds() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResumeBuilds", reflect.TypeOf((*MockImageServiceInterface)(nil).ResumeBuilds))
-}
-
 // UpdateImage mocks base method
 func (m *MockImageServiceInterface) UpdateImage(image, previousImage *models.Image) error {
 	m.ctrl.T.Helper()
@@ -113,18 +101,6 @@ func (m *MockImageServiceInterface) SetErrorStatusOnImage(err error, i *models.I
 func (mr *MockImageServiceInterfaceMockRecorder) SetErrorStatusOnImage(err, i interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetErrorStatusOnImage", reflect.TypeOf((*MockImageServiceInterface)(nil).SetErrorStatusOnImage), err, i)
-}
-
-// SetInterruptedStatusOnImage mocks base method
-func (m *MockImageServiceInterface) SetInterruptedStatusOnImage(err error, i *models.Image) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetInterruptedStatusOnImage", err, i)
-}
-
-// SetInterruptedStatusOnImage indicates an expected call of SetInterruptedStatusOnImage
-func (mr *MockImageServiceInterfaceMockRecorder) SetInterruptedStatusOnImage(err, i interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInterruptedStatusOnImage", reflect.TypeOf((*MockImageServiceInterface)(nil).SetInterruptedStatusOnImage), err, i)
 }
 
 // CreateRepoForImage mocks base method
@@ -245,6 +221,20 @@ func (m *MockImageServiceInterface) RetryCreateImage(image *models.Image) error 
 func (mr *MockImageServiceInterfaceMockRecorder) RetryCreateImage(image interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetryCreateImage", reflect.TypeOf((*MockImageServiceInterface)(nil).RetryCreateImage), image)
+}
+
+// ResumeCreateImage mocks base method
+func (m *MockImageServiceInterface) ResumeCreateImage(id uint) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResumeCreateImage", id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ResumeCreateImage indicates an expected call of ResumeCreateImage
+func (mr *MockImageServiceInterfaceMockRecorder) ResumeCreateImage(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResumeCreateImage", reflect.TypeOf((*MockImageServiceInterface)(nil).ResumeCreateImage), id)
 }
 
 // GetMetadata mocks base method


### PR DESCRIPTION
* added a resume create image function
* added the call to the new resume create image function in consumer
* minor tweaks and comments

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Connect the consumer event from the INTERRUPTED poll to the resume create image call

Fixes # (issue) THEEDGE-1714

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
