### PR TITLE
fix a bug when filtering image-set with version

### DIFF
--- a/pkg/routes/common/filters.go
+++ b/pkg/routes/common/filters.go
@@ -3,6 +3,7 @@ package common
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -52,6 +53,22 @@ func BoolFilterHandler(filter *Filter) FilterFunc {
 		}
 		return tx.Where(sqlQuery + sqlValue)
 	})
+}
+
+// IntegerNumberFilterHandler handles integer number values filters
+func IntegerNumberFilterHandler(filter *Filter) FilterFunc {
+	sqlQuery := fmt.Sprintf("%s = ?", filter.DBField)
+	return func(r *http.Request, tx *gorm.DB) *gorm.DB {
+		value := r.URL.Query().Get(filter.QueryParam)
+		if value == "" {
+			return tx
+		}
+		intValue, err := strconv.Atoi(value)
+		if err != nil {
+			return nil
+		}
+		return tx.Where(sqlQuery, intValue)
+	}
 }
 
 // OneOfFilterHandler handles multiple values filters


### PR DESCRIPTION
fix a bug that filtering imageset by version doesn't work and 
when we filter imageset with version and put string instead of number, now we will get correct message
related to THEEDGE-2410

Signed-off-by: mgold1234 <mgold@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
