### PR TITLE
add validation on rhc to avoid fire update for disconnected device

### DIFF
--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -50,7 +50,6 @@ type DevicesUpdate struct {
 const (
 	// DevicesCantBeEmptyMessage is the error message when the hosts are empty
 	DevicesCantBeEmptyMessage = "devices can not be empty"
-
 	// UpdateStatusCreated is for when a update is created
 	UpdateStatusCreated = "CREATED"
 	// UpdateStatusBuilding is for when a update is building
@@ -59,6 +58,8 @@ const (
 	UpdateStatusError = "ERROR"
 	// UpdateStatusSuccess is for when a update is available to the user
 	UpdateStatusSuccess = "SUCCESS"
+	// UpdateStatusDeviceDisconnected is for when a update is UpdateStatusDeviceDisconnected
+	UpdateStatusDeviceDisconnected = "DISCONNECTED"
 )
 
 const (

--- a/pkg/routes/updates.go
+++ b/pkg/routes/updates.go
@@ -257,7 +257,9 @@ func AddUpdate(w http.ResponseWriter, r *http.Request) {
 		update.Account = account
 		upd = append(upd, update)
 		ctxServices.Log.WithField("updateID", update.ID).Info("Starting asynchronous update process")
-		go ctxServices.UpdateService.CreateUpdate(update.ID)
+		if update.Status != models.UpdateStatusDeviceDisconnected {
+			go ctxServices.UpdateService.CreateUpdate(update.ID)
+		}
 	}
 	if result := db.DB.Save(upd); result.Error != nil {
 		ctxServices.Log.WithFields(log.Fields{

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -647,6 +647,10 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 				}
 			}
 
+			if device.Ostree.RHCClientID == "" {
+				update.Status = models.UpdateStatusDeviceDisconnected
+				continue
+			}
 			updateDevice.RHCClientID = device.Ostree.RHCClientID
 			updateDevice.AvailableHash = update.Commit.OSTreeCommit
 			// update the device account if undefined


### PR DESCRIPTION
# Description

Avoid fire an update to devices that doesn't present the RHC_CLIENT_ID, once they will fail due unavailable connectivity.

Fixes # ([issue](https://issues.redhat.com/browse/THEEDGE-2094))

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `go fmt ./...` to check that my code is properly formatted
- [X] I run `go vet ./...` to check that my code is free of common Go style mistakes
- [X] I run `make lint` to prints out coding style mistakes and fix them
