### PR TITLE
start the resume after the commit compose

### DIFF
--- a/pkg/services/consumers.go
+++ b/pkg/services/consumers.go
@@ -201,7 +201,7 @@ func (s *KafkaConsumerService) ConsumeImageBuildEvents() error {
 			log.WithField("error", eventErr).Debug("Error unmarshaling event. This is not the event you're looking for")
 		} else {
 			log.WithField("imageID", eventMessage.ImageID).Debug("Resuming image ID from event on " + string(m.Topic))
-			//go s.ImageService.ResumeCreateImage(eventMessage.ImageID)
+			go s.ImageService.ResumeCreateImage(eventMessage.ImageID)
 		}
 	}
 }

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -1026,13 +1026,14 @@ func (s *ImageService) ResumeCreateImage(id uint) error {
 	//db.DB.Debug().Joins("Commit").Joins("Installer").First(&image, id)
 	image, _ = s.GetImageByID(fmt.Sprint(id))
 	s.log = s.log.WithFields(log.Fields{"imageID": image.ID, "commitID": image.Commit.ID})
-	// recompose commit
+	s.log.Debug("Resuming the image build...")
+	/* // recompose commit
 	image, err := s.ImageBuilder.ComposeCommit(image)
 	if err != nil {
 		s.log.WithField("error", err.Error()).Error("Failed recomposing commit")
 		return err
-	}
-	err = s.SetBuildingStatusOnImageToRetryBuild(image)
+	} */
+	err := s.SetBuildingStatusOnImageToRetryBuild(image)
 	if err != nil {
 		s.log.WithField("error", err.Error()).Error("Failed setting image status")
 		return err


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Starting the resume called from the Kafka event one step later since the commit compose was already gen'd.

Fixes # (issue) THEEDGE-1714

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
