### PR TITLE
Get S3 bucket information from configuration for templates.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,7 @@ type EdgeConfig struct {
 	Debug                    bool                      `json:"debug,omitempty"`
 	Database                 *dbConfig                 `json:"database,omitempty"`
 	BucketName               string                    `json:"bucket_name,omitempty"`
-	BucketRegion             *string                   `json:"bucket_region,omitempty"`
+	BucketRegion             string                    `json:"bucket_region,omitempty"`
 	AccessKey                string                    `json:"-"`
 	SecretKey                string                    `json:"-"`
 	RepoTempPath             string                    `json:"repo_temp_path,omitempty"`
@@ -92,6 +92,7 @@ func Init() {
 	options.SetDefault("Auth", false)
 	options.SetDefault("Debug", false)
 	options.SetDefault("EdgeTarballsBucket", "rh-edge-tarballs")
+	options.SetDefault("BucketRegion", "us-east-1")
 	options.SetDefault("ImageBuilderUrl", "http://image-builder:8080")
 	options.SetDefault("InventoryUrl", "http://host-inventory-service:8080/")
 	options.SetDefault("PlaybookDispatcherURL", "http://playbook-dispatcher:8080/")
@@ -159,6 +160,7 @@ func Init() {
 		Debug:           options.GetBool("Debug"),
 		LogLevel:        options.GetString("LOG_LEVEL"),
 		BucketName:      options.GetString("EdgeTarballsBucket"),
+		BucketRegion:    options.GetString("BucketRegion"),
 		RepoTempPath:    options.GetString("RepoTempPath"),
 		OpenAPIFilePath: options.GetString("OpenAPIFilePath"),
 		ImageBuilderConfig: &imageBuilderConfig{
@@ -228,7 +230,9 @@ func Init() {
 		bucket := clowder.ObjectBuckets[config.BucketName]
 
 		config.BucketName = bucket.RequestedName
-		config.BucketRegion = bucket.Region
+		if bucket.Region != nil {
+			config.BucketRegion = *bucket.Region
+		}
 		config.AccessKey = *bucket.AccessKey
 		config.SecretKey = *bucket.SecretKey
 		config.Logging = &loggingConfig{

--- a/pkg/services/files.go
+++ b/pkg/services/files.go
@@ -81,7 +81,7 @@ func NewFilesService(log *log.Entry) FilesService {
 	} else {
 		var err error
 		sess, err = session.NewSession(&aws.Config{
-			Region:      cfg.BucketRegion,
+			Region:      &cfg.BucketRegion,
 			Credentials: credentials.NewStaticCredentials(cfg.AccessKey, cfg.SecretKey, ""),
 		})
 		if err != nil {

--- a/pkg/services/files/uploader.go
+++ b/pkg/services/files/uploader.go
@@ -88,7 +88,7 @@ func newS3Uploader(log *log.Entry) *S3Uploader {
 	} else {
 		var err error
 		sess, err = session.NewSession(&aws.Config{
-			Region:      cfg.BucketRegion,
+			Region:      &cfg.BucketRegion,
 			Credentials: credentials.NewStaticCredentials(cfg.AccessKey, cfg.SecretKey, ""),
 		})
 		if err != nil {

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -70,6 +70,7 @@ type playbooks struct {
 	FleetInfraEnv        string
 	UpdateNumber         string
 	RepoURL              string
+	BucketRegion         string
 }
 
 // TemplateRemoteInfo the values to playbook
@@ -246,11 +247,13 @@ func (s *UpdateService) WriteTemplate(templateInfo TemplateRemoteInfo, account s
 	} else {
 		envName = "dev"
 	}
+
 	templateData := playbooks{
 		GoTemplateRemoteName: templateInfo.RemoteName,
 		FleetInfraEnv:        envName,
+		BucketRegion:         cfg.BucketRegion,
 		UpdateNumber:         strconv.FormatUint(uint64(templateInfo.UpdateTransactionID), 10),
-		RepoURL:              "https://{{ s3_buckets[fleet_infra_env] | default('rh-edge-tarballs-prod') }}.s3.us-east-1.amazonaws.com/{{ update_number }}/upd/{{ update_number }}/repo",
+		RepoURL:              "https://{{ s3_buckets[fleet_infra_env] | default('rh-edge-tarballs-stage') }}.s3.{{ s3_region | default('us-east-1') }}.amazonaws.com/{{ update_number }}/upd/{{ update_number }}/repo",
 	}
 
 	fname := fmt.Sprintf("playbook_dispatcher_update_%s_%d.yml", account, templateInfo.UpdateTransactionID)

--- a/templates/template_playbook_dispatcher_ostree_upgrade_payload.test.yml
+++ b/templates/template_playbook_dispatcher_ostree_upgrade_payload.test.yml
@@ -5,11 +5,12 @@
   vars:
     fleet_infra_env: "dev"
     update_number: "1000"
+    s3_region: "us-east-1"
     s3_buckets:
       prod: "rh-edge-tarballs-prod"
       stage: "rh-edge-tarballs-stage"
       perf: "rh-edge-tarballs-perf"
-    repo_url: "https://{{ s3_buckets[fleet_infra_env] | default('rh-edge-tarballs-prod') }}.s3.us-east-1.amazonaws.com/{{ update_number }}/upd/{{ update_number }}/repo"
+    repo_url: "https://{{ s3_buckets[fleet_infra_env] | default('rh-edge-tarballs-stage') }}.s3.{{ s3_region | default('us-east-1') }}.amazonaws.com/{{ update_number }}/upd/{{ update_number }}/repo"
     ostree_remote_name: "remote-name"
     ostree_gpg_verify: "false"
     ostree_gpg_keypath: "/etc/pki/rpm-gpg/"

--- a/templates/template_playbook_dispatcher_ostree_upgrade_payload.yml
+++ b/templates/template_playbook_dispatcher_ostree_upgrade_payload.yml
@@ -5,6 +5,7 @@
   vars:
     fleet_infra_env: "@@ .FleetInfraEnv @@"
     update_number: "@@ .UpdateNumber @@"
+    s3_region: "@@ .BucketRegion @@"
     s3_buckets:
       prod: "rh-edge-tarballs-prod"
       stage: "rh-edge-tarballs-stage"


### PR DESCRIPTION
When uploading ansible playbook templates to S3, get the bucket region information from configuration.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
- [ ] I run `make lint` to prints out coding style mistakes and fix them
