### PR TITLE
resume: fix edge service env name

### DIFF
--- a/cmd/kafka/main.go
+++ b/cmd/kafka/main.go
@@ -141,10 +141,10 @@ func main() {
 
 		for _, image := range images {
 			log.WithFields(log.Fields{
-				"imageID":    image.ID,
-				"Account":    image.Account,
-				"org_id":     image.OrgID,
-				"request_id": image.RequestID,
+				"imageID":   image.ID,
+				"Account":   image.Account,
+				"OrgID":     image.OrgID,
+				"RequestID": image.RequestID,
 			}).Info("Processing interrupted image")
 
 			/* we have a choice here...
@@ -159,7 +159,7 @@ func main() {
 			url := fmt.Sprintf("http://%s:%d/api/edge/v1/images/%d/resume", cfg.EdgeAPIServiceHost, cfg.EdgeAPIServicePort, image.ID)
 			req, _ := http.NewRequest("POST", url, nil)
 			req.Header.Add("Content-Type", "application/json")
-			log.WithField("api_url", url).Debug("Created the api url string")
+			log.WithField("apiURL", url).Debug("Created the api url string")
 
 			// create a client and send a request against the Edge API
 			client := &http.Client{}

--- a/config/config.go
+++ b/config/config.go
@@ -136,8 +136,8 @@ func Init() {
 		},
 		TemplatesPath:      options.GetString("TemplatesPath"),
 		EdgeAPIBaseURL:     options.GetString("EdgeAPIBaseURL"),
-		EdgeAPIServiceHost: options.GetString("EDGE_API_SERVICE_HOST"),
-		EdgeAPIServicePort: options.GetInt("EDGE_API_SERVICE_PORT"),
+		EdgeAPIServiceHost: options.GetString("EDGE_API_SERVICE_SERVICE_HOST"),
+		EdgeAPIServicePort: options.GetInt("EDGE_API_SERVICE_SERVICE_PORT"),
 		UploadWorkers:      options.GetInt("UploadWorkers"),
 		FDO: &fdoConfig{
 			URL:                 options.GetString("FDOHostURL"),

--- a/pkg/dependencies/main.go
+++ b/pkg/dependencies/main.go
@@ -34,7 +34,7 @@ func Init(ctx context.Context) *EdgeAPIServices {
 	log := log.WithFields(log.Fields{
 		"requestId": request_id.GetReqID(ctx),
 		"accountId": account,
-		"org_id":    orgID,
+		"orgID":     orgID,
 	})
 	return &EdgeAPIServices{
 		CommitService:           services.NewCommitService(ctx, log),


### PR DESCRIPTION
* updated to EDGE_API_SERVICE_SERVICE_HOST & _PORT

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Fixed typo in service host and port env variables

Fixes # (issue) THEEDGE-2024

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
