### PR TITLE
change workflow to use test-clean-no-fdo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,4 +57,4 @@ jobs:
         run: python3 -m openapi_spec_validator ${{ github.workspace }}/cmd/spec/openapi.json
 
       - name: Run unit tests without fdo
-        run: make test-no-fdo
+        run: make test-clean-no-fdo


### PR DESCRIPTION
# Description

change workflow to use test-clean-no-fdo instead of test-no-fdo

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
