### PR TITLE
add setImageStatus call to stale builds

### DIFF
--- a/cmd/kafka/main.go
+++ b/cmd/kafka/main.go
@@ -13,7 +13,6 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
-	//"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
 )
 
 // NOTE: this is currently designed for a single ibvents replica
@@ -121,12 +120,10 @@ func main() {
 				"Status":    staleImage.Status,
 			}).Info("Processing stale building image")
 
-			// FIXME: holding off on db update until we see the query work in stage
-			/* statusUpdateError := setImageStatus(staleImage.ID, models.ImageStatusError)
+			statusUpdateError := setImageStatus(staleImage.ID, models.ImageStatusError)
 			if statusUpdateError != nil {
 				log.Error("Failed to update stale building image build status")
 			}
-			*/
 		}
 
 		// handle image builds in INTERRUPTED status


### PR DESCRIPTION
* uncomment setImageStatus to set stale build status to Error

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Set image status to ERROR for stale builds in BUILDING status

Fixes # (issue) THEEDGE-1940

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
