### PR TITLE
Only run "SELECT version()" for postgresql

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -38,11 +38,13 @@ func InitDB() {
 		logger.LogErrorAndPanic("failed to connect database", err)
 	}
 
-	var minorVersion string
-	DB.Raw("SELECT version()").Scan(&minorVersion)
-	if err != nil {
-		log.WithFields(log.Fields{"error": err.Error()}).Error("error selecting version")
-	}
+	if cfg.Database.Type == "pgsql" {
+		var minorVersion string
+		DB.Raw("SELECT version()").Scan(&minorVersion)
+		if err != nil {
+			log.WithFields(log.Fields{"error": err.Error()}).Error("error selecting version")
+		}
 
-	log.Infof("Postgres information: '%s'", minorVersion)
+		log.Infof("Postgres information: '%s'", minorVersion)
+	}
 }


### PR DESCRIPTION
# Description

"SELECT version()" was running in mysql and generating an error.

Fixes # (issue)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
