### PR TITLE
FIX- sorting image-sets by status gives incorrect response as 400 

### DIFF
--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -24,7 +24,7 @@ type imageSetTypeKey int
 
 const imageSetKey imageSetTypeKey = iota
 
-var sortOption = []string{"created_at", "updated_at", "name", "status"}
+var sortOption = []string{"created_at", "updated_at", "name"}
 var statusOption = []string{models.ImageStatusCreated, models.ImageStatusBuilding, models.ImageStatusError, models.ImageStatusSuccess}
 
 // MakeImageSetsRouter adds support for operations on image-sets
@@ -38,10 +38,6 @@ func MakeImageSetsRouter(sub chi.Router) {
 
 var imageSetFilters = common.ComposeFilters(
 
-	common.ContainFilterHandler(&common.Filter{
-		QueryParam: "status",
-		DBField:    "images.status",
-	}),
 	common.ContainFilterHandler(&common.Filter{
 		QueryParam: "name",
 		DBField:    "image_sets.name",

--- a/pkg/routes/imagesets_test.go
+++ b/pkg/routes/imagesets_test.go
@@ -92,14 +92,14 @@ func TestSearchParams(t *testing.T) {
 			name:   "bad sort_by",
 			params: "sort_by=test",
 			expectedError: []validationError{
-				{Key: "sort_by", Reason: "test is not a valid sort_by. Sort-by must created_at or updated_at or name or status"},
+				{Key: "sort_by", Reason: "test is not a valid sort_by. Sort-by must created_at or updated_at or name"},
 			},
 		},
 		{
 			name:   "bad sort_by and status",
 			params: "sort_by=host&status=ONHOLD",
 			expectedError: []validationError{
-				{Key: "sort_by", Reason: "host is not a valid sort_by. Sort-by must created_at or updated_at or name or status"},
+				{Key: "sort_by", Reason: "host is not a valid sort_by. Sort-by must created_at or updated_at or name"},
 				{Key: "status", Reason: "ONHOLD is not a valid status. Status must be CREATED or BUILDING or ERROR or SUCCESS"},
 			},
 		},
@@ -152,14 +152,14 @@ func TestDetailSearchParams(t *testing.T) {
 			name:   "bad sort_by",
 			params: "sort_by=test",
 			expectedError: []validationError{
-				{Key: "sort_by", Reason: "test is not a valid sort_by. Sort-by must created_at or updated_at or name or status"},
+				{Key: "sort_by", Reason: "test is not a valid sort_by. Sort-by must created_at or updated_at or name"},
 			},
 		},
 		{
 			name:   "bad sort_by and status",
 			params: "sort_by=host&status=ONHOLD",
 			expectedError: []validationError{
-				{Key: "sort_by", Reason: "host is not a valid sort_by. Sort-by must created_at or updated_at or name or status"},
+				{Key: "sort_by", Reason: "host is not a valid sort_by. Sort-by must created_at or updated_at or name"},
 				{Key: "status", Reason: "ONHOLD is not a valid status. Status must be CREATED or BUILDING or ERROR or SUCCESS"},
 			},
 		},


### PR DESCRIPTION
# Description

We've disabled sorting using status for image-sets endpoint. But we forgot to make changes to the response when the status is used as a sorting parameter. 

Currently the endpoint **image-sets?sort_by=status** responds with 400 instead, it should respond with something like this 

`[
  {
    "Key": "sort_by",
    "Reason": "status is not a valid sort_by. Sort-by must created_at or updated_at or name"
  }
]`
Fixes # [THEEDGE-1616]

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `go fmt ./...` to check that my code is properly formatted
- [x] I run `go vet ./...` to check that my code is free of common Go style mistakes
- [x] I run `make lint` to prints out coding style mistakes and fix them
