### PR TITLE
add setImageStatus call to stale interrupted builds

### DIFF
--- a/cmd/kafka/main.go
+++ b/cmd/kafka/main.go
@@ -18,53 +18,38 @@ import (
 
 // NOTE: this is currently designed for a single ibvents replica
 
+// get images with a build of x status and older than y hours
 func getStaleBuilds(status string, age int) []models.Image {
 	var images []models.Image
 
-	// check the database for image builds in INTERRUPTED status
-	//qresult := db.DB.Debug().Where(&models.Image{Status: models.ImageStatusInterrupted}).Find(&images)
-	//qresult := db.DB.Debug().Raw("SELECT id, status, updated_at FROM images WHERE status = ? AND updated_at < NOW() - INTERVAL '? hours'", status, age).Scan(&images)
-	//tresult := db.DB.Debug().Raw("SELECT id, status, updated_at FROM images WHERE status = ? AND updated_at < NOW() - INTERVAL '? hours'", status, age).Scan(&images)
-
-	// temporary query to see this thing work
 	// looks like we ran into a known pgx issue when using ? for parameters in certain prepared SQL statements
-	// trying out using Sprintf to predefine the query and pass to Where
+	// 		using Sprintf to predefine the query and pass to Where
 	query := fmt.Sprintf("status = '%s' AND updated_at < NOW() - INTERVAL '%d hours'", status, age)
-	tresult := db.DB.Debug().Where(query).Find(&images)
-	if tresult.Error != nil {
-		log.WithField("error", tresult.Error.Error()).Error("tresult query failed")
-	} else {
-		log.WithFields(log.Fields{
-			"numImages": tresult.RowsAffected,
-			"status":    status,
-		}).Info("Found testing image(s) with interval")
-
-		for _, staleImage := range images {
-			log.WithFields(log.Fields{
-				"UpdatedAt": staleImage.UpdatedAt,
-				"ID":        staleImage.ID,
-				"Status":    staleImage.Status,
-			}).Info("Logging test interrupted image")
-		}
+	qresult := db.DB.Debug().Where(query).Find(&images)
+	if qresult.Error != nil {
+		log.WithField("error", qresult.Error.Error()).Error("Stale builds query failed")
+		return nil
 	}
 
-	qresult := db.DB.Debug().Raw("SELECT id, status, updated_at FROM images WHERE status = ?", status).Scan(&images)
 	log.WithFields(log.Fields{
 		"numImages": qresult.RowsAffected,
 		"status":    status,
-	}).Info("Found stale image(s)")
+		"interval":  age,
+	}).Debug("Found stale image(s) with interval")
 
 	return images
 }
 
+// set the status for a specific image
 func setImageStatus(id uint, status string) error {
-	/*tx := db.DB.Debug().Model(&models.Image{}).Where("ID = ?", id).Update("Status", status)
-	log.WithField("imageID", id).Debug("Image updated with " + fmt.Sprint(status) + " status")
+	tx := db.DB.Debug().Model(&models.Image{}).Where("ID = ?", id).Update("Status", status)
 	if tx.Error != nil {
 		log.WithField("error", tx.Error.Error()).Error("Error updating image status")
 		return tx.Error
 	}
-	*/
+
+	log.WithField("imageID", id).Debug("Image updated with " + fmt.Sprint(status) + " status")
+
 	return nil
 }
 
@@ -112,6 +97,7 @@ func main() {
 		// TODO: work out programatic method to avoid resuming a build until app is up or on way up
 
 		// handle stale interrupted builds not complete after x hours
+		// FIXME: change 48 hours to something closer to stale builds (6?)
 		staleInterruptedImages := getStaleBuilds(models.ImageStatusInterrupted, 48)
 		for _, staleImage := range staleInterruptedImages {
 			log.WithFields(log.Fields{
@@ -120,7 +106,6 @@ func main() {
 				"Status":    staleImage.Status,
 			}).Info("Processing stale interrupted image")
 
-			// FIXME: holding off on db update until we see the query work in stage
 			statusUpdateError := setImageStatus(staleImage.ID, models.ImageStatusError)
 			if statusUpdateError != nil {
 				log.Error("Failed to update stale interrupted image build status")
@@ -137,13 +122,16 @@ func main() {
 			}).Info("Processing stale building image")
 
 			// FIXME: holding off on db update until we see the query work in stage
-			statusUpdateError := setImageStatus(staleImage.ID, models.ImageStatusError)
+			/* statusUpdateError := setImageStatus(staleImage.ID, models.ImageStatusError)
 			if statusUpdateError != nil {
 				log.Error("Failed to update stale building image build status")
 			}
+			*/
 		}
 
 		// handle image builds in INTERRUPTED status
+		//	this is meant to handle builds that are interrupted when they are interrupted
+		// 	the stale interrupted build routine should never actually find anything while this is running
 		qresult := db.DB.Debug().Where(&models.Image{Status: models.ImageStatusInterrupted}).Find(&images)
 		log.WithField("numImages", qresult.RowsAffected).Info("Found image(s) with interrupted status")
 


### PR DESCRIPTION
* set image status to Error for stale interrupted builds

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Set image status for stale interrupted builds to Error

Fixes # (issue) THEEDGE-1940

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
