### PR TITLE
Fix SetErrorStatusOnImage SIGSEGV

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -628,7 +628,7 @@ func (s *ImageService) SetErrorStatusOnImage(err error, i *models.Image) {
 			}
 		}
 		if err != nil {
-			s.log.WithField("error", tx.Error.Error()).Error("Error setting image final status")
+			s.log.WithField("error", err.Error()).Error("Error setting image final status")
 		}
 	}
 }


### PR DESCRIPTION
# Description

Fix SIGSEGV in SetErrorStatusOnImage.  "tx.Error.Error()" was accidentally used instead of "err.Error()"

Fixes # (issue)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
