### PR TITLE
add pagination

### DIFF
--- a/pkg/routes/devicegroups.go
+++ b/pkg/routes/devicegroups.go
@@ -56,7 +56,7 @@ func MakeDeviceGroupsRouter(sub chi.Router) {
 			d.Get("/", GetDeviceGroupDetailsByID)
 		})
 		r.Route("/view", func(d chi.Router) {
-			d.Get("/", GetDeviceGroupDetailsByIDView)
+			d.With(common.Paginate).Get("/", GetDeviceGroupDetailsByIDView)
 		})
 		r.Route("/devices/{DEVICE_ID}", func(d chi.Router) {
 			d.Use(DeviceGroupDeviceCtx)


### PR DESCRIPTION
# Description

We should be able to paginate the list of devices inside of a group. The parameter wasnt being passed in the route, so the default was 100.

Fixes # ([issue](https://issues.redhat.com/browse/THEEDGE-2067))

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
