### PR TITLE
add parent repo back on updates

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -304,9 +304,8 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 			return err
 		}
 
-		if previousImage.Distribution == image.Distribution {
-			image.Commit.OSTreeParentCommit = repo.URL
-		}
+		image.Commit.OSTreeParentCommit = repo.URL
+
 		var refs string
 		if image.Distribution == "" {
 			refs = config.DistributionsRefs[config.DefaultDistribution]


### PR DESCRIPTION
# Description

rollback the change from #1172 
To respect the parent structure and avoid problems between the images.

Fixes # (issue)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
