### PR TITLE
remove repo to be able generate diferent versions  on update

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -302,7 +302,9 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 			return err
 		}
 
-		image.Commit.OSTreeParentCommit = repo.URL
+		if previousImage.Distribution == image.Distribution {
+			image.Commit.OSTreeParentCommit = repo.URL
+		}
 		var refs string
 		if image.Distribution == "" {
 			refs = config.DistributionsRefs[config.DefaultDistribution]


### PR DESCRIPTION
# Description

Add validation of distribution before send request to image builder to be able to generate a brand new image when try to update from rhel8x to rhel9

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
