### PR TITLE
image-builder: FIXES repository RHSM that has to be supplied.

### DIFF
--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -59,7 +59,7 @@ type Repository struct {
 	IgnoreSSL  *bool   `json:"ignore_ssl,omitempty"`
 	MetaLink   *string `json:"metalink,omitempty"`
 	MirrorList *string `json:"mirrorlist,omitempty"`
-	RHSM       bool    `json:"rhsm,omitempty"`
+	RHSM       bool    `json:"rhsm"`
 }
 
 // UploadRequest is the upload options accepted by Image Builder API


### PR DESCRIPTION
Image-builder use a general structure for a general repository where the rhsm has to be present.

Fixes THEEDGE-2127

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [X] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
