### PR TITLE
add validation of change refs on update level; compare between curren…

### DIFF
--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -26,6 +26,7 @@ type UpdateTransaction struct {
 	Status          string           `json:"Status"`
 	RepoID          uint             `json:"RepoID"`
 	Repo            *Repo            `json:"Repo"`
+	ChangesRefs     bool             `gorm:"default:false" json:"ChangesRefs"`
 	DispatchRecords []DispatchRecord `gorm:"many2many:updatetransaction_dispatchrecords;" json:"DispatchRecords"`
 }
 

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -592,16 +592,13 @@ func (s *UpdateService) ValidateUpdateDeviceGroup(account string, orgID string, 
 //BuildUpdateTransactions build records
 func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpdate,
 	account string, orgID string, commit *models.Commit) (*[]models.UpdateTransaction, error) {
-	// client := s.Inventory.InitClient(s.ctx, log.NewEntry(log.StandardLogger()))
 	var inv inventory.Response
 	var ii []inventory.Response
 	var err error
 
 	if len(devicesUpdate.DevicesUUID) > 0 {
 		for _, UUID := range devicesUpdate.DevicesUUID {
-			fmt.Printf("\nUUID: %v\n", UUID)
 			inv, err = s.Inventory.ReturnDevicesByID(UUID)
-			fmt.Printf("\ninv.Count: %v\n", inv.Count)
 
 			if inv.Count >= 0 {
 				ii = append(ii, inv)
@@ -743,7 +740,6 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 					} else {
 						oldCommits = append(oldCommits, oldCommit)
 					}
-					fmt.Printf("\ndeployment.Checksum: %v\n", deployment.Checksum)
 					currentImage, cError := s.ImageService.GetImageByOSTreeCommitHash(deployment.Checksum)
 					if cError != nil {
 						s.log.WithField("error", err.Error()).Error("Error returning current image ostree checksum")

--- a/pkg/services/updates_test.go
+++ b/pkg/services/updates_test.go
@@ -14,6 +14,8 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/clients/inventory"
+	"github.com/redhatinsights/edge-api/pkg/clients/inventory/mock_inventory"
 	"github.com/redhatinsights/edge-api/pkg/db"
 	"github.com/redhatinsights/edge-api/pkg/models"
 	"github.com/redhatinsights/edge-api/pkg/services"
@@ -170,7 +172,6 @@ var _ = Describe("UpdateService Basic functions", func() {
 				OrgID: org_id,
 			}
 			db.DB.Create(&device)
-			fmt.Printf("TESTETETETETETETETE :::::: %v\n", device.ID)
 			d := &models.DispatchRecord{
 				PlaybookDispatcherID: faker.UUIDHyphenated(),
 				Status:               models.UpdateStatusBuilding,
@@ -519,6 +520,275 @@ var _ = Describe("UpdateService Basic functions", func() {
 				Expect(currentDevice.ImageID).To(Equal(image.ID))
 				// should detect that we have newer images
 				Expect(currentDevice.UpdateAvailable).To(Equal(true))
+			})
+		})
+	})
+	Describe("Update Devices from version 1 to version 3", func() {
+		account := faker.UUIDHyphenated()
+		org_id := faker.UUIDHyphenated()
+		var updateService services.UpdateServiceInterface
+
+		var mockImageService *mock_services.MockImageServiceInterface
+		var mockInventoryClient *mock_inventory.MockClientInterface
+
+		var mockRepoBuilder *mock_services.MockRepoBuilderInterface
+		BeforeEach(func() {
+			ctrl := gomock.NewController(GinkgoT())
+			defer ctrl.Finish()
+			mockRepoBuilder = mock_services.NewMockRepoBuilderInterface(ctrl)
+			mockImageService = mock_services.NewMockImageServiceInterface(ctrl)
+			mockInventoryClient = mock_inventory.NewMockClientInterface(ctrl)
+			updateService = &services.UpdateService{
+				Service:       services.NewService(context.Background(), log.WithField("service", "update")),
+				RepoBuilder:   mockRepoBuilder,
+				Inventory:     mockInventoryClient,
+				ImageService:  mockImageService,
+				WaitForReboot: 0,
+			}
+		})
+
+		imageSet := models.ImageSet{Account: account, OrgID: org_id, Name: faker.UUIDHyphenated()}
+		db.DB.Create(&imageSet)
+
+		currentCommit := models.Commit{Account: account, OrgID: org_id, OSTreeCommit: faker.UUIDHyphenated()}
+		db.DB.Create(&currentCommit)
+		currentImage := models.Image{Account: account, OrgID: org_id, CommitID: currentCommit.ID, ImageSetID: &imageSet.ID, Status: models.ImageStatusSuccess, Distribution: "rhel-86"}
+		db.DB.Create(&currentImage)
+
+		commit := models.Commit{Account: account, OrgID: org_id, OSTreeCommit: faker.UUIDHyphenated(), ChangesRefs: true}
+		db.DB.Create(&commit)
+		image := models.Image{Account: account, OrgID: org_id, CommitID: commit.ID, ImageSetID: &imageSet.ID, Status: models.ImageStatusSuccess, Distribution: "rhel-90"}
+		db.DB.Create(&image)
+
+		latestCommit := models.Commit{Account: account, OrgID: org_id, OSTreeCommit: faker.UUIDHyphenated(), ChangesRefs: false}
+		db.DB.Create(&latestCommit)
+		latestImage := models.Image{Account: account, OrgID: org_id, CommitID: latestCommit.ID, ImageSetID: &imageSet.ID, Status: models.ImageStatusSuccess, Distribution: "rhel-90"}
+		db.DB.Create(&latestImage)
+
+		device := models.Device{Account: account, OrgID: org_id, ImageID: currentImage.ID, UpdateAvailable: true, UUID: faker.UUIDHyphenated()}
+		db.DB.Create(&device)
+
+		repo := models.Repo{Status: models.RepoStatusSuccess, URL: "www.redhat.com"}
+		db.DB.Create(&repo)
+
+		update := models.UpdateTransaction{
+			Account:  account,
+			OrgID:    org_id,
+			Devices:  []models.Device{device},
+			CommitID: latestCommit.ID,
+			Commit:   &latestCommit,
+			RepoID:   repo.ID,
+			Repo:     &repo,
+			Status:   models.UpdateStatusBuilding,
+		}
+		db.DB.Create(&update)
+
+		var devicesUpdate models.DevicesUpdate
+		devicesUpdate.DevicesUUID = append(devicesUpdate.DevicesUUID, device.UUID)
+		devicesUpdate.CommitID = latestCommit.ID
+
+		Context("when update change Refs success", func() {
+
+			It("initialisation should pass", func() {
+				resp := inventory.Response{Total: 1, Count: 1, Result: []inventory.Device{
+					{ID: device.UUID, Ostree: inventory.SystemProfile{
+						RHCClientID: faker.UUIDHyphenated(),
+						RpmOstreeDeployments: []inventory.OSTree{
+							{Checksum: currentCommit.OSTreeCommit, Booted: true},
+						},
+					},
+						OrgID: org_id,
+					},
+				}}
+				mockInventoryClient.EXPECT().ReturnDevicesByID(device.UUID).Return(resp, nil)
+
+				mockImageService.EXPECT().GetImageByOSTreeCommitHash(currentCommit.OSTreeCommit).Return(&currentImage, nil)
+				mockImageService.EXPECT().GetImageByOSTreeCommitHash(commit.OSTreeCommit).Return(&image, nil)
+				mockImageService.EXPECT().GetImageByOSTreeCommitHash(latestCommit.OSTreeCommit).Return(&latestImage, nil)
+
+				upd, err := updateService.BuildUpdateTransactions(&devicesUpdate, account, org_id, &commit)
+				Expect(err).To(BeNil())
+				for _, u := range *upd {
+					Expect(u.ChangesRefs).To(BeTrue())
+				}
+			})
+		})
+	})
+
+	Describe("Update Devices to same distribution", func() {
+		account := faker.UUIDHyphenated()
+		org_id := faker.UUIDHyphenated()
+		var updateService services.UpdateServiceInterface
+
+		var mockImageService *mock_services.MockImageServiceInterface
+		var mockInventoryClient *mock_inventory.MockClientInterface
+
+		var mockRepoBuilder *mock_services.MockRepoBuilderInterface
+		BeforeEach(func() {
+			ctrl := gomock.NewController(GinkgoT())
+			defer ctrl.Finish()
+			mockRepoBuilder = mock_services.NewMockRepoBuilderInterface(ctrl)
+			mockImageService = mock_services.NewMockImageServiceInterface(ctrl)
+			mockInventoryClient = mock_inventory.NewMockClientInterface(ctrl)
+			updateService = &services.UpdateService{
+				Service:       services.NewService(context.Background(), log.WithField("service", "update")),
+				RepoBuilder:   mockRepoBuilder,
+				Inventory:     mockInventoryClient,
+				ImageService:  mockImageService,
+				WaitForReboot: 0,
+			}
+		})
+
+		imageSet := models.ImageSet{Account: account, OrgID: org_id, Name: faker.UUIDHyphenated()}
+		db.DB.Create(&imageSet)
+
+		currentCommit := models.Commit{Account: account, OrgID: org_id, OSTreeCommit: faker.UUIDHyphenated()}
+		db.DB.Create(&currentCommit)
+		currentImage := models.Image{Account: account, OrgID: org_id, CommitID: currentCommit.ID, ImageSetID: &imageSet.ID, Status: models.ImageStatusSuccess, Distribution: "rhel-90"}
+		db.DB.Create(&currentImage)
+
+		commit := models.Commit{Account: account, OrgID: org_id, OSTreeCommit: faker.UUIDHyphenated(), ChangesRefs: false}
+		db.DB.Create(&commit)
+		image := models.Image{Account: account, OrgID: org_id, CommitID: commit.ID, ImageSetID: &imageSet.ID, Status: models.ImageStatusSuccess, Distribution: "rhel-90"}
+		db.DB.Create(&image)
+
+		latestCommit := models.Commit{Account: account, OrgID: org_id, OSTreeCommit: faker.UUIDHyphenated(), ChangesRefs: false}
+		db.DB.Create(&latestCommit)
+		latestImage := models.Image{Account: account, OrgID: org_id, CommitID: latestCommit.ID, ImageSetID: &imageSet.ID, Status: models.ImageStatusSuccess, Distribution: "rhel-90"}
+		db.DB.Create(&latestImage)
+
+		device := models.Device{Account: account, OrgID: org_id, ImageID: currentImage.ID, UpdateAvailable: true, UUID: faker.UUIDHyphenated()}
+		db.DB.Create(&device)
+
+		repo := models.Repo{Status: models.RepoStatusSuccess, URL: "www.redhat.com"}
+		db.DB.Create(&repo)
+
+		update := models.UpdateTransaction{
+			Account:  account,
+			OrgID:    org_id,
+			Devices:  []models.Device{device},
+			CommitID: latestCommit.ID,
+			Commit:   &latestCommit,
+			RepoID:   repo.ID,
+			Repo:     &repo,
+			Status:   models.UpdateStatusBuilding,
+		}
+		db.DB.Create(&update)
+
+		var devicesUpdate models.DevicesUpdate
+		devicesUpdate.DevicesUUID = append(devicesUpdate.DevicesUUID, device.UUID)
+		devicesUpdate.CommitID = latestCommit.ID
+
+		Context("when update change Refs success", func() {
+
+			It("initialisation should pass", func() {
+				resp := inventory.Response{Total: 1, Count: 1, Result: []inventory.Device{
+					{ID: device.UUID, Ostree: inventory.SystemProfile{
+						RHCClientID: faker.UUIDHyphenated(),
+						RpmOstreeDeployments: []inventory.OSTree{
+							{Checksum: currentCommit.OSTreeCommit, Booted: true},
+						},
+					},
+						OrgID: org_id,
+					},
+				}}
+				mockInventoryClient.EXPECT().ReturnDevicesByID(device.UUID).Return(resp, nil)
+
+				mockImageService.EXPECT().GetImageByOSTreeCommitHash(currentCommit.OSTreeCommit).Return(&currentImage, nil)
+				mockImageService.EXPECT().GetImageByOSTreeCommitHash(commit.OSTreeCommit).Return(&image, nil)
+				mockImageService.EXPECT().GetImageByOSTreeCommitHash(latestCommit.OSTreeCommit).Return(&latestImage, nil)
+
+				upd, err := updateService.BuildUpdateTransactions(&devicesUpdate, account, org_id, &commit)
+				Expect(err).To(BeNil())
+				for _, u := range *upd {
+					Expect(u.ChangesRefs).To(BeFalse())
+				}
+			})
+		})
+	})
+
+	Describe("Update Devices from 1 to 2", func() {
+		account := faker.UUIDHyphenated()
+		org_id := faker.UUIDHyphenated()
+		var updateService services.UpdateServiceInterface
+
+		var mockImageService *mock_services.MockImageServiceInterface
+		var mockInventoryClient *mock_inventory.MockClientInterface
+
+		var mockRepoBuilder *mock_services.MockRepoBuilderInterface
+		BeforeEach(func() {
+			ctrl := gomock.NewController(GinkgoT())
+			defer ctrl.Finish()
+			mockRepoBuilder = mock_services.NewMockRepoBuilderInterface(ctrl)
+			mockImageService = mock_services.NewMockImageServiceInterface(ctrl)
+			mockInventoryClient = mock_inventory.NewMockClientInterface(ctrl)
+			updateService = &services.UpdateService{
+				Service:       services.NewService(context.Background(), log.WithField("service", "update")),
+				RepoBuilder:   mockRepoBuilder,
+				Inventory:     mockInventoryClient,
+				ImageService:  mockImageService,
+				WaitForReboot: 0,
+			}
+		})
+
+		imageSet := models.ImageSet{Account: account, OrgID: org_id, Name: faker.UUIDHyphenated()}
+		db.DB.Create(&imageSet)
+
+		currentCommit := models.Commit{Account: account, OrgID: org_id, OSTreeCommit: faker.UUIDHyphenated()}
+		db.DB.Create(&currentCommit)
+		currentImage := models.Image{Account: account, OrgID: org_id, CommitID: currentCommit.ID, ImageSetID: &imageSet.ID, Status: models.ImageStatusSuccess, Distribution: "rhel-86"}
+		db.DB.Create(&currentImage)
+
+		commit := models.Commit{Account: account, OrgID: org_id, OSTreeCommit: faker.UUIDHyphenated(), ChangesRefs: false}
+		db.DB.Create(&commit)
+		image := models.Image{Account: account, OrgID: org_id, CommitID: commit.ID, ImageSetID: &imageSet.ID, Status: models.ImageStatusSuccess, Distribution: "rhel-90"}
+		db.DB.Create(&image)
+
+		device := models.Device{Account: account, OrgID: org_id, ImageID: currentImage.ID, UpdateAvailable: true, UUID: faker.UUIDHyphenated()}
+		db.DB.Create(&device)
+
+		repo := models.Repo{Status: models.RepoStatusSuccess, URL: "www.redhat.com"}
+		db.DB.Create(&repo)
+
+		update := models.UpdateTransaction{
+			Account:  account,
+			OrgID:    org_id,
+			Devices:  []models.Device{device},
+			CommitID: commit.ID,
+			Commit:   &commit,
+			RepoID:   repo.ID,
+			Repo:     &repo,
+			Status:   models.UpdateStatusBuilding,
+		}
+		db.DB.Create(&update)
+
+		var devicesUpdate models.DevicesUpdate
+		devicesUpdate.DevicesUUID = append(devicesUpdate.DevicesUUID, device.UUID)
+		devicesUpdate.CommitID = commit.ID
+
+		Context("when update change Refs success", func() {
+
+			It("initialisation should pass", func() {
+				resp := inventory.Response{Total: 1, Count: 1, Result: []inventory.Device{
+					{ID: device.UUID, Ostree: inventory.SystemProfile{
+						RHCClientID: faker.UUIDHyphenated(),
+						RpmOstreeDeployments: []inventory.OSTree{
+							{Checksum: currentCommit.OSTreeCommit, Booted: true},
+						},
+					},
+						OrgID: org_id,
+					},
+				}}
+				mockInventoryClient.EXPECT().ReturnDevicesByID(device.UUID).Return(resp, nil)
+
+				mockImageService.EXPECT().GetImageByOSTreeCommitHash(currentCommit.OSTreeCommit).Return(&currentImage, nil)
+				mockImageService.EXPECT().GetImageByOSTreeCommitHash(commit.OSTreeCommit).Return(&image, nil)
+
+				upd, err := updateService.BuildUpdateTransactions(&devicesUpdate, account, org_id, &commit)
+				Expect(err).To(BeNil())
+				for _, u := range *upd {
+					Expect(u.ChangesRefs).To(BeTrue())
+				}
 			})
 		})
 	})


### PR DESCRIPTION
# Description

Change validation to be on device level once device can run different version from latest commit

Fixes # (THEEDGE-2389)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
