### PR TITLE
fix the bug when trying to add device to group

### DIFF
--- a/pkg/services/devicegroups.go
+++ b/pkg/services/devicegroups.go
@@ -56,7 +56,7 @@ func NewDeviceGroupsService(ctx context.Context, log *log.Entry) DeviceGroupsSer
 
 // DeviceGroupNameExists check if a device group exists by (account or orgID) and name
 func (s *DeviceGroupsService) DeviceGroupNameExists(account string, orgID string, name string) (bool, error) {
-	if (account == "" || orgID == "") || name == "" {
+	if (account == "" && orgID == "") || name == "" {
 		return false, new(DeviceGroupMandatoryFieldsUndefined)
 	}
 	var deviceGroupsCount int64
@@ -351,7 +351,7 @@ func (s *DeviceGroupsService) UpdateDeviceGroup(deviceGroup *models.DeviceGroup,
 
 // GetDeviceGroupDeviceByID return the device of a device group by its ID
 func (s *DeviceGroupsService) GetDeviceGroupDeviceByID(account string, orgID string, deviceGroupID uint, deviceID uint) (*models.Device, error) {
-	if (account == "" || orgID == "") || deviceGroupID == 0 {
+	if (account == "" && orgID == "") || deviceGroupID == 0 {
 		s.log.Debug("account and deviceGroupID must be defined")
 		return nil, new(DeviceGroupMandatoryFieldsUndefined)
 	}
@@ -377,7 +377,7 @@ func (s *DeviceGroupsService) GetDeviceGroupDeviceByID(account string, orgID str
 
 // AddDeviceGroupDevices add devices to device group
 func (s *DeviceGroupsService) AddDeviceGroupDevices(account string, orgID string, deviceGroupID uint, devices []models.Device) (*[]models.Device, error) {
-	if (account == "" || orgID == "") || deviceGroupID == 0 {
+	if (account == "" && orgID == "") || deviceGroupID == 0 {
 		s.log.Debug("account and deviceGroupID must be defined")
 		return nil, new(DeviceGroupMandatoryFieldsUndefined)
 	}
@@ -424,7 +424,7 @@ func (s *DeviceGroupsService) AddDeviceGroupDevices(account string, orgID string
 
 // DeleteDeviceGroupDevices delete devices from device-group
 func (s *DeviceGroupsService) DeleteDeviceGroupDevices(account string, orgID string, deviceGroupID uint, devices []models.Device) (*[]models.Device, error) {
-	if (account == "" || orgID == "") || deviceGroupID == 0 {
+	if (account == "" && orgID == "") || deviceGroupID == 0 {
 		s.log.Debug("account and deviceGroupID must be defined")
 		return nil, new(DeviceGroupMandatoryFieldsUndefined)
 	}

--- a/pkg/services/devicegroups_test.go
+++ b/pkg/services/devicegroups_test.go
@@ -388,11 +388,7 @@ var _ = Describe("DeviceGroupsService basic functions", func() {
 				Expect(err.Error()).To(Equal("devices not found in device group"))
 			})
 
-			It("should return error when account is undefined", func() {
-				_, err := deviceGroupsService.DeleteDeviceGroupDevices("", orgID, deviceGroupID, []models.Device{savedDeviceGroup.Devices[0]})
-				Expect(err).ToNot(BeNil())
-				Expect(err.Error()).To(Equal("device group mandatory field are undefined"))
-			})
+
 
 			It("should return error when deviceGroupId is undefined", func() {
 				_, err := deviceGroupsService.DeleteDeviceGroupDevices(account, orgID, 0, []models.Device{savedDeviceGroup.Devices[0]})


### PR DESCRIPTION
when org_id is empty we will receive an error,
change the condition that only when orgID and account
are empty we will recieve an error
realted to issue -THEEDGE-2298

Signed-off-by: mgold1234 <mgold@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
