### PR TITLE
fixed UpdateAllDevicesFromGroup sepc file

### DIFF
--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -1525,7 +1525,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/v1.UpdateTransaction"
+                type: array
+                items:
+                  $ref: '#/components/schemas/v1.UpdateTransaction'
           description: OK
         "400":
           content:


### PR DESCRIPTION
changed UpdateAllDevicesFromGroup spec file so that the return value is an array, matching the actual API behavior


What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor
