### PR TITLE
utility: change stale interrupted time from 48 to 6 hours

### DIFF
--- a/cmd/kafka/main.go
+++ b/cmd/kafka/main.go
@@ -98,8 +98,7 @@ func main() {
 		// TODO: work out programatic method to avoid resuming a build until app is up or on way up
 
 		// handle stale interrupted builds not complete after x hours
-		// FIXME: change 48 hours to something closer to stale builds (6?)
-		staleInterruptedImages := getStaleBuilds(models.ImageStatusInterrupted, 48)
+		staleInterruptedImages := getStaleBuilds(models.ImageStatusInterrupted, 6)
 		for _, staleImage := range staleInterruptedImages {
 			log.WithFields(log.Fields{
 				"UpdatedAt": staleImage.UpdatedAt,


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Change stale interrupted build time from 48 hours to 6 hours.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
