### PR TITLE
THEEDGE-1928: Add devicegroups/devices many2many back reference

### DIFF
--- a/pkg/models/devices.go
+++ b/pkg/models/devices.go
@@ -69,5 +69,5 @@ type Device struct {
 	Account         string        `gorm:"index" json:"Account"`
 	ImageID         uint          `json:"ImageID"`
 	UpdateAvailable bool          `json:"UpdateAvailable"`
-	DevicesGroups   []DeviceGroup `json:"DevicesGroups" gorm:"many2many:device_groups_devices;"`
+	DevicesGroups   []DeviceGroup `faker:"-" gorm:"many2many:device_groups_devices;" json:"DevicesGroups"`
 }

--- a/pkg/models/devices.go
+++ b/pkg/models/devices.go
@@ -19,6 +19,7 @@ type DeviceDetails struct {
 	Device             EdgeDevice           `json:"Device,omitempty"`
 	Image              *ImageInfo           `json:"ImageInfo"`
 	UpdateTransactions *[]UpdateTransaction `json:"UpdateTransactions,omitempty"`
+	DevicesGroups      *[]DeviceGroup       `json:"DevicesGroups,omitempty"`
 }
 
 // DeviceDetailsList is the list of devices with details from Inventory and Edge API
@@ -58,14 +59,15 @@ type DeviceView struct {
 // THEEDGE-1921 created 2 temporary indexes to address production issue
 type Device struct {
 	Model
-	UUID            string      `gorm:"index" json:"UUID"`
-	AvailableHash   string      `json:"AvailableHash,omitempty"`
-	RHCClientID     string      `json:"RHCClientID"`
-	Connected       bool        `gorm:"default:true" json:"Connected"`
-	Name            string      `json:"Name"`
-	LastSeen        EdgeAPITime `json:"LastSeen"`
-	CurrentHash     string      `json:"CurrentHash,omitempty"`
-	Account         string      `gorm:"index" json:"Account"`
-	ImageID         uint        `json:"ImageID"`
-	UpdateAvailable bool        `json:"UpdateAvailable"`
+	UUID            string        `gorm:"index" json:"UUID"`
+	AvailableHash   string        `json:"AvailableHash,omitempty"`
+	RHCClientID     string        `json:"RHCClientID"`
+	Connected       bool          `gorm:"default:true" json:"Connected"`
+	Name            string        `json:"Name"`
+	LastSeen        EdgeAPITime   `json:"LastSeen"`
+	CurrentHash     string        `json:"CurrentHash,omitempty"`
+	Account         string        `gorm:"index" json:"Account"`
+	ImageID         uint          `json:"ImageID"`
+	UpdateAvailable bool          `json:"UpdateAvailable"`
+	DevicesGroups   []DeviceGroup `json:"DevicesGroups" gorm:"many2many:device_groups_devices;"`
 }

--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -406,7 +406,8 @@ func (s *DeviceService) GetDevices(params *inventory.Params) (*models.DeviceDeta
 
 		//Load from device DB the groups info and add to the new struct
 		var storeDevice models.Device
-		result := db.DB.Where("id=?", dbDeviceID).First(&storeDevice)
+		// Don't throw error if device not found
+		db.DB.Where("id=?", dbDeviceID).First(&storeDevice)
 
 		err := db.DB.Model(&storeDevice).Association("DevicesGroups").Find(&storeDevice.DevicesGroups)
 		if err != nil {

--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -242,10 +242,7 @@ func (s *DeviceService) GetUpdateAvailableForDevice(device inventory.Device, lat
 
 	for _, upd := range images {
 		upd := upd // this will prevent implicit memory aliasing in the loop
-		if err := db.DB.First(&upd.Commit, upd.CommitID); err != nil {
-			s.log.WithField("error", err).Error("Could not find commit")
-			return nil, new(CommitNotFound)
-		}
+		db.DB.First(&upd.Commit, upd.CommitID)
 
 		if err := db.DB.Model(&upd.Commit).Association("InstalledPackages").Find(&upd.Commit.InstalledPackages); err != nil {
 			s.log.WithField("error", err.Error()).Error("Could not find installed packages")

--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -407,10 +407,6 @@ func (s *DeviceService) GetDevices(params *inventory.Params) (*models.DeviceDeta
 		//Load from device DB the groups info and add to the new struct
 		var storeDevice models.Device
 		result := db.DB.Where("id=?", dbDeviceID).First(&storeDevice)
-		if result.Error != nil {
-			s.log.WithField("error", result.Error.Error()).Error("Error finding device")
-			return nil, new(DeviceNotFoundError)
-		}
 
 		err := db.DB.Model(&storeDevice).Association("DevicesGroups").Find(&storeDevice.DevicesGroups)
 		if err != nil {

--- a/pkg/services/devices_test.go
+++ b/pkg/services/devices_test.go
@@ -127,15 +127,15 @@ var _ = Describe("DeviceService", func() {
 				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(inventory.Response{}, errors.New("error on inventory api"))
 
 				updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false)
-				Expect(updatesAvailable).To(BeNil())
 				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
+				Expect(updatesAvailable).To(BeNil())
 			})
 			It("should return error and no updates available - for latest update", func() {
 				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(inventory.Response{}, errors.New("error on inventory api"))
 
 				updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, true)
-				Expect(updatesAvailable).To(BeNil())
 				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
+				Expect(updatesAvailable).To(BeNil())
 			})
 		})
 		When("device is not found on InventoryAPI", func() {
@@ -148,8 +148,8 @@ var _ = Describe("DeviceService", func() {
 				}
 
 				updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false)
-				Expect(updatesAvailable).To(BeNil())
 				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
+				Expect(updatesAvailable).To(BeNil())
 			})
 			It("should return error and nil on latest update available", func() {
 				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(inventory.Response{}, nil)
@@ -160,8 +160,8 @@ var _ = Describe("DeviceService", func() {
 				}
 
 				updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, true)
-				Expect(updatesAvailable).To(BeNil())
 				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
+				Expect(updatesAvailable).To(BeNil())
 			})
 		})
 		When("there are no booted deployments", func() {
@@ -183,8 +183,8 @@ var _ = Describe("DeviceService", func() {
 				}
 
 				updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false)
-				Expect(updatesAvailable).To(BeNil())
 				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
+				Expect(updatesAvailable).To(BeNil())
 			})
 			It("should return error and nil on latest update available", func() {
 				checksum := "fake-checksum"
@@ -204,8 +204,8 @@ var _ = Describe("DeviceService", func() {
 				}
 
 				updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, true)
-				Expect(updatesAvailable).To(BeNil())
 				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
+				Expect(updatesAvailable).To(BeNil())
 			})
 		})
 		When("everything is okay", func() {
@@ -393,8 +393,8 @@ var _ = Describe("DeviceService", func() {
 				db.DB.Create(oldImage)
 
 				updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false)
-				Expect(updatesAvailable).To(BeNil())
 				Expect(err).To(BeNil())
+				Expect(updatesAvailable).To(BeNil())
 			})
 		})
 		When("no checksum is found", func() {
@@ -411,9 +411,9 @@ var _ = Describe("DeviceService", func() {
 				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
 
 				updatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false)
-				Expect(updatesAvailable).To(BeNil())
 				Expect(err).ToNot(BeNil())
 				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
+				Expect(updatesAvailable).To(BeNil())
 			})
 		})
 	})
