### PR TITLE
Overloading /updates endpoint when CommitID is Zero

### DIFF
--- a/pkg/services/devices_test.go
+++ b/pkg/services/devices_test.go
@@ -858,4 +858,82 @@ var _ = Describe("DeviceService", func() {
 			})
 		})
 	})
+	Context("Get CommitID from Device Image", func() {
+		It("should return zero images", func() {
+			account := faker.UUIDHyphenated()
+			device := models.Device{
+				Account: account,
+				UUID:    faker.UUIDHyphenated(),
+			}
+			updateImageCommitID, err := deviceService.GetUpdateCommitFromDevice(account, device.UUID)
+			Expect(updateImageCommitID == 0).To(BeTrue())
+			Expect(err).To(MatchError("record not found"))
+			Expect(err).ToNot(BeNil())
+		})
+	})
+	When("device Image does not have update", func() {
+		It("should return no image updates", func() {
+			account := faker.HyphenatedID
+			imageSet := &models.ImageSet{
+				Name:    "test",
+				Version: 1,
+			}
+			updateImage := models.Image{
+				Account:    account,
+				ImageSetID: &imageSet.ID,
+				Status:     models.ImageStatusSuccess,
+			}
+			device := models.Device{
+				UUID: faker.UUIDHyphenated(),
+			}
+			updateImageCommitID, err := deviceService.GetUpdateCommitFromDevice(updateImage.Account, device.UUID)
+			Expect(updateImageCommitID == 0).To(BeTrue())
+			Expect(err).ToNot(BeNil())
+			Expect(err).To(MatchError("record not found"))
+		})
+	})
+	When("device Image have update", func() {
+		It("should return commitID", func() {
+			account := faker.HyphenatedID
+			imageSet := models.ImageSet{
+				Account: account,
+			}
+			db.DB.Create(&imageSet)
+
+			firstCommit := models.Commit{
+				Account: account,
+			}
+			db.DB.Create(&firstCommit)
+
+			firstImage := models.Image{
+				Account:    account,
+				CommitID:   firstCommit.ID,
+				Status:     models.ImageStatusSuccess,
+				Version:    1,
+				ImageSetID: &imageSet.ID,
+			}
+			db.DB.Create(&firstImage)
+			device := models.Device{
+				Account: account,
+				ImageID: firstImage.ID,
+			}
+			db.DB.Create(&device)
+			secondCommit := models.Commit{
+				Account: account,
+			}
+			db.DB.Create(&secondCommit)
+
+			secondImage := models.Image{
+				Account:    account,
+				CommitID:   secondCommit.ID,
+				Status:     models.ImageStatusSuccess,
+				Version:    2,
+				ImageSetID: &imageSet.ID,
+			}
+			db.DB.Create(&secondImage)
+			updateImageCommitID, err := deviceService.GetUpdateCommitFromDevice(device.Account, device.UUID)
+			Expect(err).To(BeNil())
+			Expect(updateImageCommitID).To(Equal(secondCommit.ID))
+		})
+	})
 })

--- a/pkg/services/errors.go
+++ b/pkg/services/errors.go
@@ -122,5 +122,12 @@ func (e *DeviceHasImageUndefined) Error() string {
 	return "device has image undefined"
 }
 
+// DeviceHasNoImageUpdate indicates that device record no image
+type DeviceHasNoImageUpdate struct{}
+
+func (e *DeviceHasNoImageUpdate) Error() string {
+	return "device has no image update"
+}
+
 // ErrUndefinedCommit indicate that the update transaction/image or some entity  has no commit defined.
 var ErrUndefinedCommit = errors.New("entity has defined commit")

--- a/pkg/services/mock_services/devices.go
+++ b/pkg/services/mock_services/devices.go
@@ -270,3 +270,18 @@ func (mr *MockDeviceServiceInterfaceMockRecorder) ProcessPlatformInventoryUpdate
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessPlatformInventoryUpdatedEvent", reflect.TypeOf((*MockDeviceServiceInterface)(nil).ProcessPlatformInventoryUpdatedEvent), message)
 }
+
+// GetUpdateCommitFromDevice mocks base method
+func (m *MockDeviceServiceInterface) GetUpdateCommitFromDevice(account, deviceUUID string) (uint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUpdateCommitFromDevice", account, deviceUUID)
+	ret0, _ := ret[0].(uint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUpdateCommitFromDevice indicates an expected call of GetUpdateCommitFromDevice
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetUpdateCommitFromDevice(account, deviceUUID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdateCommitFromDevice", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetUpdateCommitFromDevice), account, deviceUUID)
+}


### PR DESCRIPTION
# Description

Overloading the /updates endpoint to have the latest CommitID, when CommitID is zero in the /update request to update a device.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
