### PR TITLE
temporarily nailing lint image to a specific digest name sha

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Vet
         uses: addnab/docker-run-action@v3
         with:
-          image: quay.io/fleet-management/libfdo-data:latest
+          image: quay.io/fleet-management/libfdo-data:sha256:1eb087a42f3380ba0fed4a381fe4181ef82d2e2acf7e598129f85cb489fa03c0
           options: -v ${{ github.workspace }}:/edge-api
           run: make -C edge-api vet
 


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Temporarily nailing the lint image for PR check to previous digest name

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
