### PR TITLE
Add a method to ensure org_id is not empty for all models

### DIFF
--- a/pkg/models/devicegroups.go
+++ b/pkg/models/devicegroups.go
@@ -96,7 +96,7 @@ func (group *DeviceGroup) BeforeDelete(tx *gorm.DB) error {
 // BeforeCreate method is called before creating device group, it make sure org_id is not empty
 func (group *DeviceGroup) BeforeCreate(tx *gorm.DB) error {
 	if group.OrgID == "" {
-		return errors.New("Device Groups doesn't belong to org_id")
+		return errors.New("org_id is required")
 	}
 
 	return nil

--- a/pkg/models/devicegroups.go
+++ b/pkg/models/devicegroups.go
@@ -92,3 +92,12 @@ func (group *DeviceGroup) ValidateRequest() error {
 func (group *DeviceGroup) BeforeDelete(tx *gorm.DB) error {
 	return tx.Model(group).Association("Devices").Delete(&group.Devices)
 }
+
+// BeforeCreate method is called before creating device group, it make sure org_id is not empty
+func (group *DeviceGroup) BeforeCreate(tx *gorm.DB) error {
+	if group.OrgID == "" {
+		return errors.New("Device Groups doesn't belong to org_id")
+	}
+
+	return nil
+}

--- a/pkg/models/devicegroups_test.go
+++ b/pkg/models/devicegroups_test.go
@@ -2,9 +2,9 @@ package models
 
 import (
 	"errors"
-	"github.com/bxcodec/faker/v3"
 	"testing"
 
+	"github.com/bxcodec/faker/v3"
 	"github.com/redhatinsights/edge-api/pkg/db"
 )
 
@@ -14,11 +14,11 @@ func TestGroupValidateRequest(t *testing.T) {
 		group    *DeviceGroup
 		expected error
 	}{
-		{name: "Empty name", group: &DeviceGroup{Account: "111111", Type: "static"}, expected: errors.New(DeviceGroupNameEmptyErrorMessage)},
-		{name: "Invalid type", group: &DeviceGroup{Name: "test_group", Account: "111111", Type: "invalid type"}, expected: errors.New(DeviceGroupTypeInvalidErrorMessage)},
-		{name: "Invalid name", group: &DeviceGroup{Name: "** test group", Account: "111111", Type: DeviceGroupTypeDefault}, expected: errors.New(DeviceGroupNameInvalidErrorMessage)},
-		{name: "Empty account", group: &DeviceGroup{Name: "test_group", Type: "static"}, expected: errors.New(DeviceGroupAccountEmptyErrorMessage)},
-		{name: "Valid DeviceGroup", group: &DeviceGroup{Name: "test_group", Account: "111111", Type: DeviceGroupTypeDefault}, expected: nil},
+		{name: "Empty name", group: &DeviceGroup{OrgID: "222222", Account: "111111", Type: "static"}, expected: errors.New(DeviceGroupNameEmptyErrorMessage)},
+		{name: "Invalid type", group: &DeviceGroup{Name: "test_group", OrgID: "222222", Account: "111111", Type: "invalid type"}, expected: errors.New(DeviceGroupTypeInvalidErrorMessage)},
+		{name: "Invalid name", group: &DeviceGroup{Name: "** test group", OrgID: "222222", Account: "111111", Type: DeviceGroupTypeDefault}, expected: errors.New(DeviceGroupNameInvalidErrorMessage)},
+		{name: "Empty account", group: &DeviceGroup{Name: "test_group", Type: "static", OrgID: "222222"}, expected: errors.New(DeviceGroupAccountEmptyErrorMessage)},
+		{name: "Valid DeviceGroup", group: &DeviceGroup{Name: "test_group", Account: "111111", OrgID: "222222", Type: DeviceGroupTypeDefault}, expected: nil},
 	}
 
 	for _, testScenario := range testScenarios {
@@ -39,12 +39,14 @@ func TestGroupCreateUpdateConstraint(t *testing.T) {
 	groupInitialAccount := "111111"
 	groupInitialName := "test_group"
 	groupInitialType := DeviceGroupTypeDynamic
-
+	groupInitialOrgID := "333333"
 	groupNewAccount := "222222"
+	groupNewOrgID := "444444"
+
 	groupNewType := DeviceGroupTypeStatic
 	groupNewName := "new_test_group"
 
-	group := DeviceGroup{Name: groupInitialName, Account: groupInitialAccount, Type: groupInitialType}
+	group := DeviceGroup{Name: groupInitialName, OrgID: groupInitialOrgID, Account: groupInitialAccount, Type: groupInitialType}
 
 	err := group.ValidateRequest()
 	if err != nil {
@@ -63,6 +65,7 @@ func TestGroupCreateUpdateConstraint(t *testing.T) {
 	}
 
 	savedGroup.Account = groupNewAccount
+	savedGroup.OrgID = groupNewOrgID
 	savedGroup.Type = groupNewType
 	savedGroup.Name = groupNewName
 
@@ -91,6 +94,7 @@ func TestGroupCreateUpdateConstraint(t *testing.T) {
 }
 
 func TestBeforeDelete(t *testing.T) {
+	orgID := faker.UUIDHyphenated()
 	account := faker.UUIDHyphenated()
 	deviceGroupName := faker.Name()
 	devices := []Device{
@@ -98,17 +102,20 @@ func TestBeforeDelete(t *testing.T) {
 			Name:    faker.Name(),
 			UUID:    faker.UUIDHyphenated(),
 			Account: account,
+			OrgID:   orgID,
 		},
 		{
 			Name:    faker.Name(),
 			UUID:    faker.UUIDHyphenated(),
 			Account: account,
+			OrgID:   orgID,
 		},
 	}
 	deviceGroup := &DeviceGroup{
 		Name:    deviceGroupName,
 		Type:    DeviceGroupTypeDefault,
 		Account: account,
+		OrgID:   orgID,
 		Devices: devices,
 	}
 	// Create the DeviceGroup
@@ -136,5 +143,32 @@ func TestBeforeDelete(t *testing.T) {
 	}
 	if len(deviceGroup.Devices) != 0 {
 		t.Errorf("Expected 0 devices but found %d: %v", len(deviceGroup.Devices), deviceGroup.Devices)
+	}
+}
+
+func TestBeforeCreate(t *testing.T) {
+	orgID := faker.UUIDHyphenated()
+	account := faker.UUIDHyphenated()
+	deviceGroupNameWithNoOrgID := faker.Name()
+	devices := []Device{
+		{
+			Name:    faker.Name(),
+			UUID:    faker.UUIDHyphenated(),
+			OrgID:   orgID,
+			Account: account,
+		},
+	}
+
+	deviceGroupWithNoOrgID := &DeviceGroup{
+		Name:    deviceGroupNameWithNoOrgID,
+		Type:    DeviceGroupTypeDefault,
+		OrgID:   orgID,
+		Account: account,
+		Devices: devices,
+	}
+
+	err := deviceGroupWithNoOrgID.BeforeCreate(db.DB)
+	if err != nil {
+		t.Error("Error running BeforeCreate")
 	}
 }

--- a/pkg/models/devicegroups_test.go
+++ b/pkg/models/devicegroups_test.go
@@ -166,7 +166,7 @@ func TestBeforeCreate(t *testing.T) {
 		Account: account,
 		Devices: devices,
 	}
-
+	// BeforeCreate make sure DeviceGroup belongs to orgID
 	err := deviceGroupWithNoOrgID.BeforeCreate(db.DB)
 	if err != nil {
 		t.Error("Error running BeforeCreate")


### PR DESCRIPTION
# Description

Create a BeforeCreate function for all models to make sure org_id is not empty when creating any records.
Gorms provides a way to ensure it, https://gorm.io/docs/create.html#Create-Hooks 

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
