### PR TITLE
orgmigration: skip hooks for org migration tests to allow creating empty orgID.

### DIFF
--- a/cmd/migrate/orgmigration/orgmigration_test.go
+++ b/cmd/migrate/orgmigration/orgmigration_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/redhatinsights/edge-api/cmd/migrate/orgmigration"
 	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 )
 
 func getModelInterfaceFieldValue(modelInterface interface{}, fieldName string) string {
@@ -136,7 +137,7 @@ var _ = Describe("Main", func() {
 	It("All records created successfully", func() {
 		for _, modelsData := range modelsDataMap {
 			for _, modelRecord := range modelsData {
-				result := db.DB.Debug().Create(modelRecord.modelValue)
+				result := db.DB.Session(&gorm.Session{SkipHooks: true}).Debug().Create(modelRecord.modelValue)
 				Expect(result.Error).ToNot(HaveOccurred())
 			}
 		}


### PR DESCRIPTION
When BeforeCreate hook will be in place the migration scripts will not be able to create records with empty orgIds.


## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [X] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
