### PR TITLE
add preload of oldcommits to enable calculate the static deltas; add …

### DIFF
--- a/pkg/routes/updates.go
+++ b/pkg/routes/updates.go
@@ -259,7 +259,6 @@ func AddUpdate(w http.ResponseWriter, r *http.Request) {
 // GetUpdateByID obtains an update from the database for an account
 func GetUpdateByID(w http.ResponseWriter, r *http.Request) {
 	update := getUpdate(w, r)
-	update = update
 	if update == nil {
 		// Error set by UpdateCtx already
 		return

--- a/pkg/routes/updates.go
+++ b/pkg/routes/updates.go
@@ -60,7 +60,7 @@ func UpdateCtx(next http.Handler) http.Handler {
 			respondWithAPIError(w, ctxServices.Log, errors.NewBadRequest(err.Error()))
 			return
 		}
-		if result := db.AccountOrOrg(account, orgID, "update_transactions").Preload("DispatchRecords").Preload("Devices").
+		if result := db.AccountOrOrg(account, orgID, "update_transactions").Preload("DispatchRecords").Preload("Devices").Preload("OldCommits").
 			Joins("Commit").Joins("Repo").Find(&updates, id); result.Error != nil {
 			ctxServices.Log.WithFields(log.Fields{
 				"error": result.Error.Error(),
@@ -259,6 +259,7 @@ func AddUpdate(w http.ResponseWriter, r *http.Request) {
 // GetUpdateByID obtains an update from the database for an account
 func GetUpdateByID(w http.ResponseWriter, r *http.Request) {
 	update := getUpdate(w, r)
+	update = update
 	if update == nil {
 		// Error set by UpdateCtx already
 		return

--- a/pkg/services/repobuilder.go
+++ b/pkg/services/repobuilder.go
@@ -51,7 +51,7 @@ func NewRepoBuilder(ctx context.Context, log *log.Entry) RepoBuilderInterface {
 // with static deltas generated between them all
 func (rb *RepoBuilder) BuildUpdateRepo(id uint) (*models.UpdateTransaction, error) {
 	var update *models.UpdateTransaction
-	db.DB.Preload("DispatchRecords").Preload("Devices").Joins("Commit").Joins("Repo").Find(&update, id)
+	db.DB.Preload("DispatchRecords").Preload("Devices").Preload("OldCommits").Joins("Commit").Joins("Repo").Find(&update, id)
 
 	rb.log.Info("Starts building update repo...")
 	if update == nil {
@@ -63,8 +63,9 @@ func (rb *RepoBuilder) BuildUpdateRepo(id uint) (*models.UpdateTransaction, erro
 		return nil, errors.New("invalid models.UpdateTransaction.Commit Provided: nil pointer")
 	}
 	rb.log = rb.log.WithFields(log.Fields{
-		"commitID": update.Commit.ID,
-		"updateID": update.ID})
+		"commitID":   update.Commit.ID,
+		"updateID":   update.ID,
+		"OldCommits": len(update.OldCommits)})
 	if update.Repo == nil {
 		rb.log.Error("Repo is unavailable")
 		return nil, errors.New("repo unavailable")
@@ -372,16 +373,23 @@ func (rb *RepoBuilder) ExtractVersionRepo(c *models.Commit, tarFileName string, 
 //  uprepo should be where the update commit lives, u is the update commit
 //  oldrepo should be where the old commit lives, o is the commit to be merged
 func (rb *RepoBuilder) repoPullLocalStaticDeltas(u *models.Commit, o *models.Commit, uprepo string, oldrepo string) error {
+
+	rb.log.WithFields(log.Fields{"Oldrepo": oldrepo,
+		"Oldcommit": o.Repo.URL,
+		"commit":    u.Repo.URL}).Debug("repoPullLocalStaticDeltas")
 	err := os.Chdir(uprepo)
 	if err != nil {
 		return err
 	}
 
 	updateRevParse, err := RepoRevParse(uprepo, u.OSTreeRef)
+	rb.log.WithFields(log.Fields{"updateRevParse": updateRevParse}).Debug("updateRevParse")
 	if err != nil {
 		return err
 	}
 	oldRevParse, err := RepoRevParse(oldrepo, o.OSTreeRef)
+	rb.log.WithFields(log.Fields{"oldRevParse": updateRevParse}).Debug("oldRevParse")
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
…logs

# Description

we should be able to see previous commit to devices already updated and calculate the delta based on that record.
I've adde the preload to add it to the api and also to be used on condition.
Added some logs as well to identify the values used

Fixes # ([issue](https://issues.redhat.com/browse/THEEDGE-2354))

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
