### PR TITLE
images: FIXES image installer orgID.

### DIFF
--- a/pkg/models/commits.go
+++ b/pkg/models/commits.go
@@ -3,6 +3,7 @@ package models
 import (
 	"errors"
 
+	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
@@ -74,6 +75,7 @@ type InstalledPackage struct {
 // BeforeCreate method is called before creating Commits, it make sure org_id is not empty
 func (c *Commit) BeforeCreate(tx *gorm.DB) error {
 	if c.OrgID == "" {
+		log.Error("commit do not have an org_id")
 		return ErrOrgIDIsMandatory
 	}
 

--- a/pkg/models/devicegroups.go
+++ b/pkg/models/devicegroups.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"regexp"
 
+	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
@@ -96,6 +97,7 @@ func (group *DeviceGroup) BeforeDelete(tx *gorm.DB) error {
 // BeforeCreate method is called before creating device group, it make sure org_id is not empty
 func (group *DeviceGroup) BeforeCreate(tx *gorm.DB) error {
 	if group.OrgID == "" {
+		log.Error("device-group do not have an org_id")
 		return ErrOrgIDIsMandatory
 	}
 

--- a/pkg/models/devices.go
+++ b/pkg/models/devices.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
@@ -97,6 +98,7 @@ type Device struct {
 // BeforeCreate method is called before creating devices, it make sure org_id is not empty
 func (d *Device) BeforeCreate(tx *gorm.DB) error {
 	if d.OrgID == "" {
+		log.Error("device do not have an org_id")
 		return ErrOrgIDIsMandatory
 	}
 

--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -93,6 +93,8 @@ const (
 	ImageStatusSuccess = "SUCCESS"
 	// ImageStatusInterrupted is for when an image build is interrupted
 	ImageStatusInterrupted = "INTERRUPTED"
+	// ImageStatusPending is for when an image or installer is waiting to be built
+	ImageStatusPending = "PENDING"
 
 	// MissingInstaller is the error message for not passing an installer in the request
 	MissingInstaller = "installer info must be provided"
@@ -244,10 +246,8 @@ func (i *Image) GetALLPackagesList() *[]string {
 
 // BeforeCreate method is called before creating Images, it make sure org_id is not empty
 func (i *Image) BeforeCreate(tx *gorm.DB) error {
-	log.WithFields(log.Fields{
-		"image_orgID": i.OrgID,
-	}).Error("image dosent have an org_id")
-	if len(i.OrgID) == 0 {
+	if i.OrgID == "" {
+		log.Error("image do not have an org_id")
 		return ErrOrgIDIsMandatory
 
 	}
@@ -257,12 +257,9 @@ func (i *Image) BeforeCreate(tx *gorm.DB) error {
 
 // BeforeCreate method is called before creating ImageSet, it make sure org_id is not empty
 func (imgset *ImageSet) BeforeCreate(tx *gorm.DB) error {
-	log.WithFields(log.Fields{
-		"imageset_orgID": imgset.OrgID,
-	}).Error("imageset dosent have an org_id")
-	if len(imgset.OrgID) == 0 {
+	if imgset.OrgID == "" {
+		log.Error("imageSet do have an org_id")
 		return ErrOrgIDIsMandatory
-
 	}
 
 	return nil

--- a/pkg/models/installers.go
+++ b/pkg/models/installers.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
@@ -20,6 +21,7 @@ type Installer struct {
 // BeforeCreate method is called before create a record on installer, it make sure org_id is not empty
 func (i *Installer) BeforeCreate(tx *gorm.DB) error {
 	if i.OrgID == "" {
+		log.Error("installer do not have an org_id")
 		return ErrOrgIDIsMandatory
 	}
 

--- a/pkg/models/thirdpartyrepo.go
+++ b/pkg/models/thirdpartyrepo.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
+	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
@@ -66,6 +67,7 @@ func (t *ThirdPartyRepo) ValidateRequest() error {
 // BeforeCreate method is called before creating Third Party Tepository, it make sure org_id is not empty
 func (t *ThirdPartyRepo) BeforeCreate(tx *gorm.DB) error {
 	if t.OrgID == "" {
+		log.Error("custom-repository do not have an org_id")
 		return ErrOrgIDIsMandatory
 	}
 

--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -3,6 +3,7 @@ package models
 import (
 	"errors"
 
+	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
@@ -90,6 +91,7 @@ func (ur *UpdateTransaction) ValidateRequest() error {
 // BeforeCreate method is called before creating any record with update, it make sure org_id is not empty
 func (ur *UpdateTransaction) BeforeCreate(tx *gorm.DB) error {
 	if ur.OrgID == "" {
+		log.Error("update-transaction do not have an org_id")
 		return ErrOrgIDIsMandatory
 	}
 


### PR DESCRIPTION
Notes: We may set installer to nil when no iso needed , but that may break sql queries, that rely on simple joins (as we will need left join), this will need more time to investigate. We only fixed without changing the behaviour e.g. as it is functioning now.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #THEEDGE-2402


## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [X] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
