### PR TITLE
Add BeforeCreate method for ImageSet

### DIFF
--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -250,3 +250,13 @@ func (i *Image) BeforeCreate(tx *gorm.DB) error {
 
 	return nil
 }
+
+// BeforeCreate method is called before creating ImageSet, it make sure org_id is not empty
+func (imgset *ImageSet) BeforeCreate(tx *gorm.DB) error {
+	if imgset.OrgID == "" {
+		return ErrOrgIDIsMandatory
+
+	}
+
+	return nil
+}

--- a/pkg/models/images_test.go
+++ b/pkg/models/images_test.go
@@ -313,3 +313,18 @@ func TestImagesBeforeCreate(t *testing.T) {
 		t.Error("Error running BeforeCreate")
 	}
 }
+
+func TestImageSetBeforeCreate(t *testing.T) {
+	orgID := faker.UUIDHyphenated()
+	imageSet1 := ImageSet{
+		Name:    "image-set-1",
+		Version: 1,
+		OrgID:   orgID,
+	}
+
+	// BeforeCreate make sure ImageSet has orgID
+	err := imageSet1.BeforeCreate(db.DB)
+	if err != nil {
+		t.Error("Error running BeforeCreate")
+	}
+}

--- a/pkg/routes/updates_test.go
+++ b/pkg/routes/updates_test.go
@@ -104,6 +104,7 @@ func TestGetUpdatePlaybook(t *testing.T) {
 
 var _ = Describe("Update routes", func() {
 	var edgeAPIServices *dependencies.EdgeAPIServices
+	orgID := faker.UUIDHyphenated()
 	BeforeEach(func() {
 		logger := log.NewEntry(log.StandardLogger())
 		edgeAPIServices = &dependencies.EdgeAPIServices{
@@ -118,10 +119,12 @@ var _ = Describe("Update routes", func() {
 
 		BeforeEach(func() {
 			imageSetSameGroup := &models.ImageSet{
-				Name: "image-set-same-group",
+				Name:  "image-set-same-group",
+				OrgID: orgID,
 			}
 			imageSetDifferentGroup := &models.ImageSet{
-				Name: "image-set-different-group",
+				Name:  "image-set-different-group",
+				OrgID: orgID,
 			}
 			db.DB.Create(&imageSetSameGroup)
 			db.DB.Create(&imageSetDifferentGroup)

--- a/pkg/services/images_test.go
+++ b/pkg/services/images_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Image Service Test", func() {
 				uid := uint(id[0])
 				account := faker.UUIDHyphenated()
 				orgID := faker.UUIDHyphenated()
-				imageSet := &models.ImageSet{Account: account}
+				imageSet := &models.ImageSet{Account: account, OrgID: orgID}
 				result := db.DB.Save(imageSet)
 				Expect(result.Error).To(Not(HaveOccurred()))
 				previousImage := &models.Image{


### PR DESCRIPTION
# Description

Create a BeforeCreate function for ImageSet to make sure org_id is not empty when creating any records.
Gorms provides a way to ensure it, https://gorm.io/docs/create.html#Create-Hooks 

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
