### PR TITLE
THEEDGE-2406 Fix device update with status disconnected

### DIFF
--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -25,7 +25,7 @@ type UpdateTransaction struct {
 	Devices         []Device         `gorm:"many2many:updatetransaction_devices;" json:"Devices"`
 	Tag             string           `json:"Tag"`
 	Status          string           `json:"Status"`
-	RepoID          uint             `json:"RepoID"`
+	RepoID          *uint            `json:"RepoID"`
 	Repo            *Repo            `json:"Repo"`
 	ChangesRefs     bool             `gorm:"default:false" json:"ChangesRefs"`
 	DispatchRecords []DispatchRecord `gorm:"many2many:updatetransaction_dispatchrecords;" json:"DispatchRecords"`

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -757,7 +757,7 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 
 				//Should not create a transaction to device already updated
 				update.OldCommits = oldCommits
-				update.RepoID = repo.ID
+				update.RepoID = &repo.ID
 				if err := db.DB.Save(&update).Error; err != nil {
 					err = errors.NewBadRequest(err.Error())
 					s.log.WithField("error", err.Error()).Error("Error encoding error")

--- a/pkg/services/updates_test.go
+++ b/pkg/services/updates_test.go
@@ -858,7 +858,6 @@ var _ = Describe("UpdateService Basic functions", func() {
 				Expect(len(*updates)).Should(Equal(1))
 				Expect((*updates)[0].ID).Should(BeNumerically(">", 0))
 				Expect((*updates)[0].RepoID).ToNot(BeNil())
-				Expect((*updates)[0].Account).Should(Equal(common.DefaultAccount))
 				Expect((*updates)[0].OrgID).Should(Equal(common.DefaultOrgID))
 				Expect((*updates)[0].Status).Should(Equal(models.UpdateStatusCreated))
 				Expect((*updates)[0].Repo.ID).Should(BeNumerically(">", 0))
@@ -888,7 +887,6 @@ var _ = Describe("UpdateService Basic functions", func() {
 				Expect(len(*updates)).Should(Equal(1))
 				Expect((*updates)[0].ID).Should(BeNumerically(">", 0))
 				Expect((*updates)[0].RepoID).Should(BeNil())
-				Expect((*updates)[0].Account).Should(Equal(common.DefaultAccount))
 				Expect((*updates)[0].OrgID).Should(Equal(common.DefaultOrgID))
 				Expect((*updates)[0].Status).Should(Equal(models.UpdateStatusDeviceDisconnected))
 				Expect((*updates)[0].Repo).Should(BeNil())
@@ -916,13 +914,12 @@ var _ = Describe("UpdateService Basic functions", func() {
 				mockInventory.EXPECT().ReturnDevicesByID(device2.UUID).
 					Return(responseInventory2, nil)
 
-				updates, err := updateService.BuildUpdateTransactions(&devicesUpdate, common.DefaultAccount, common.DefaultOrgID, &newCommit)
+				updates, err := updateService.BuildUpdateTransactions(&devicesUpdate, common.DefaultOrgID, &newCommit)
 
 				Expect(err).To(BeNil())
 				Expect(len(*updates)).Should(Equal(2))
 				Expect((*updates)[0].ID).Should(BeNumerically(">", 0))
 				Expect((*updates)[0].RepoID).ToNot(BeNil())
-				Expect((*updates)[0].Account).Should(Equal(common.DefaultAccount))
 				Expect((*updates)[0].OrgID).Should(Equal(common.DefaultOrgID))
 				Expect((*updates)[0].Status).Should(Equal(models.UpdateStatusCreated))
 				Expect((*updates)[0].Repo.ID).Should(BeNumerically(">", 0))
@@ -935,7 +932,6 @@ var _ = Describe("UpdateService Basic functions", func() {
 
 				Expect((*updates)[1].ID).Should(BeNumerically(">", 0))
 				Expect((*updates)[1].RepoID).Should(BeNil())
-				Expect((*updates)[1].Account).Should(Equal(common.DefaultAccount))
 				Expect((*updates)[1].OrgID).Should(Equal(common.DefaultOrgID))
 				Expect((*updates)[1].Status).Should(Equal(models.UpdateStatusDeviceDisconnected))
 				Expect((*updates)[1].Repo).Should(BeNil())

--- a/pkg/services/updates_test.go
+++ b/pkg/services/updates_test.go
@@ -579,7 +579,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 			Devices:  []models.Device{device},
 			CommitID: latestCommit.ID,
 			Commit:   &latestCommit,
-			RepoID:   repo.ID,
+			RepoID:   &repo.ID,
 			Repo:     &repo,
 			Status:   models.UpdateStatusBuilding,
 		}
@@ -671,7 +671,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 			Devices:  []models.Device{device},
 			CommitID: latestCommit.ID,
 			Commit:   &latestCommit,
-			RepoID:   repo.ID,
+			RepoID:   &repo.ID,
 			Repo:     &repo,
 			Status:   models.UpdateStatusBuilding,
 		}
@@ -758,7 +758,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 			Devices:  []models.Device{device},
 			CommitID: commit.ID,
 			Commit:   &commit,
-			RepoID:   repo.ID,
+			RepoID:   &repo.ID,
 			Repo:     &repo,
 			Status:   models.UpdateStatusBuilding,
 		}
@@ -805,6 +805,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 		var newCommit models.Commit
 		var newImage models.Image
 		var device models.Device
+		var device2 models.Device
 
 		var updateService services.UpdateServiceInterface
 		var mockRepoBuilder *mock_services.MockRepoBuilderInterface
@@ -834,6 +835,8 @@ var _ = Describe("UpdateService Basic functions", func() {
 			db.DB.Create(&newImage)
 			device = models.Device{Account: account, OrgID: orgId, ImageID: currentImage.ID, UpdateAvailable: true, UUID: faker.UUIDHyphenated(), RHCClientID: rhcClientId}
 			db.DB.Create(&device)
+			device2 = models.Device{Account: account, OrgID: orgId, ImageID: currentImage.ID, UpdateAvailable: true, UUID: faker.UUIDHyphenated()}
+			db.DB.Create(&device2)
 		})
 
 		Context("when device has rhc_client_id", func() {
@@ -854,7 +857,8 @@ var _ = Describe("UpdateService Basic functions", func() {
 				Expect(err).To(BeNil())
 				Expect(len(*updates)).Should(Equal(1))
 				Expect((*updates)[0].ID).Should(BeNumerically(">", 0))
-				Expect((*updates)[0].RepoID).Should(BeNumerically(">", 0))
+				Expect((*updates)[0].RepoID).ToNot(BeNil())
+				Expect((*updates)[0].Account).Should(Equal(common.DefaultAccount))
 				Expect((*updates)[0].OrgID).Should(Equal(common.DefaultOrgID))
 				Expect((*updates)[0].Status).Should(Equal(models.UpdateStatusCreated))
 				Expect((*updates)[0].Repo.ID).Should(BeNumerically(">", 0))
@@ -883,12 +887,58 @@ var _ = Describe("UpdateService Basic functions", func() {
 				Expect(err).To(BeNil())
 				Expect(len(*updates)).Should(Equal(1))
 				Expect((*updates)[0].ID).Should(BeNumerically(">", 0))
-				Expect((*updates)[0].RepoID).Should(Equal(uint(0)))
+				Expect((*updates)[0].RepoID).Should(BeNil())
+				Expect((*updates)[0].Account).Should(Equal(common.DefaultAccount))
 				Expect((*updates)[0].OrgID).Should(Equal(common.DefaultOrgID))
 				Expect((*updates)[0].Status).Should(Equal(models.UpdateStatusDeviceDisconnected))
 				Expect((*updates)[0].Repo).Should(BeNil())
 
 				Expect(len((*updates)[0].Devices)).Should(Equal(0))
+			})
+		})
+
+		Context("when has two devices, one with rhc_client_id and another without", func() {
+			It("should create an update transaction with a repo", func() {
+				var devicesUpdate models.DevicesUpdate
+				devicesUpdate.DevicesUUID = []string{device.UUID, device2.UUID}
+
+				responseInventory := inventory.Response{Total: 1, Count: 1, Result: []inventory.Device{
+					{ID: device.UUID, Ostree: inventory.SystemProfile{
+						RHCClientID: rhcClientId,
+					}},
+				}}
+				mockInventory.EXPECT().ReturnDevicesByID(device.UUID).
+					Return(responseInventory, nil)
+
+				responseInventory2 := inventory.Response{Total: 1, Count: 1, Result: []inventory.Device{
+					{ID: device2.UUID, Ostree: inventory.SystemProfile{}},
+				}}
+				mockInventory.EXPECT().ReturnDevicesByID(device2.UUID).
+					Return(responseInventory2, nil)
+
+				updates, err := updateService.BuildUpdateTransactions(&devicesUpdate, common.DefaultAccount, common.DefaultOrgID, &newCommit)
+
+				Expect(err).To(BeNil())
+				Expect(len(*updates)).Should(Equal(2))
+				Expect((*updates)[0].ID).Should(BeNumerically(">", 0))
+				Expect((*updates)[0].RepoID).ToNot(BeNil())
+				Expect((*updates)[0].Account).Should(Equal(common.DefaultAccount))
+				Expect((*updates)[0].OrgID).Should(Equal(common.DefaultOrgID))
+				Expect((*updates)[0].Status).Should(Equal(models.UpdateStatusCreated))
+				Expect((*updates)[0].Repo.ID).Should(BeNumerically(">", 0))
+				Expect((*updates)[0].Repo.URL).Should(BeEmpty())
+				Expect((*updates)[0].Repo.Status).Should(Equal(models.RepoStatusBuilding))
+
+				Expect(len((*updates)[0].Devices)).Should(Equal(1))
+				Expect((*updates)[0].Devices[0].UUID).Should(Equal(device.UUID))
+				Expect((*updates)[0].Devices[0].RHCClientID).Should(Equal(device.RHCClientID))
+
+				Expect((*updates)[1].ID).Should(BeNumerically(">", 0))
+				Expect((*updates)[1].RepoID).Should(BeNil())
+				Expect((*updates)[1].Account).Should(Equal(common.DefaultAccount))
+				Expect((*updates)[1].OrgID).Should(Equal(common.DefaultOrgID))
+				Expect((*updates)[1].Status).Should(Equal(models.UpdateStatusDeviceDisconnected))
+				Expect((*updates)[1].Repo).Should(BeNil())
 			})
 		})
 

--- a/pkg/services/updates_test.go
+++ b/pkg/services/updates_test.go
@@ -898,7 +898,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 		})
 
 		Context("when has two devices, one with rhc_client_id and another without", func() {
-			It("should create an update transaction with a repo", func() {
+			It("should create two update transactions, one with a repo and another without", func() {
 				var devicesUpdate models.DevicesUpdate
 				devicesUpdate.DevicesUUID = []string{device.UUID, device2.UUID}
 


### PR DESCRIPTION
# Description

Devices upgrading with status disconnected are getting HTTP status 500.
Fixes THEEDGE-2406.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
