### PR TITLE
THEEDGE-2231 Fix update transaction when device is disconnected

### DIFF
--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -599,8 +599,7 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 	if len(devicesUpdate.DevicesUUID) > 0 {
 		for _, UUID := range devicesUpdate.DevicesUUID {
 			inv, err = s.Inventory.ReturnDevicesByID(UUID)
-
-			if inv.Count >= 0 {
+			if inv.Count > 0 {
 				ii = append(ii, inv)
 			}
 			if err != nil {
@@ -633,27 +632,11 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 
 		update.DispatchRecords = []models.DispatchRecord{}
 
-		//  Removing commit dependency to avoid overwriting the repo
-		var repo *models.Repo
-		s.log.WithField("updateID", update.ID).Debug("Ceating new repo for update transaction")
-		repo = &models.Repo{
-			Status: models.RepoStatusBuilding,
-		}
-		result := db.DB.Create(&repo)
-		if result.Error != nil {
-			s.log.WithField("error", result.Error.Error()).Debug("Result error")
-
-		}
-
-		update.Repo = repo
-		s.log.WithFields(log.Fields{
-			"repoURL": repo.URL,
-			"repoID":  repo.ID,
-		}).Debug("Getting repo info")
-
 		devices := update.Devices
 		oldCommits := update.OldCommits
 		toUpdate := true
+
+		var repo *models.Repo
 
 		for _, device := range inventory.Result {
 			//  Check for the existence of a Repo that already has this commit and don't duplicate
@@ -682,7 +665,13 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 				}
 			}
 
+			s.log.WithFields(log.Fields{
+				"deviceUUID": device.ID,
+			}).Info("Device is disconnected 2")
 			if device.Ostree.RHCClientID == "" {
+				s.log.WithFields(log.Fields{
+					"deviceUUID": device.ID,
+				}).Info("Device is disconnected")
 				update.Status = models.UpdateStatusDeviceDisconnected
 				if result := db.DB.Create(&update); result.Error != nil {
 					return nil, result.Error
@@ -756,8 +745,27 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 			}
 
 			if toUpdate {
+				if repo == nil {
+					//  Removing commit dependency to avoid overwriting the repo
+					s.log.WithField("updateID", update.ID).Debug("Creating new repo for update transaction")
+					repo = &models.Repo{
+						Status: models.RepoStatusBuilding,
+					}
+					result := db.DB.Create(&repo)
+					if result.Error != nil {
+						s.log.WithField("error", result.Error.Error()).Debug("Result error")
+					}
+					s.log.WithFields(log.Fields{
+						"repoURL": repo.URL,
+						"repoID":  repo.ID,
+					}).Debug("Getting repo info")
+				}
+
+				update.Repo = repo
+
 				//Should not create a transaction to device already updated
 				update.OldCommits = oldCommits
+				update.RepoID = repo.ID
 				if err := db.DB.Save(&update).Error; err != nil {
 					err = errors.NewBadRequest(err.Error())
 					s.log.WithField("error", err.Error()).Error("Error encoding error")

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -665,9 +665,6 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 				}
 			}
 
-			s.log.WithFields(log.Fields{
-				"deviceUUID": device.ID,
-			}).Info("Device is disconnected 2")
 			if device.Ostree.RHCClientID == "" {
 				s.log.WithFields(log.Fields{
 					"deviceUUID": device.ID,

--- a/pkg/services/updates_test.go
+++ b/pkg/services/updates_test.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/redhatinsights/edge-api/pkg/clients/inventory"
-	"github.com/redhatinsights/edge-api/pkg/clients/inventory/mock_inventory"
 	apiError "github.com/redhatinsights/edge-api/pkg/errors"
 	"github.com/redhatinsights/edge-api/pkg/routes/common"
 	"io/ioutil"


### PR DESCRIPTION
# Description

When updating a device without rhc_client_id, the device is considered disconnected which should not create a repo on an update transaction.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
