### PR TITLE
added limit and offset to image-sets spec-file

### DIFF
--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -705,6 +705,16 @@ paths:
           description: "field: filter by status"
           schema:
             type: string
+        - name: limit
+          in: query
+          description: "field: return number of image-sets until limit is reached. Default is 100."
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          description: "field: return number of image-sets begining at the offset."
+          schema:
+            type: integer
       responses:
         "200":
           content:
@@ -764,6 +774,16 @@ paths:
           description: "field: filter by status"
           schema:
             type: string
+        - name: limit
+          in: query
+          description: "field: return number of images until limit is reached. Default is 100."
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          description: "field: return number of images begining at the offset."
+          schema:
+            type: integer
       responses:
         "200":
           content:


### PR DESCRIPTION
# Description

limit and offset query params were missing form the spec file for get-image-set and list-image-sets endpoints.
this PR adds them to the spec file 


What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor
