### PR TITLE
THEEDGE-2149 Logging format fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,13 +71,13 @@ Logging must follow the above logging key concepts as much as possible.
 ### Key concepts
 
 - Messages will only contain plain English and we should be able to group by messages, which means that no variables can be added.
-- All useful data must go onto extra fields. Try to keep the pattern for the extra field name from the rest of the code for common things ("error" for errros, "imageID" for image ID, or for other objects use "objectID").
+- All useful data must go into extra fields. Try to keep the pattern for the extra field name from the rest of the code for common things ("error" for errors, "imageID" for image ID, or for other objects use "objectID").
 - The dependencies middleware adds request-id and account number for debugging & distributed tracing. This is important and needs to be used accross all log messages.
 - The HTTP Handler has an instance of log that can be accessed through services.Log.
-- The services used by the HTTP Handler should be initialized by the dependencies middleware, and they should accept an instance of a LogEntry on the constructor. This needs to be per-request, and relies heavily on context, to be able to have one instance of logging per dependency. This can be refactored in the future if we realize its not the best way (its probably not) as long as we keep the funcionality.
-- Each service will gain a log entry as a private variable and this LogEntry should be used to log inside of the service (s.log instead of log)
+- The services used by the HTTP Handler should be initialized by the dependencies middleware, and they should accept an instance of a LogEntry on the constructor. This needs to be per-request, and relies heavily on context, to be able to have one instance of logging per dependency. This can be refactored in the future if we realize it's not the best way (it's probably not) as long as we keep the functionality.
+- Each service will gain a log entry as a private variable and this LogEntry should be used to log inside of the service (s.log instead of log).
 - All IDs must be added to the LogEntry when an object is saved.
 - All errors must be logged by the first method that catches them.
-- Be mindful of log levels. **Debug** is for insights of a route. **Info** should give enough information on a production service to answer most questions about what happened to a specific route for a specific customer.**Error** are for actual errors.
+- Be mindful of log levels. **Debug** is for insights of a route. **Info** should give enough information on a production service to answer most questions about what happened to a specific route for a specific customer. **Error** is for actual errors.
 
 Happy logging!

--- a/pkg/clients/fdo/client.go
+++ b/pkg/clients/fdo/client.go
@@ -47,7 +47,7 @@ func (c *Client) BatchUpload(ovs []byte, numOfOVs uint) (interface{}, error) {
 	res, err := c.httpClient.Do(req)
 	// handle response
 	if err != nil {
-		c.log.WithField("method", "fdo.BatchUpload").Error("Failed to perform api call to upload vouchers ", err)
+		c.log.WithFields(log.Fields{"method": "fdo.BatchUpload", "error": err}).Error("Failed to perform api call to upload vouchers")
 		return nil, err
 	}
 	return resUploadHandler(c, res)
@@ -64,7 +64,7 @@ func (c *Client) BatchDelete(fdoUUIDList []string) (interface{}, error) {
 	res, err := c.httpClient.Do(req)
 	// handle response
 	if err != nil {
-		c.log.WithField("method", "fdo.BatchDelete").Error("Failed to perform api call to remove vouchers ", err)
+		c.log.WithFields(log.Fields{"method": "fdo.BatchDelete", "error": err}).Error("Failed to perform api call to remove vouchers")
 		return nil, err
 	}
 	return resDeleteHandler(c, res)
@@ -113,7 +113,7 @@ func resUploadHandler(c *Client, res *http.Response) (interface{}, error) {
 		c.log.WithField("method", "fdo.resUploadHandler").Error("Ownershipvouchers couldn't be created, bad request")
 	default:
 		err = errors.New(fmt.Sprint("unknown error with status code: ", res.StatusCode))
-		c.log.WithField("method", "fdo.resUploadHandler").Error("Ownershipvouchers couldn't be created, unknown error with status code: ", res.StatusCode)
+		c.log.WithFields(log.Fields{"method": "fdo.resUploadHandler", "statusCode": res.StatusCode}).Error("Ownershipvouchers couldn't be created, unknown error")
 	}
 	return decodeResBody(&res.Body), err
 }
@@ -150,7 +150,7 @@ func resDeleteHandler(c *Client, res *http.Response) (interface{}, error) {
 		c.log.WithField("method", "fdo.resDeleteHandler").Error("Ownershipvouchers couldn't be removed, bad request")
 	default:
 		err = errors.New(fmt.Sprint("unknown error with status code: ", res.StatusCode))
-		c.log.WithField("method", "fdo.resDeleteHandler").Error("Ownershipvouchers couldn't be removed, unknown error with status code: ", res.StatusCode)
+		c.log.WithFields(log.Fields{"method": "fdo.resDeleteHandler", "statusCode": res.StatusCode}).Error("Ownershipvouchers couldn't be removed, unknown error")
 	}
 	return decodeResBody(&res.Body), err
 }