@@ -545,11 +545,11 @@ var _ = Describe("DeviceService", func() {
 				}
 				mockInventoryClient.EXPECT().ReturnDevices(gomock.Any()).Return(resp, nil)
 				devices, err := deviceService.GetDevices(params)
+				Expect(err).To(BeNil())
 				Expect(devices).ToNot(BeNil())
 				Expect(devices.Devices).To(HaveLen(0))
 				Expect(devices.Count).To(Equal(0))
 				Expect(devices.Total).To(Equal(0))
-				Expect(err).To(BeNil())
 			})
 		})
 		When("devices are returned from InventoryAPI", func() {
@@ -579,11 +579,11 @@ var _ = Describe("DeviceService", func() {
 				}
 
 				devices, err := deviceService.GetDevices(params)
+				Expect(err).To(BeNil())
 				Expect(devices).ToNot(BeNil())
 				Expect(devices.Devices).To(HaveLen(2))
 				Expect(devices.Count).To(Equal(2))
 				Expect(devices.Total).To(Equal(2))
-				Expect(err).To(BeNil())
 			})
 		})
 	})
@@ -853,8 +853,8 @@ var _ = Describe("DeviceService", func() {
 				}
 
 				devices, err := deviceService.GetDevicesView(0, 0, nil)
-				Expect(devices).ToNot(BeNil())
 				Expect(err).To(BeNil())
+				Expect(devices).ToNot(BeNil())
 			})
 		})
 	})

--- a/pkg/services/errors.go
+++ b/pkg/services/errors.go
@@ -124,3 +124,10 @@ func (e *DeviceHasImageUndefined) Error() string {
 
 // ErrUndefinedCommit indicate that the update transaction/image or some entity  has no commit defined.
 var ErrUndefinedCommit = errors.New("entity has defined commit")
+
+// CommitNotFound indicates commit matching the given id was not found
+type CommitNotFound struct{}
+
+func (e *CommitNotFound) Error() string {
+	return "commit not found"
+}


### PR DESCRIPTION
# Description

Add many2many back reference for devicegroups/devices.  Incorporates Ana"s changed from PR 86.  Still need to resolve local "go test" issue that works elsewhere

Fixes # THEEDGE-1928

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
