### PR TITLE
Revert "test podman no-cache on pr_check"

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -13,9 +13,6 @@ export IQE_CJI_TIMEOUT="30m"  # This is the time to wait for smoke test to compl
 CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
 curl -s $CICD_URL/bootstrap.sh > ${WORKSPACE}/cicd_bootstrap.sh && source ${WORKSPACE}/cicd_bootstrap.sh
 
-#temporary build to clear the layer cache
-podman build --no-cache -f "${APP_ROOT}/${DOCKERFILE}" -t "${IMAGE}:${IMAGE_TAG}" $APP_ROOT
-
 # Build the image and push to quay
 source $CICD_ROOT/build.sh
 


### PR DESCRIPTION
Reverts RedHatInsights/edge-api#909

podman layer cache is working, so removing the --no-cache line