--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -372,7 +372,7 @@ func (c *Client) GetInstallerStatus(image *models.Image) (*models.Image, error) 
 
 // GetMetadata returns the metadata on image builder for a particular image based on the ComposeJobID
 func (c *Client) GetMetadata(image *models.Image) (*models.Image, error) {
-	c.log.Infof("Getting metadata for image")
+	c.log.Info("Getting metadata for image")
 	composeJobID := image.Commit.ComposeJobID
 	cfg := config.Get()
 	url := fmt.Sprintf("%s/api/image-builder/v1/composes/%s/metadata", cfg.ImageBuilderConfig.URL, composeJobID)
@@ -412,7 +412,7 @@ func (c *Client) GetMetadata(image *models.Image) (*models.Image, error) {
 
 	var metadata Metadata
 	if err := json.Unmarshal(respBody, &metadata); err != nil {
-		c.log.Error("Error while trying to unmarshal ", metadata)
+		c.log.WithField("response", metadata).Error("Error while trying to unmarshal Image Builder GetMetadata Response")
 		return nil, err
 	}
 	for n := range metadata.InstalledPackages {
@@ -425,7 +425,7 @@ func (c *Client) GetMetadata(image *models.Image) (*models.Image, error) {
 		image.Commit.InstalledPackages = append(image.Commit.InstalledPackages, pkg)
 	}
 	image.Commit.OSTreeCommit = metadata.OstreeCommit
-	c.log.Infof("Done with metadata for image")
+	c.log.Info("Done with metadata for image")
 	return image, nil
 }
 
@@ -447,7 +447,7 @@ func (c *Client) GetImageThirdPartyRepos(image *models.Image) ([]Repository, err
 	var count int64
 	result := db.DB.Where("account = ?", image.Account).Find(&thirdpartyrepos, thirdpartyrepoIDS).Count(&count)
 	if result.Error != nil {
-		log.Error(result.Error)
+		c.log.WithField("error", result.Error).Error("Error finding custom repositories")
 		return nil, result.Error
 	}
 

--- a/pkg/clients/inventory/client.go
+++ b/pkg/clients/inventory/client.go
@@ -158,9 +158,7 @@ func (c *Client) ReturnDevices(parameters *Params) (Response, error) {
 // ReturnDevicesByID will return the list of devices by uuid
 func (c *Client) ReturnDevicesByID(deviceID string) (Response, error) {
 	if _, err := uuid.Parse(deviceID); err != nil {
-		c.log.WithFields(log.Fields{
-			"error": err,
-		}).Error("invalid device ID, ", deviceID)
+		c.log.WithFields(log.Fields{"error": err, "deviceID": deviceID}).Error("invalid device ID")
 		return Response{}, err
 	}
 	url := fmt.Sprintf("%s/%s%s&hostname_or_id=%s", config.Get().InventoryConfig.URL, inventoryAPI, FilterParams, deviceID)
@@ -197,7 +195,7 @@ func (c *Client) ReturnDevicesByID(deviceID string) (Response, error) {
 	}
 	var inventory Response
 	if err := json.Unmarshal([]byte(body), &inventory); err != nil {
-		c.log.Error("Error while trying to unmarshal ", &inventory)
+		c.log.WithField("response", &inventory).Error("Error while trying to unmarshal InventoryResponse")
 		return Response{}, err
 	}
 	return inventory, nil
@@ -241,7 +239,7 @@ func (c *Client) ReturnDevicesByTag(tag string) (Response, error) {
 	}
 	var inventory Response
 	if err := json.Unmarshal([]byte(body), &inventory); err != nil {
-		c.log.Error("Error while trying to unmarshal ", &inventory)
+		c.log.WithField("response", &inventory).Error("Error while trying to unmarshal InventoryResponse")
 		return Response{}, err
 	}
 	return inventory, nil

--- a/pkg/clients/playbookdispatcher/client.go
+++ b/pkg/clients/playbookdispatcher/client.go
@@ -90,7 +90,7 @@ func (c *Client) ExecuteDispatcher(payload DispatcherPayload) ([]Response, error
 
 	var playbookResponse []Response
 	if err := json.Unmarshal([]byte(body), &playbookResponse); err != nil {
-		c.log.Error("Error while trying to unmarshal ", &playbookResponse)
+		c.log.WithField("response", &playbookResponse).Error("Error while trying to unmarshal PlaybookDispatcher ExecuteDispatcher Response")
 		return nil, err
 	}
 	return playbookResponse, nil

--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -532,8 +532,7 @@ func CreateKickStartForImage(w http.ResponseWriter, r *http.Request) {
 		services := dependencies.ServicesFromContext(r.Context())
 		err := services.ImageService.AddUserInfo(image)
 		if err != nil {
-			// TODO: Temporary. Handle error better.
-			services.Log.Errorf("Kickstart file injection failed %s", err.Error())
+			services.Log.WithField("error", err.Error()).Error("Kickstart file injection failed")
 			err := errors.NewInternalServerError()
 			w.WriteHeader(err.GetStatus())
 			if err := json.NewEncoder(w).Encode(&err); err != nil {

--- a/pkg/services/consumers.go
+++ b/pkg/services/consumers.go
@@ -56,7 +56,7 @@ func NewKafkaConsumerService(config *clowder.KafkaConfig, topic string) Consumer
 	case "platform.edge.fleetmgmt.image-build":
 		s.consumer = s.ConsumeImageBuildEvents
 	default:
-		log.Errorf("No consumer for topic: %s", topic)
+		log.WithField("topic", topic).Error("No consumer for topic")
 		return nil
 	}
 	s.Reader = s.initReader()
@@ -117,7 +117,7 @@ func (s *KafkaConsumerService) ConsumePlaybookDispatcherRuns() error {
 			log.Debug("Skipping message - it is not from edge service")
 		}
 		if s.isShuttingDown() {
-			log.Info("ShootingDown, exiting playbook dispatcher's runs consumer")
+			log.Info("Shutting down, exiting playbook dispatcher's runs consumer")
 			return nil
 		}
 	}
@@ -173,7 +173,7 @@ func (s *KafkaConsumerService) ConsumePlatformInventoryEvents() error {
 			}).Error("Error writing Kafka message to DB")
 		}
 		if s.isShuttingDown() {
-			log.Info("ShootingDown, exiting platform inventory events consumer")
+			log.Info("Shutting down, exiting platform inventory events consumer")
 			return nil
 		}
 	}
@@ -209,13 +209,13 @@ func (s *KafkaConsumerService) ConsumeImageBuildEvents() error {
 		// currently only logging events while resume is handled via API
 		eventErr := json.Unmarshal([]byte(m.Value), &eventMessage)
 		if eventErr != nil {
-			log.WithField("error", eventErr).Debug("Error unmarshaling event. This is not the event you're looking for")
+			log.WithField("error", eventErr).Debug("Error unmarshalling event. This is not the event you're looking for")
 		} else {
-			log.WithField("imageID", eventMessage.ImageID).Debug("Resuming image ID from event on " + string(m.Topic))
+			log.WithFields(log.Fields{"imageID": eventMessage.ImageID, "topic": m.Topic}).Debug("Resuming image ID from event")
 		}
 
 		if s.isShuttingDown() {
-			log.Info("ShuttingDown, exiting image build events consumer")
+			log.Info("Shutting down, exiting image build events consumer")
 			return nil
 		}
 	}
@@ -264,7 +264,7 @@ func (s *KafkaConsumerService) Start() {
 					"error": err.Error(),
 				}).Error("There was en error connecting to the broker. Reader was intentionally closed.")
 			}
-			log.Info("ShuttingDown, exiting main consumer loop")
+			log.Info("Shutting down, exiting main consumer loop")
 			break
 		}
 

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -603,7 +603,7 @@ func (s *ImageService) CreateRepoForImage(i *models.Image) (*models.Repo, error)
 	if err != nil {
 		return nil, err
 	}
-	s.log.Infof("OSTree repo is ready")
+	s.log.Info("OSTree repo is ready")
 
 	return repo, nil
 }

