### PR TITLE
Fix incorrect ImageSet version for Updated Image 

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -227,9 +227,9 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 		s.log.WithField("error", result.Error.Error()).Error("Error retrieving the image set from parent image")
 		return result.Error
 	}
-	currentImageSet.Version = currentImageSet.Version + 1
+	currentImageSet.Version = previousImage.Version + 1
 	if err := db.DB.Save(currentImageSet).Error; err != nil {
-		return result.Error
+		return err
 	}
 
 	if previousImage.Status == models.ImageStatusSuccess {
@@ -289,7 +289,7 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 
 	s.log = s.log.WithFields(log.Fields{"updatedImageID": image.ID, "updatedCommitID": image.Commit.ID})
 
-	s.log.Info("Image Updated successfully - starting bulding processs")
+	s.log.Info("Image Updated successfully - starting bulding process")
 
 	go s.postProcessImage(image.ID)
 

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -221,13 +221,8 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 	image.ImageSetID = previousImage.ImageSetID
 	image.Account = previousImage.Account
 
-	if previousImage.Status == models.ImageStatusError {
-		// Previous image was not built successfully
-		s.log.WithField("previousImageID", previousImage.ID).Info("Creating an update based on a image with a status that is not success")
-	}
 	var currentImageSet models.ImageSet
 	result := db.DB.Where("Id = ?", previousImage.ImageSetID).First(&currentImageSet)
-
 	if result.Error != nil {
 		s.log.WithField("error", result.Error.Error()).Error("Error retrieving the image set from parent image")
 		return result.Error
@@ -237,23 +232,27 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 		return result.Error
 	}
 
-	// Always get the repo URL from the previous Image's commit
-	repo, err := s.RepoService.GetRepoByID(previousImage.Commit.RepoID)
-	if err != nil {
-		s.log.WithField("error", err.Error()).Error("Commit repo wasn't found on the database")
-		err := errors.NewBadRequest(fmt.Sprintf("Commit repo wasn't found in the database: #%v", image.Commit.ID))
-		return err
-	}
-
-	image.Commit.OSTreeParentCommit = repo.URL
-	if image.Commit.OSTreeRef == "" {
-		if previousImage.Commit.OSTreeRef != "" {
-			image.Commit.OSTreeRef = previousImage.Commit.OSTreeRef
-		} else {
-			image.Commit.OSTreeRef = config.Get().DefaultOSTreeRef
+	if previousImage.Status == models.ImageStatusSuccess {
+		// Always get the repo URL from the previous Image's commit
+		repo, err := s.RepoService.GetRepoByID(previousImage.Commit.RepoID)
+		if err != nil {
+			s.log.WithField("error", err.Error()).Error("Commit repo wasn't found on the database")
+			err := errors.NewBadRequest(fmt.Sprintf("Commit repo wasn't found in the database: #%v", image.Commit.ID))
+			return err
 		}
-	}
 
+		image.Commit.OSTreeParentCommit = repo.URL
+		if image.Commit.OSTreeRef == "" {
+			if previousImage.Commit.OSTreeRef != "" {
+				image.Commit.OSTreeRef = previousImage.Commit.OSTreeRef
+			} else {
+				image.Commit.OSTreeRef = config.Get().DefaultOSTreeRef
+			}
+		}
+	} else {
+		// Previous image was not built successfully
+		s.log.WithField("previousImageID", previousImage.ID).Info("Creating an update based on a image with a status that is not success")
+	}
 	image, err = s.ImageBuilder.ComposeCommit(image)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description

[BE] EDGE-API sending incorrect ImageSet version for the latest image.

Fixes # [THEEDGE-2164]

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
