### PR TITLE
THEEDGE-2168: update kickstart template to install RHEL for Edge 8.x/9.x

### DIFF
--- a/templates/templateKickstart.ks
+++ b/templates/templateKickstart.ks
@@ -16,11 +16,11 @@ network --bootproto=dhcp --device=link --activate --onboot=on
 echo PRE
 
 # RHEL for Edge 8.5 moves the ostree dir to the root of the image
+# RHEL for Edge 8.4 and 9.0 install from /run/install/repo
 # Auto-detect a dir at that location and inject it into the command list for install
-# Default to prior ostree/repo location in 8.4
-[[ -d /run/install/repo/ostree ]] \
-	&& echo "ostreesetup --nogpg --osname=rhel-edge --remote=rhel-edge --url=file:///run/install/repo/ostree/repo --ref=rhel/8/x86_64/edge" > /tmp/ostreesetup \
-	|| echo "ostreesetup --nogpg --osname=rhel-edge --remote=rhel-edge --url=file:///ostree/repo --ref=rhel/8/x86_64/edge" > /tmp/ostreesetup
+[[ -d /run/install/repo/ostree ]] && repodir='/run/install/repo/ostree/repo' || repodir='/ostree/repo'
+ref=$(ostree refs --repo=${repodir})
+echo "ostreesetup --nogpg --osname=rhel-edge --remote=rhel-edge --url=file://${repodir} --ref=${ref}" > /tmp/ostreesetup
 
 # Handle include for custom post section if a post file exists
 [[ -e /run/install/repo/fleet_kspost.txt ]] && cp /run/install/repo/fleet_kspost.txt /tmp \


### PR DESCRIPTION
* refactor to handle 8.4, 8.5, or 9.0 repo dir at install

Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Updated the kickstart template to make ostreesetup handle 8.4, 8.5, or 9.0 at install

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `go fmt ./...` to check that my code is properly formatted
- [ ] I run `go vet ./...` to check that my code is free of common Go style mistakes
- [ ] I run `make lint` to prints out coding style mistakes and fix them