--- a/pkg/services/ownershipvoucher_active.go
+++ b/pkg/services/ownershipvoucher_active.go
@@ -77,7 +77,7 @@ func (ovs *OwnershipVoucherService) ConnectDevices(fdoUUIDList []string) (resp [
 	for _, guid := range fdoUUIDList {
 		fdoDevice, err := ovs.GetFDODeviceByGUID(guid)
 		if err != nil {
-			ovs.log.WithFields(logFields).Warn("Couldn't find OwnershipVoucher ", guid, err)
+			ovs.log.WithFields(logFields).WithFields(log.Fields{"guid": guid, "error": err}).Warn("Couldn't find OwnershipVoucher")
 			errList = append(errList, errors.New(guid))
 		} else {
 			fdoDevice.Connected = true
@@ -108,7 +108,7 @@ func (ovs *OwnershipVoucherService) GetFDODeviceByGUID(ownershipVoucherGUID stri
 	var fdoDevice models.FDODevice
 	result := preloadFDODevices(ownershipVoucherGUID).First(&fdoDevice)
 	if result.Error != nil {
-		ovs.log.WithFields(logFields).Error("Failed to get FDO device by GUID ", result.Error)
+		ovs.log.WithFields(logFields).WithField("error", result.Error).Error("Failed to get FDO device by GUID")
 		return nil, result.Error
 	}
 	return &fdoDevice, nil
@@ -125,7 +125,7 @@ func (ovs *OwnershipVoucherService) storeFDODevices(data []models.OwnershipVouch
 		}
 		result := preloadFDODevices(voucherData.GUID).FirstOrCreate(&fdoDevice)
 		if result.Error != nil {
-			ovs.log.WithFields(logFields).Error("Failed to store FDO device ", result.Error)
+			ovs.log.WithFields(logFields).WithField("error", result.Error).Error("Failed to store FDO device")
 		}
 	}
 }
@@ -137,7 +137,7 @@ func (ovs *OwnershipVoucherService) removeFDODevices(fdoUUIDList []string) {
 		var fdoDevice models.FDODevice
 		result := preloadFDODevices(guid).First(&fdoDevice)
 		if result.Error != nil {
-			ovs.log.WithFields(logFields).Error("Failed to remove FDO device ", result.Error)
+			ovs.log.WithFields(logFields).WithField("error", result.Error).Error("Failed to remove FDO device")
 		}
 		db.DB.Delete(&fdoDevice)
 	}
@@ -148,7 +148,7 @@ func (ovs *OwnershipVoucherService) parseVouchers(voucherBytes []byte) ([]models
 	logFields := log.Fields{"method": "services.parseVouchers"}
 	vouchers, err := libfdo.ParseManyOwnershipVouchers(voucherBytes)
 	if err != nil {
-		ovs.log.WithFields(logFields).Error("Failed to parse vouchers ", err)
+		ovs.log.WithFields(logFields).WithField("error", err).Error("Failed to parse vouchers")
 		return nil, err
 	}
 	defer vouchers.Free()
@@ -157,7 +157,7 @@ func (ovs *OwnershipVoucherService) parseVouchers(voucherBytes []byte) ([]models
 	for i := 0; i < vouchers.Len(); i++ {
 		voucher, err := vouchers.GetVoucher(i)
 		if err != nil {
-			ovs.log.WithFields(logFields).Error("Failed to get voucher ", err)
+			ovs.log.WithFields(logFields).WithField("error", err).Error("Failed to get voucher")
 			return nil, err
 		}
 		data[i] = models.OwnershipVoucherData{

--- a/pkg/services/thirdpartyrepo.go
+++ b/pkg/services/thirdpartyrepo.go
@@ -36,7 +36,7 @@ type ThirdPartyRepoService struct {
 func (s *ThirdPartyRepoService) thirdPartyRepoNameExists(account string, name string) (bool, error) {
 	var reposCount int64
 	if result := db.DB.Model(&models.ThirdPartyRepo{}).Where("account = ? AND name = ?", account, name).Count(&reposCount); result.Error != nil {
-		s.log.WithField("error", result.Error.Error()).Error("Error checking third party repository existence")
+		s.log.WithField("error", result.Error.Error()).Error("Error checking custom repository existence")
 		return false, result.Error
 	}
 
@@ -57,7 +57,7 @@ func (s *ThirdPartyRepoService) thirdPartyRepoImagesExists(id string, imageStatu
 		tx = tx.Where("images.status IN (?)", imageStatuses)
 	}
 	if result := tx.Debug().Count(&imagesCount); result.Error != nil {
-		s.log.WithField("error", result.Error.Error()).Error("Error checking third party repository existence")
+		s.log.WithField("error", result.Error.Error()).Error("Error checking custom repository existence")
 		return false, result.Error
 	}
 
@@ -89,7 +89,7 @@ func (s *ThirdPartyRepoService) CreateThirdPartyRepo(thirdPartyRepo *models.Thir
 		Account:     account,
 	}
 	if result := db.DB.Create(&createdThirdPartyRepo); result.Error != nil {
-		s.log.WithField("error", result.Error.Error()).Error("Error creating third party repository")
+		s.log.WithField("error", result.Error.Error()).Error("Error creating custom repository")
 		return nil, result.Error
 	}
 
@@ -118,7 +118,7 @@ func (s *ThirdPartyRepoService) UpdateThirdPartyRepo(tprepo *models.ThirdPartyRe
 	tprepo.Account = account
 	repoDetails, err := s.GetThirdPartyRepoByID(ID)
 	if err != nil {
-		s.log.WithField("error", err.Error()).Error("Error retrieving third party repository")
+		s.log.WithField("error", err.Error()).Error("Error retrieving custom repository")
 		return err
 	}
 	if tprepo.Name != "" {
@@ -170,7 +170,7 @@ func (s *ThirdPartyRepoService) DeleteThirdPartyRepoByID(ID string) (*models.Thi
 	}
 	repoDetails, err := s.GetThirdPartyRepoByID(ID)
 	if err != nil {
-		s.log.WithField("error", err.Error()).Error("Error retrieving third party repository")
+		s.log.WithField("error", err.Error()).Error("Error retrieving custom repository")
 		return nil, err
 	}
 	// fail to delete if any image exists (with any status)
@@ -182,7 +182,7 @@ func (s *ThirdPartyRepoService) DeleteThirdPartyRepoByID(ID string) (*models.Thi
 		return nil, new(ThirdPartyRepositoryImagesExists)
 	}
 	if result := db.DB.Where("account = ? and id = ?", account, ID).Delete(&repoDetails); result.Error != nil {
-		s.log.WithField("error", result.Error.Error()).Error("Error deleting third party repository")
+		s.log.WithField("error", result.Error.Error()).Error("Error deleting custom repository")
 		return nil, result.Error
 	}
 	return repoDetails, nil

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -236,7 +236,7 @@ func (s *UpdateService) WriteTemplate(templateInfo TemplateRemoteInfo, account s
 	templateName := "template_playbook_dispatcher_ostree_upgrade_payload.yml"
 	templateContents, err := template.New(templateName).Delims("@@", "@@").ParseFiles(filePath + templateName)
 	if err != nil {
-		s.log.WithField("error", err.Error()).Errorf("Error parsing playbook template")
+		s.log.WithField("error", err.Error()).Error("Error parsing playbook template")
 		return "", err
 	}
 	var envName string
@@ -257,19 +257,19 @@ func (s *UpdateService) WriteTemplate(templateInfo TemplateRemoteInfo, account s
 	tmpfilepath := fmt.Sprintf("/tmp/%s", fname)
 	f, err := os.Create(tmpfilepath)
 	if err != nil {
-		s.log.WithField("error", err.Error()).Errorf("Error creating file")
+		s.log.WithField("error", err.Error()).Error("Error creating file")
 		return "", err
 	}
 	err = templateContents.Execute(f, templateData)
 	if err != nil {
-		s.log.WithField("error", err.Error()).Errorf("Error executing template")
+		s.log.WithField("error", err.Error()).Error("Error executing template")
 		return "", err
 	}
 
 	uploadPath := fmt.Sprintf("%s/playbooks/%s", account, fname)
 	playbookURL, err := s.FilesService.GetUploader().UploadFile(tmpfilepath, uploadPath)
 	if err != nil {
-		s.log.WithField("error", err.Error()).Errorf("Error uploading file to S3")
+		s.log.WithField("error", err.Error()).Error("Error uploading file to S3")
 		return "", err
 	}
 	s.log.WithField("playbookURL", playbookURL).Info("Template file uploaded to S3")
@@ -281,7 +281,7 @@ func (s *UpdateService) WriteTemplate(templateInfo TemplateRemoteInfo, account s
 	}
 	playbookURL = s.getPlaybookURL(templateInfo.UpdateTransactionID)
 	s.log.WithField("playbookURL", playbookURL).Info("Proxied playbook URL")
-	s.log.Infof("Update was finished")
+	s.log.Info("Update was finished")
 	return playbookURL, nil
 }
 
@@ -431,7 +431,7 @@ func (s *UpdateService) SendDeviceNotification(i *models.UpdateTransaction) (Ima
 		p, err := kafka.NewProducer(&kafka.ConfigMap{
 			"bootstrap.servers": brokers[0]})
 		if err != nil {
-			s.log.WithField("message", err.Error()).Error("producer")
+			s.log.WithField("message", err.Error()).Error("Error creating Kafka producer")
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
# Description
This PR fixes some typos in logging messages. It also changes logging calls that log the specific variable values as part of the message, so that the variable data are in extra fields instead. This is to bring them in line with the contributor guidelines:

```
- Messages will only contain plain English and we should be able to group by messages, which means that no variables can be added.
- All useful data must go onto extra fields. Try to keep the pattern for the extra field name from the rest of the code for common things ("error" for errros, "imageID" for image ID, or for other objects use "objectID").
```

Fixes # (THEEDGE-2149)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
- [x] I run `make lint` to prints out coding style mistakes and fix them
