### PR TITLE
custom-repos: FIXES - Lock custom repo from update/deletion when used in images.

### DIFF
--- a/pkg/routes/thirdpartyrepo.go
+++ b/pkg/routes/thirdpartyrepo.go
@@ -94,7 +94,7 @@ func CreateThirdPartyRepo(w http.ResponseWriter, r *http.Request) {
 		case *services.ThirdPartyRepositoryNameIsEmpty, *services.ThirdPartyRepositoryURLIsEmpty, *services.ThirdPartyRepositoryAlreadyExists:
 			apiError = errors.NewBadRequest(err.Error())
 		default:
-			apiError := errors.NewInternalServerError()
+			apiError = errors.NewInternalServerError()
 			apiError.SetTitle("failed creating third party repository")
 		}
 		respondWithAPIError(w, ctxServices.Log, apiError)
@@ -289,10 +289,12 @@ func UpdateThirdPartyRepo(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var apiError errors.APIError
 		switch err.(type) {
-		case *services.ThirdPartyRepositoryAlreadyExists:
+		case *services.ThirdPartyRepositoryAlreadyExists, *services.ThirdPartyRepositoryImagesExists:
 			apiError = errors.NewBadRequest(err.Error())
+		case *services.ThirdPartyRepositoryNotFound:
+			apiError = errors.NewNotFound(err.Error())
 		default:
-			apiError := errors.NewInternalServerError()
+			apiError = errors.NewInternalServerError()
 			apiError.SetTitle("failed updating third party repository")
 		}
 		respondWithAPIError(w, ctxServices.Log, apiError)
@@ -320,6 +322,8 @@ func DeleteThirdPartyRepoByID(w http.ResponseWriter, r *http.Request) {
 			switch err.(type) {
 			case *services.ThirdPartyRepositoryNotFound:
 				responseErr = errors.NewNotFound(err.Error())
+			case *services.ThirdPartyRepositoryImagesExists:
+				responseErr = errors.NewBadRequest(err.Error())
 			default:
 				responseErr = errors.NewInternalServerError()
 				responseErr.SetTitle("failed deleting third party repository")

--- a/pkg/services/errors.go
+++ b/pkg/services/errors.go
@@ -72,6 +72,13 @@ func (e *ThirdPartyRepositoryURLIsEmpty) Error() string {
 	return "custom repository URL cannot be empty"
 }
 
+// ThirdPartyRepositoryImagesExists indicates the Third Party Repository has been used in some images
+type ThirdPartyRepositoryImagesExists struct{}
+
+func (e *ThirdPartyRepositoryImagesExists) Error() string {
+	return "custom repository is used by some images"
+}
+
 // ImageVersionAlreadyExists indicates the updated image version was already present
 type ImageVersionAlreadyExists struct{}
 

--- a/pkg/services/thirdpartyrepo_test.go
+++ b/pkg/services/thirdpartyrepo_test.go
@@ -1,0 +1,158 @@
+package services_test
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/redhatinsights/edge-api/pkg/db"
+	"github.com/redhatinsights/edge-api/pkg/models"
+	"github.com/redhatinsights/edge-api/pkg/routes/common"
+	"github.com/redhatinsights/edge-api/pkg/services"
+
+	"github.com/bxcodec/faker/v3"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+)
+
+var _ = Describe("ThirdPartyRepos basic functions", func() {
+	var (
+		ctx                context.Context
+		customReposService services.ThirdPartyRepoServiceInterface
+	)
+	BeforeEach(func() {
+		ctx = context.Background()
+		customReposService = services.NewThirdPartyRepoService(ctx, log.NewEntry(log.StandardLogger()))
+	})
+
+	Context("Custom repos creation", func() {
+
+		It("Custom repo should not be created without account", func() {
+			repo := models.ThirdPartyRepo{Name: faker.UUIDHyphenated(), URL: faker.URL()}
+			_, err := customReposService.CreateThirdPartyRepo(&repo, "")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Account is not set"))
+		})
+
+		It("Custom repo should not be created with empty name", func() {
+			account := faker.UUIDHyphenated()
+			repo := models.ThirdPartyRepo{Name: "", URL: faker.URL()}
+			_, err := customReposService.CreateThirdPartyRepo(&repo, account)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("custom repository name cannot be empty"))
+		})
+
+		It("Custom repo should not be created with empty URL", func() {
+			account := faker.UUIDHyphenated()
+			repo := models.ThirdPartyRepo{Name: faker.UUIDHyphenated(), URL: ""}
+			_, err := customReposService.CreateThirdPartyRepo(&repo, account)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("custom repository URL cannot be empty"))
+		})
+
+		It("Custom repo should be created successfully", func() {
+			account := faker.UUIDHyphenated()
+			repo := models.ThirdPartyRepo{Name: faker.UUIDHyphenated(), URL: faker.URL()}
+			newRepo, err := customReposService.CreateThirdPartyRepo(&repo, account)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(newRepo.Name).To(Equal(repo.Name))
+			Expect(newRepo.URL).To(Equal(repo.URL))
+			Expect(newRepo.Account).To(Equal(account))
+		})
+
+		It("Custom repo should not be created if name already exists", func() {
+			account := faker.UUIDHyphenated()
+			repo := models.ThirdPartyRepo{Name: faker.UUIDHyphenated(), URL: faker.URL()}
+			_, err := customReposService.CreateThirdPartyRepo(&repo, account)
+			Expect(err).ToNot(HaveOccurred())
+			repo2 := models.ThirdPartyRepo{Name: repo.Name, URL: faker.URL()}
+			_, err = customReposService.CreateThirdPartyRepo(&repo2, account)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("custom repository already exists"))
+		})
+	})
+
+	Context("Custom repos update", func() {
+		account := common.DefaultAccount
+		repo := models.ThirdPartyRepo{Name: faker.UUIDHyphenated(), URL: faker.URL(), Account: account}
+		result := db.DB.Create(&repo)
+		repo2 := models.ThirdPartyRepo{Name: faker.UUIDHyphenated(), URL: faker.URL(), Account: account}
+		result2 := db.DB.Create(&repo2)
+
+		It("Custom repo should not be updated if name exists ", func() {
+			Expect(result.Error).ToNot(HaveOccurred())
+			Expect(result2.Error).ToNot(HaveOccurred())
+			upRepo := models.ThirdPartyRepo{Name: repo2.Name}
+			err := customReposService.UpdateThirdPartyRepo(&upRepo, account, strconv.FormatUint(uint64(repo.ID), 10))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("custom repository already exists"))
+		})
+
+		It("Custom repo url should not be updated if image exists", func() {
+			image := models.Image{
+				Account:                account,
+				ThirdPartyRepositories: []models.ThirdPartyRepo{repo2},
+				Status:                 models.ImageStatusSuccess,
+			}
+			result := db.DB.Create(&image)
+			Expect(result.Error).ToNot(HaveOccurred())
+			upRepo := models.ThirdPartyRepo{URL: faker.URL()}
+			err := customReposService.UpdateThirdPartyRepo(&upRepo, account, strconv.FormatUint(uint64(repo2.ID), 10))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("custom repository is used by some images"))
+		})
+
+		It("Custom repo name should be updated successfully if image exists", func() {
+			image := models.Image{
+				Account:                account,
+				ThirdPartyRepositories: []models.ThirdPartyRepo{repo2},
+				Status:                 models.ImageStatusSuccess,
+			}
+			result := db.DB.Create(&image)
+			Expect(result.Error).ToNot(HaveOccurred())
+			upRepo := models.ThirdPartyRepo{Name: faker.URL()}
+			err := customReposService.UpdateThirdPartyRepo(&upRepo, account, strconv.FormatUint(uint64(repo2.ID), 10))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Custom repo URL should be updated successfully even if image exists (error status)", func() {
+			image := models.Image{
+				Account:                account,
+				ThirdPartyRepositories: []models.ThirdPartyRepo{repo2},
+				Status:                 models.ImageStatusError,
+			}
+			result := db.DB.Create(&image)
+			Expect(result.Error).ToNot(HaveOccurred())
+			upRepo := models.ThirdPartyRepo{Name: faker.URL()}
+			err := customReposService.UpdateThirdPartyRepo(&upRepo, account, strconv.FormatUint(uint64(repo2.ID), 10))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+	Context("Custom repos delete", func() {
+		account := common.DefaultAccount
+
+		It("Custom repo should be deleted successfully", func() {
+			repo := models.ThirdPartyRepo{Name: faker.UUIDHyphenated(), URL: faker.URL(), Account: account}
+			result := db.DB.Create(&repo)
+			Expect(result.Error).ToNot(HaveOccurred())
+			deletedRepo, err := customReposService.DeleteThirdPartyRepoByID(strconv.FormatUint(uint64(repo.ID), 10))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deletedRepo.ID).To(Equal(repo.ID))
+		})
+
+		It("Custom repo should not be deleted when used by image", func() {
+			repo := models.ThirdPartyRepo{Name: faker.UUIDHyphenated(), URL: faker.URL(), Account: account}
+			result := db.DB.Create(&repo)
+			Expect(result.Error).ToNot(HaveOccurred())
+			image := models.Image{
+				Account:                account,
+				ThirdPartyRepositories: []models.ThirdPartyRepo{repo},
+			}
+			result = db.DB.Create(&image)
+			Expect(result.Error).ToNot(HaveOccurred())
+			_, err := customReposService.DeleteThirdPartyRepoByID(strconv.FormatUint(uint64(repo.ID), 10))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("custom repository is used by some images"))
+		})
+	})
+})


### PR DESCRIPTION
name update is always allowed.
url update allowed when images may exist with status not success not building and not interrupted.
always disallow deletion when image exists.

Fixes # THEEDGE-2146

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [X] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
