### PR TITLE
squelching non edge inventory messages in logs

### DIFF
--- a/pkg/services/consumers.go
+++ b/pkg/services/consumers.go
@@ -136,7 +136,7 @@ func (s *KafkaConsumerService) ConsumePlatformInventoryEvents() error {
 			}
 		}
 		if eventType != InventoryEventTypeCreated && eventType != InventoryEventTypeUpdated && eventType != InventoryEventTypeDelete {
-			log.Debug("Skipping kafka message - Insights Platform Inventory message is not a created and not an updated event type")
+			//log.Debug("Skipping kafka message - Insights Platform Inventory message is not a created and not an updated event type")
 			continue
 		}
 		log.WithFields(log.Fields{


### PR DESCRIPTION
* commented out log message for inventory events unrelated to edge

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Squelching message for non Edge inventory events to ease production log storage

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `go fmt ./...` to check that my code is properly formatted
- [ ] I run `go vet ./...` to check that my code is free of common Go style mistakes
