### PR TITLE
updates: fixes codebase for createUpdate async call.

### DIFF
--- a/pkg/routes/devicegroups.go
+++ b/pkg/routes/devicegroups.go
@@ -688,7 +688,7 @@ func UpdateAllDevicesFromGroup(w http.ResponseWriter, r *http.Request) {
 		update.Account = account
 		upd = append(upd, update)
 		ctxServices.Log.WithField("updateID", update.ID).Info("Starting asynchronous update process")
-		go ctxServices.UpdateService.CreateUpdate(update.ID)
+		ctxServices.UpdateService.CreateUpdateAsync(update.ID)
 	}
 	if len(upd) == 0 {
 		respondWithAPIError(w, ctxServices.Log, errors.NewNotFound("devices not found"))

--- a/pkg/routes/devicegroups_test.go
+++ b/pkg/routes/devicegroups_test.go
@@ -641,7 +641,7 @@ var _ = Describe("DeviceGroup routes", func() {
 				mockUpdateService.EXPECT().BuildUpdateTransactions(&devicesUpdate, account, &commit).
 					Return(&updTransactions, nil)
 				for _, trans := range updTransactions {
-					mockUpdateService.EXPECT().CreateUpdate(trans.ID).Return(&trans, nil)
+					mockUpdateService.EXPECT().CreateUpdateAsync(trans.ID)
 				}
 				handler := http.HandlerFunc(UpdateAllDevicesFromGroup)
 				handler.ServeHTTP(rr, req)

--- a/pkg/routes/updates.go
+++ b/pkg/routes/updates.go
@@ -258,7 +258,7 @@ func AddUpdate(w http.ResponseWriter, r *http.Request) {
 		upd = append(upd, update)
 		ctxServices.Log.WithField("updateID", update.ID).Info("Starting asynchronous update process")
 		if update.Status != models.UpdateStatusDeviceDisconnected {
-			go ctxServices.UpdateService.CreateUpdate(update.ID)
+			ctxServices.UpdateService.CreateUpdateAsync(update.ID)
 		}
 	}
 	if result := db.DB.Save(upd); result.Error != nil {

--- a/pkg/routes/updates_test.go
+++ b/pkg/routes/updates_test.go
@@ -374,7 +374,7 @@ var _ = Describe("Update routes", func() {
 				req = req.WithContext(ctx)
 
 				mockUpdateService.EXPECT().BuildUpdateTransactions(gomock.Any(), account, gomock.Any()).Return(&updateTransactions, nil)
-				mockUpdateService.EXPECT().CreateUpdate(updateTransactions[0].ID)
+				mockUpdateService.EXPECT().CreateUpdateAsync(updateTransactions[0].ID)
 
 				responseRecorder := httptest.NewRecorder()
 				handler := http.HandlerFunc(AddUpdate)
@@ -394,7 +394,7 @@ var _ = Describe("Update routes", func() {
 				req = req.WithContext(ctx)
 
 				mockUpdateService.EXPECT().BuildUpdateTransactions(gomock.Any(), account, gomock.Any()).Return(&updateTransactions, nil)
-				mockUpdateService.EXPECT().CreateUpdate(updateTransactions[0].ID)
+				mockUpdateService.EXPECT().CreateUpdateAsync(updateTransactions[0].ID)
 
 				responseRecorder := httptest.NewRecorder()
 				handler := http.HandlerFunc(AddUpdate)

--- a/pkg/services/mock_services/updates.go
+++ b/pkg/services/mock_services/updates.go
@@ -5,37 +5,38 @@
 package mock_services
 
 import (
+	io "io"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/redhatinsights/edge-api/pkg/models"
 	services "github.com/redhatinsights/edge-api/pkg/services"
-	io "io"
-	reflect "reflect"
 )
 
-// MockUpdateServiceInterface is a mock of UpdateServiceInterface interface
+// MockUpdateServiceInterface is a mock of UpdateServiceInterface interface.
 type MockUpdateServiceInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockUpdateServiceInterfaceMockRecorder
 }
 
-// MockUpdateServiceInterfaceMockRecorder is the mock recorder for MockUpdateServiceInterface
+// MockUpdateServiceInterfaceMockRecorder is the mock recorder for MockUpdateServiceInterface.
 type MockUpdateServiceInterfaceMockRecorder struct {
 	mock *MockUpdateServiceInterface
 }
 
-// NewMockUpdateServiceInterface creates a new mock instance
+// NewMockUpdateServiceInterface creates a new mock instance.
 func NewMockUpdateServiceInterface(ctrl *gomock.Controller) *MockUpdateServiceInterface {
 	mock := &MockUpdateServiceInterface{ctrl: ctrl}
 	mock.recorder = &MockUpdateServiceInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockUpdateServiceInterface) EXPECT() *MockUpdateServiceInterfaceMockRecorder {
 	return m.recorder
 }
 
-// BuildUpdateTransactions mocks base method
+// BuildUpdateTransactions mocks base method.
 func (m *MockUpdateServiceInterface) BuildUpdateTransactions(devicesUpdate *models.DevicesUpdate, account string, commit *models.Commit) (*[]models.UpdateTransaction, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BuildUpdateTransactions", devicesUpdate, account, commit)
@@ -44,13 +45,13 @@ func (m *MockUpdateServiceInterface) BuildUpdateTransactions(devicesUpdate *mode
 	return ret0, ret1
 }
 
-// BuildUpdateTransactions indicates an expected call of BuildUpdateTransactions
+// BuildUpdateTransactions indicates an expected call of BuildUpdateTransactions.
 func (mr *MockUpdateServiceInterfaceMockRecorder) BuildUpdateTransactions(devicesUpdate, account, commit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildUpdateTransactions", reflect.TypeOf((*MockUpdateServiceInterface)(nil).BuildUpdateTransactions), devicesUpdate, account, commit)
 }
 
-// CreateUpdate mocks base method
+// CreateUpdate mocks base method.
 func (m *MockUpdateServiceInterface) CreateUpdate(id uint) (*models.UpdateTransaction, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateUpdate", id)
@@ -59,13 +60,25 @@ func (m *MockUpdateServiceInterface) CreateUpdate(id uint) (*models.UpdateTransa
 	return ret0, ret1
 }
 
-// CreateUpdate indicates an expected call of CreateUpdate
+// CreateUpdate indicates an expected call of CreateUpdate.
 func (mr *MockUpdateServiceInterfaceMockRecorder) CreateUpdate(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUpdate", reflect.TypeOf((*MockUpdateServiceInterface)(nil).CreateUpdate), id)
 }
 
-// GetUpdatePlaybook mocks base method
+// CreateUpdateAsync mocks base method.
+func (m *MockUpdateServiceInterface) CreateUpdateAsync(id uint) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "CreateUpdateAsync", id)
+}
+
+// CreateUpdateAsync indicates an expected call of CreateUpdateAsync.
+func (mr *MockUpdateServiceInterfaceMockRecorder) CreateUpdateAsync(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUpdateAsync", reflect.TypeOf((*MockUpdateServiceInterface)(nil).CreateUpdateAsync), id)
+}
+
+// GetUpdatePlaybook mocks base method.
 func (m *MockUpdateServiceInterface) GetUpdatePlaybook(update *models.UpdateTransaction) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUpdatePlaybook", update)
@@ -74,13 +87,13 @@ func (m *MockUpdateServiceInterface) GetUpdatePlaybook(update *models.UpdateTran
 	return ret0, ret1
 }
 
-// GetUpdatePlaybook indicates an expected call of GetUpdatePlaybook
+// GetUpdatePlaybook indicates an expected call of GetUpdatePlaybook.
 func (mr *MockUpdateServiceInterfaceMockRecorder) GetUpdatePlaybook(update interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdatePlaybook", reflect.TypeOf((*MockUpdateServiceInterface)(nil).GetUpdatePlaybook), update)
 }
 
-// GetUpdateTransactionsForDevice mocks base method
+// GetUpdateTransactionsForDevice mocks base method.
 func (m *MockUpdateServiceInterface) GetUpdateTransactionsForDevice(device *models.Device) (*[]models.UpdateTransaction, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUpdateTransactionsForDevice", device)
@@ -89,13 +102,13 @@ func (m *MockUpdateServiceInterface) GetUpdateTransactionsForDevice(device *mode
 	return ret0, ret1
 }
 
-// GetUpdateTransactionsForDevice indicates an expected call of GetUpdateTransactionsForDevice
+// GetUpdateTransactionsForDevice indicates an expected call of GetUpdateTransactionsForDevice.
 func (mr *MockUpdateServiceInterfaceMockRecorder) GetUpdateTransactionsForDevice(device interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdateTransactionsForDevice", reflect.TypeOf((*MockUpdateServiceInterface)(nil).GetUpdateTransactionsForDevice), device)
 }
 
-// ProcessPlaybookDispatcherRunEvent mocks base method
+// ProcessPlaybookDispatcherRunEvent mocks base method.
 func (m *MockUpdateServiceInterface) ProcessPlaybookDispatcherRunEvent(message []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessPlaybookDispatcherRunEvent", message)
@@ -103,56 +116,13 @@ func (m *MockUpdateServiceInterface) ProcessPlaybookDispatcherRunEvent(message [
 	return ret0
 }
 
-// ProcessPlaybookDispatcherRunEvent indicates an expected call of ProcessPlaybookDispatcherRunEvent
+// ProcessPlaybookDispatcherRunEvent indicates an expected call of ProcessPlaybookDispatcherRunEvent.
 func (mr *MockUpdateServiceInterfaceMockRecorder) ProcessPlaybookDispatcherRunEvent(message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessPlaybookDispatcherRunEvent", reflect.TypeOf((*MockUpdateServiceInterface)(nil).ProcessPlaybookDispatcherRunEvent), message)
 }
 
-// WriteTemplate mocks base method
-func (m *MockUpdateServiceInterface) WriteTemplate(templateInfo services.TemplateRemoteInfo, account string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteTemplate", templateInfo, account)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WriteTemplate indicates an expected call of WriteTemplate
-func (mr *MockUpdateServiceInterfaceMockRecorder) WriteTemplate(templateInfo, account interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteTemplate", reflect.TypeOf((*MockUpdateServiceInterface)(nil).WriteTemplate), templateInfo, account)
-}
-
-// SetUpdateStatusBasedOnDispatchRecord mocks base method
-func (m *MockUpdateServiceInterface) SetUpdateStatusBasedOnDispatchRecord(dispatchRecord models.DispatchRecord) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetUpdateStatusBasedOnDispatchRecord", dispatchRecord)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetUpdateStatusBasedOnDispatchRecord indicates an expected call of SetUpdateStatusBasedOnDispatchRecord
-func (mr *MockUpdateServiceInterfaceMockRecorder) SetUpdateStatusBasedOnDispatchRecord(dispatchRecord interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpdateStatusBasedOnDispatchRecord", reflect.TypeOf((*MockUpdateServiceInterface)(nil).SetUpdateStatusBasedOnDispatchRecord), dispatchRecord)
-}
-
-// SetUpdateStatus mocks base method
-func (m *MockUpdateServiceInterface) SetUpdateStatus(update *models.UpdateTransaction) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetUpdateStatus", update)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetUpdateStatus indicates an expected call of SetUpdateStatus
-func (mr *MockUpdateServiceInterfaceMockRecorder) SetUpdateStatus(update interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpdateStatus", reflect.TypeOf((*MockUpdateServiceInterface)(nil).SetUpdateStatus), update)
-}
-
-// SendDeviceNotification mocks base method
+// SendDeviceNotification mocks base method.
 func (m *MockUpdateServiceInterface) SendDeviceNotification(update *models.UpdateTransaction) (services.ImageNotification, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendDeviceNotification", update)
@@ -161,13 +131,41 @@ func (m *MockUpdateServiceInterface) SendDeviceNotification(update *models.Updat
 	return ret0, ret1
 }
 
-// SendDeviceNotification indicates an expected call of SendDeviceNotification
+// SendDeviceNotification indicates an expected call of SendDeviceNotification.
 func (mr *MockUpdateServiceInterfaceMockRecorder) SendDeviceNotification(update interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendDeviceNotification", reflect.TypeOf((*MockUpdateServiceInterface)(nil).SendDeviceNotification), update)
 }
 
-// UpdateDevicesFromUpdateTransaction mocks base method
+// SetUpdateStatus mocks base method.
+func (m *MockUpdateServiceInterface) SetUpdateStatus(update *models.UpdateTransaction) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetUpdateStatus", update)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetUpdateStatus indicates an expected call of SetUpdateStatus.
+func (mr *MockUpdateServiceInterfaceMockRecorder) SetUpdateStatus(update interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpdateStatus", reflect.TypeOf((*MockUpdateServiceInterface)(nil).SetUpdateStatus), update)
+}
+
+// SetUpdateStatusBasedOnDispatchRecord mocks base method.
+func (m *MockUpdateServiceInterface) SetUpdateStatusBasedOnDispatchRecord(dispatchRecord models.DispatchRecord) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetUpdateStatusBasedOnDispatchRecord", dispatchRecord)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetUpdateStatusBasedOnDispatchRecord indicates an expected call of SetUpdateStatusBasedOnDispatchRecord.
+func (mr *MockUpdateServiceInterfaceMockRecorder) SetUpdateStatusBasedOnDispatchRecord(dispatchRecord interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpdateStatusBasedOnDispatchRecord", reflect.TypeOf((*MockUpdateServiceInterface)(nil).SetUpdateStatusBasedOnDispatchRecord), dispatchRecord)
+}
+
+// UpdateDevicesFromUpdateTransaction mocks base method.
 func (m *MockUpdateServiceInterface) UpdateDevicesFromUpdateTransaction(update models.UpdateTransaction) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDevicesFromUpdateTransaction", update)
@@ -175,13 +173,13 @@ func (m *MockUpdateServiceInterface) UpdateDevicesFromUpdateTransaction(update m
 	return ret0
 }
 
-// UpdateDevicesFromUpdateTransaction indicates an expected call of UpdateDevicesFromUpdateTransaction
+// UpdateDevicesFromUpdateTransaction indicates an expected call of UpdateDevicesFromUpdateTransaction.
 func (mr *MockUpdateServiceInterfaceMockRecorder) UpdateDevicesFromUpdateTransaction(update interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDevicesFromUpdateTransaction", reflect.TypeOf((*MockUpdateServiceInterface)(nil).UpdateDevicesFromUpdateTransaction), update)
 }
 
-// ValidateUpdateSelection mocks base method
+// ValidateUpdateSelection mocks base method.
 func (m *MockUpdateServiceInterface) ValidateUpdateSelection(account string, imageIds []uint) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateUpdateSelection", account, imageIds)
@@ -190,8 +188,23 @@ func (m *MockUpdateServiceInterface) ValidateUpdateSelection(account string, ima
 	return ret0, ret1
 }
 
-// ValidateUpdateSelection indicates an expected call of ValidateUpdateSelection
+// ValidateUpdateSelection indicates an expected call of ValidateUpdateSelection.
 func (mr *MockUpdateServiceInterfaceMockRecorder) ValidateUpdateSelection(account, imageIds interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateUpdateSelection", reflect.TypeOf((*MockUpdateServiceInterface)(nil).ValidateUpdateSelection), account, imageIds)
+}
+
+// WriteTemplate mocks base method.
+func (m *MockUpdateServiceInterface) WriteTemplate(templateInfo services.TemplateRemoteInfo, account string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteTemplate", templateInfo, account)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WriteTemplate indicates an expected call of WriteTemplate.
+func (mr *MockUpdateServiceInterfaceMockRecorder) WriteTemplate(templateInfo, account interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteTemplate", reflect.TypeOf((*MockUpdateServiceInterface)(nil).WriteTemplate), templateInfo, account)
 }

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -30,6 +30,7 @@ import (
 type UpdateServiceInterface interface {
 	BuildUpdateTransactions(devicesUpdate *models.DevicesUpdate, account string, commit *models.Commit) (*[]models.UpdateTransaction, error)
 	CreateUpdate(id uint) (*models.UpdateTransaction, error)
+	CreateUpdateAsync(id uint)
 	GetUpdatePlaybook(update *models.UpdateTransaction) (io.ReadCloser, error)
 	GetUpdateTransactionsForDevice(device *models.Device) (*[]models.UpdateTransaction, error)
 	ProcessPlaybookDispatcherRunEvent(message []byte) error
@@ -104,6 +105,11 @@ type PlaybookDispatcherEventPayload struct {
 type PlaybookDispatcherEvent struct {
 	EventType string                         `json:"event_type"`
 	Payload   PlaybookDispatcherEventPayload `json:"payload"`
+}
+
+// CreateUpdateAsync is the function that creates an update transaction asynchronously
+func (s *UpdateService) CreateUpdateAsync(id uint) {
+	go s.CreateUpdate(id)
 }
 
 // CreateUpdate is the function that creates an update transaction


### PR DESCRIPTION
Make the go routine call internal to service, so that we can mock the service properly and test the call using expect function, the function go routine is detected in local dev env, but is flaky on GitHub.

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [X] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
