### PR TITLE
utility: remove logging when no stale builds are found

### DIFF
--- a/cmd/kafka/main.go
+++ b/cmd/kafka/main.go
@@ -30,11 +30,13 @@ func getStaleBuilds(status string, age int) []models.Image {
 		return nil
 	}
 
-	log.WithFields(log.Fields{
-		"numImages": qresult.RowsAffected,
-		"status":    status,
-		"interval":  age,
-	}).Debug("Found stale image(s) with interval")
+	if qresult.RowsAffected > 0 {
+		log.WithFields(log.Fields{
+			"numImages": qresult.RowsAffected,
+			"status":    status,
+			"interval":  age,
+		}).Debug("Found stale image(s) with interval")
+	}
 
 	return images
 }
@@ -130,7 +132,9 @@ func main() {
 		//	this is meant to handle builds that are interrupted when they are interrupted
 		// 	the stale interrupted build routine should never actually find anything while this is running
 		qresult := db.DB.Debug().Where(&models.Image{Status: models.ImageStatusInterrupted}).Find(&images)
-		log.WithField("numImages", qresult.RowsAffected).Info("Found image(s) with interrupted status")
+		if qresult.RowsAffected > 0 {
+			log.WithField("numImages", qresult.RowsAffected).Info("Found image(s) with interrupted status")
+		}
 
 		for _, image := range images {
 			log.WithField("imageID", image.ID).Info("Processing interrupted image")


### PR DESCRIPTION
* cmd/kafka/main.go: remove misleading logs when found 0 stale builds

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Currently logging when 0 stale images are found with 0 only being obvious when looking at the fields.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
