### PR TITLE
fix image info on devicesview route

### DIFF
--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -677,6 +677,7 @@ func ReturnDevicesView(storedDevices []models.Device, account string) ([]models.
 
 	// create a map of unique image id's. We dont want to look of a given image id more than once.
 	deviceStatusSet := make(map[uint]string)
+	setOfImages := make(map[uint]*neededImageInfo)
 	for _, devices := range storedDevices {
 		var status = models.DeviceViewStatusRunning
 		if devices.UpdateTransaction != nil && len(*devices.UpdateTransaction) > 0 {
@@ -685,11 +686,15 @@ func ReturnDevicesView(storedDevices []models.Device, account string) ([]models.
 				status = models.DeviceViewStatusUpdating
 			}
 		}
+
 		deviceStatusSet[devices.ID] = status
+
+		if devices.ImageID != 0 {
+			setOfImages[devices.ImageID] = &neededImageInfo{}
+		}
 	}
 
 	// using the map of unique image ID's, get the corresponding image name and status.
-	setOfImages := make(map[uint]*neededImageInfo)
 	imagesIDS := []uint{}
 	for key := range setOfImages {
 		imagesIDS = append(imagesIDS, key)
@@ -709,7 +714,7 @@ func ReturnDevicesView(storedDevices []models.Device, account string) ([]models.
 	returnDevices := []models.DeviceView{}
 	for _, device := range storedDevices {
 		var imageName string
-		var imageStatus string
+		var deviceStatus string
 		var imageSetID uint
 		var deviceGroups []models.DeviceDeviceGroup
 		if _, ok := setOfImages[device.ImageID]; ok {
@@ -720,7 +725,7 @@ func ReturnDevicesView(storedDevices []models.Device, account string) ([]models.
 			deviceGroups = deviceToGroupMap[device.ID]
 		}
 		if _, ok := deviceStatusSet[device.ID]; ok {
-			imageStatus = deviceStatusSet[device.ID]
+			deviceStatus = deviceStatusSet[device.ID]
 		}
 		currentDeviceView := models.DeviceView{
 			DeviceID:        device.ID,
@@ -730,7 +735,7 @@ func ReturnDevicesView(storedDevices []models.Device, account string) ([]models.
 			ImageName:       imageName,
 			LastSeen:        device.LastSeen,
 			UpdateAvailable: device.UpdateAvailable,
-			Status:          imageStatus,
+			Status:          deviceStatus,
 			ImageSetID:      imageSetID,
 			DeviceGroups:    deviceGroups,
 		}


### PR DESCRIPTION
# Description
The image info is missing on `/devicesview` route, this should fix because the image IDs array was empty.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
