### PR TITLE
add ostree parentRef to update image and be able to calculate the upg…

### DIFF
--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -42,8 +42,9 @@ func InitClient(ctx context.Context, log *log.Entry) *Client {
 
 // OSTree gives OSTree information for an image
 type OSTree struct {
-	URL string `json:"url,omitempty"`
-	Ref string `json:"ref"`
+	URL       string `json:"url,omitempty"`
+	Ref       string `json:"ref"`
+	ParentRef string `json:"parent"`
 }
 
 // Customizations is made of the packages that are baked into an image
@@ -254,6 +255,7 @@ func (c *Client) ComposeCommit(image *models.Image) (*models.Image, error) {
 			req.ImageRequests[0].Ostree = &OSTree{}
 		}
 		req.ImageRequests[0].Ostree.URL = image.Commit.OSTreeParentCommit
+		req.ImageRequests[0].Ostree.ParentRef = image.Commit.OSTreeParentRef
 	}
 
 	cr, err := c.compose(req)

--- a/pkg/models/commits.go
+++ b/pkg/models/commits.go
@@ -21,6 +21,7 @@ type Commit struct {
 	OSTreeCommit         string             `json:"OSTreeCommit"`
 	OSTreeParentCommit   string             `json:"OSTreeParentCommit"`
 	OSTreeRef            string             `json:"OSTreeRef"`
+	OSTreeParentRef      string             `json:"OSTreeParentRef"`
 	BuildDate            string             `json:"BuildDate"`
 	BuildNumber          uint               `json:"BuildNumber"`
 	BlueprintToml        string             `json:"BlueprintToml"`

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -316,6 +316,10 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 		if image.Commit.OSTreeRef == "" {
 			image.Commit.OSTreeRef = refs
 		}
+		if previousImage.Commit.OSTreeRef == "" {
+			image.Commit.OSTreeParentRef = config.DistributionsRefs[previousImage.Distribution]
+		}
+
 	} else {
 		// Previous image was not built successfully
 		s.log.WithField("previousImageID", previousImage.ID).Info("Creating an update based on a image with a status that is not success")

--- a/pkg/services/images_test.go
+++ b/pkg/services/images_test.go
@@ -259,6 +259,50 @@ var _ = Describe("Image Service Test", func() {
 				Expect(actualErr).To(HaveOccurred())
 				Expect(actualErr).To(MatchError(expectedErr))
 				Expect(image.Commit.OSTreeParentCommit).To(Equal(parentRepo.URL))
+				Expect(image.Commit.OSTreeParentRef).To(Equal("rhel/8/x86_64/edge"))
+				Expect(image.Commit.OSTreeRef).To(Equal("rhel/8/x86_64/edge"))
+			})
+		})
+
+		Context("when previous image has success status", func() {
+			It("should have the parent image repo url set as parent commit url", func() {
+				id, _ := faker.RandomInt(1)
+				uid := uint(id[0])
+				account := faker.UUIDHyphenated()
+				imageSet := &models.ImageSet{Account: account}
+				result := db.DB.Save(imageSet)
+				Expect(result.Error).To(Not(HaveOccurred()))
+				previousImage := &models.Image{
+					Account:      account,
+					Status:       models.ImageStatusSuccess,
+					Commit:       &models.Commit{RepoID: &uid},
+					Version:      1,
+					Distribution: "rhel-86",
+					Name:         faker.Name(),
+					ImageSetID:   &imageSet.ID,
+				}
+				image := &models.Image{
+					Account:      account,
+					Commit:       &models.Commit{},
+					OutputTypes:  []string{models.ImageTypeCommit},
+					Version:      2,
+					Distribution: "rhel-90",
+					Name:         previousImage.Name,
+				}
+				result = db.DB.Save(previousImage)
+				Expect(result.Error).To(Not(HaveOccurred()))
+
+				parentRepo := &models.Repo{URL: faker.URL()}
+				expectedErr := fmt.Errorf("Failed creating commit for image")
+				mockImageBuilderClient.EXPECT().ComposeCommit(image).Return(image, expectedErr)
+				mockRepoService.EXPECT().GetRepoByID(previousImage.Commit.RepoID).Return(parentRepo, nil)
+				actualErr := service.UpdateImage(image, previousImage)
+
+				Expect(actualErr).To(HaveOccurred())
+				Expect(actualErr).To(MatchError(expectedErr))
+				Expect(image.Commit.OSTreeParentCommit).To(Equal(parentRepo.URL))
+				Expect(image.Commit.OSTreeParentRef).To(Equal("rhel/8/x86_64/edge"))
+				Expect(image.Commit.OSTreeRef).To(Equal("rhel/9/x86_64/edge"))
 			})
 		})
 	})


### PR DESCRIPTION
…rade

# Description

Based on ImageBuilder info we need to inform the parentRef when we want to upgrade an image version.
I've added the new field to our commit structure and also to the payload that we send to them

Fixes # ([issue](https://issues.redhat.com/browse/THEEDGE-2178))

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
