### PR TITLE
save the update transactions when try update to a disconnected device

### DIFF
--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -652,6 +652,9 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 
 			if device.Ostree.RHCClientID == "" {
 				update.Status = models.UpdateStatusDeviceDisconnected
+				if result := db.DB.Create(&update); result.Error != nil {
+					return nil, result.Error
+				}
 				continue
 			}
 			updateDevice.RHCClientID = device.Ostree.RHCClientID


### PR DESCRIPTION
# Description

When RHC_Client_c is null the update should not be fired to playbook dispatcher, however, we should save the transaction as DISCONNECTED. 
The problem occurred because we weren't storing the transaction.

Fixes # ([issue](https://issues.redhat.com/browse/THEEDGE-2276))

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
