### PR TITLE
read fflag config from env and overwrite with clowder if enabled

### DIFF
--- a/main.go
+++ b/main.go
@@ -125,13 +125,25 @@ func serveWeb(cfg *config.EdgeConfig, consumers []services.ConsumerService) *htt
 
 func gracefulTermination(server *http.Server, serviceName string) {
 	log.Infof("%s service stopped", serviceName)
-	unleash.Close()
+	if featureFlagsServiceUnleash() && featureFlagsConfigPresent() {
+		unleash.Close()
+	}
 	ctxShutdown, cancel := context.WithTimeout(context.Background(), 5*time.Second) // 5 seconds for graceful shutdown
 	defer cancel()
 	if err := server.Shutdown(ctxShutdown); err != nil {
 		l.LogErrorAndPanic(fmt.Sprintf("%s service shutdown failed", serviceName), err)
 	}
 	log.Infof("%s service shutdown complete", serviceName)
+}
+
+func featureFlagsConfigPresent() bool {
+	conf := config.Get()
+	return conf.FeatureFlagsURL != ""
+}
+
+func featureFlagsServiceUnleash() bool {
+	conf := config.Get()
+	return conf.FeatureFlagsService == "unleash"
 }
 
 func main() {
@@ -147,16 +159,21 @@ func main() {
 	_ = json.Unmarshal(cfgBytes, &configValues)
 	log.WithFields(configValues).Info("Configuration Values")
 
-	err := unleash.Initialize(
-		unleash.WithListener(&unleash.DebugListener{}),
-		unleash.WithAppName("edge-api"),
-		unleash.WithUrl(cfg.UnleashURL),
-		unleash.WithRefreshInterval(5*time.Second),
-		unleash.WithMetricsInterval(5*time.Second),
-		unleash.WithCustomHeaders(http.Header{"Authorization": {"Bearer " + cfg.UnleashSecretName}}),
-	)
-	if err != nil {
-		l.LogErrorAndPanic("Unleash client failed to initialized", err)
+	if featureFlagsServiceUnleash() && featureFlagsConfigPresent() {
+		err := unleash.Initialize(
+			unleash.WithListener(&unleash.DebugListener{}),
+			unleash.WithAppName("edge-api"),
+			unleash.WithUrl(cfg.UnleashURL),
+			unleash.WithRefreshInterval(5*time.Second),
+			unleash.WithMetricsInterval(5*time.Second),
+			unleash.WithCustomHeaders(http.Header{"Authorization": {"Bearer " + cfg.UnleashSecretName}}),
+		)
+		if err != nil {
+			//l.LogErrorAndPanic("Unleash client failed to initialized", err)
+			log.WithField("Error", err).Error("Unleash client failed to initialize")
+		}
+	} else {
+		log.WithField("FeatureFlagURL", cfg.UnleashURL).Warning("FeatureFlag service initialization was skipped.")
 	}
 
 	consumers := []services.ConsumerService{


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Add Feature Flag host and key from clowder config if clowder is enabled.
Defaults to env var if clowder is unavailable.

Fixes # (issue) 

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
- [x] I run `make lint` to prints out coding style mistakes and fix them
