### PR TITLE
Add explicit error message when creating/updating image

### DIFF
--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -173,7 +173,7 @@ func CreateImage(w http.ResponseWriter, r *http.Request) {
 		ctxServices.Log.WithField("error", err.Error()).Error("Failed creating image")
 		var apiError errors.APIError
 		switch err.(type) {
-		case *services.PackageNameDoesNotExist, *services.ThirdPartyRepositoryInfoIsInvalid, *services.ThirdPartyRepositoryNotFound:
+		case *services.PackageNameDoesNotExist, *services.ThirdPartyRepositoryInfoIsInvalid, *services.ThirdPartyRepositoryNotFound, *services.ImageNameAlreadyExists, *services.ImageSetAlreadyExists:
 			apiError = errors.NewBadRequest(err.Error())
 		default:
 			apiError := errors.NewInternalServerError()
@@ -222,7 +222,7 @@ func CreateImageUpdate(w http.ResponseWriter, r *http.Request) {
 		ctxServices.Log.WithField("error", err.Error()).Error("Failed creating an update to an image")
 		var apiError errors.APIError
 		switch err.(type) {
-		case *services.PackageNameDoesNotExist, *services.ThirdPartyRepositoryInfoIsInvalid, *services.ThirdPartyRepositoryNotFound:
+		case *services.PackageNameDoesNotExist, *services.ThirdPartyRepositoryInfoIsInvalid, *services.ThirdPartyRepositoryNotFound, *services.ImageNameAlreadyExists, *services.ImageSetAlreadyExists:
 			apiError = errors.NewBadRequest(err.Error())
 		default:
 			apiError := errors.NewInternalServerError()


### PR DESCRIPTION
realted to THEEDGE-2305

Signed-off-by: mgold1234 <mgold@redhat.com>

# Description
Add explicit error message when creating/updating image with already existing image name or image set
Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
