### PR TITLE
devicesview filter-by-image-id fix and unit-tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @maxamillion @acosferreira @loadtheaccumulator @Saurabh-Thakre @AaronH88 @thom-at-redhat @ldjebran @mgold1234
+* @maxamillion @acosferreira @loadtheaccumulator @Saurabh-Thakre @AaronH88 @thom-at-redhat @ldjebran @mgold1234 @tomershinhar

--- a/pkg/routes/devices.go
+++ b/pkg/routes/devices.go
@@ -84,7 +84,7 @@ var devicesFilters = common.ComposeFilters(
 		DBField:    "devices.created_at",
 	}),
 	// Filter handler for "image_id"
-	common.ContainFilterHandler(&common.Filter{
+	common.IntegerNumberFilterHandler(&common.Filter{
 		QueryParam: "image_id",
 		DBField:    "devices.image_id",
 	}),

--- a/pkg/routes/devices_test.go
+++ b/pkg/routes/devices_test.go
@@ -14,9 +14,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/redhatinsights/edge-api/pkg/db"
 	"github.com/redhatinsights/edge-api/pkg/dependencies"
 	"github.com/redhatinsights/edge-api/pkg/models"
 	"github.com/redhatinsights/edge-api/pkg/routes"
+	"github.com/redhatinsights/edge-api/pkg/routes/common"
 	"github.com/redhatinsights/edge-api/pkg/services"
 	"github.com/redhatinsights/edge-api/pkg/services/mock_services"
 )
@@ -200,76 +202,117 @@ var _ = Describe("Devices View Router", func() {
 			})
 		})
 	})
-	Context("Filters", func() {
-		BeforeEach(func() {
-			mockDeviceService.EXPECT().GetDevicesCount(gomock.Any()).Return(int64(0), nil)
-			mockDeviceService.EXPECT().GetDevicesView(gomock.Any(), gomock.Any(), gomock.Any()).Return(&models.DeviceViewList{}, nil)
+})
 
-		})
+var _ = Describe("Devices View Filters", func() {
+	var imageV1 *models.Image
+	var deviceUUID string
 
-		When("filter by name", func() {
-			It("should return devices with given name", func() {
-				name := "device-1"
-				req, err := http.NewRequest("GET", fmt.Sprintf("/devices/devicesview?name=%s", name), nil)
-				if err != nil {
-					Expect(err).ToNot(HaveOccurred())
-				}
-				rr := httptest.NewRecorder()
-				handler := http.HandlerFunc(routes.GetDevicesView)
+	BeforeEach(func() {
 
-				ctx := dependencies.ContextWithServices(req.Context(), mockServices)
-				req = req.WithContext(ctx)
-				handler.ServeHTTP(rr, req)
-				Expect(rr.Code).To(Equal(http.StatusOK))
-			})
-		})
-		When("filter by update_available", func() {
-			It("should return devices with update_available as true", func() {
-				req, err := http.NewRequest("GET", "/devices/devicesview?update_available=trues", nil)
-				if err != nil {
-					Expect(err).ToNot(HaveOccurred())
-				}
-				rr := httptest.NewRecorder()
-				handler := http.HandlerFunc(routes.GetDevicesView)
+		orgID := common.DefaultOrgID
 
-				ctx := dependencies.ContextWithServices(req.Context(), mockServices)
-				req = req.WithContext(ctx)
-				handler.ServeHTTP(rr, req)
-				Expect(rr.Code).To(Equal(http.StatusOK))
-			})
-		})
-		When("filter by uuid", func() {
-			It("should return devices with given uuid", func() {
-				uuid := "bbb-bbb-bbb-bbb"
-				req, err := http.NewRequest("GET", fmt.Sprintf("/devices/devicesview?uuid=%s", uuid), nil)
-				if err != nil {
-					Expect(err).ToNot(HaveOccurred())
-				}
-				rr := httptest.NewRecorder()
-				handler := http.HandlerFunc(routes.GetDevicesView)
+		imageSet := &models.ImageSet{
+			Name:    "test",
+			Version: 2,
+			OrgID:   orgID,
+		}
+		result := db.DB.Create(imageSet)
+		Expect(result.Error).ToNot(HaveOccurred())
+		imageV1 = &models.Image{
+			Commit: &models.Commit{
+				OSTreeCommit: faker.UUIDHyphenated(),
+				OrgID:        orgID,
+			},
+			Status:     models.ImageStatusSuccess,
+			ImageSetID: &imageSet.ID,
+			Version:    1,
+			OrgID:      common.DefaultOrgID,
+		}
+		result = db.DB.Create(imageV1.Commit)
+		Expect(result.Error).ToNot(HaveOccurred())
+		result = db.DB.Create(imageV1)
+		Expect(result.Error).ToNot(HaveOccurred())
+		deviceUUID = faker.UUIDHyphenated()
+		device1 := models.Device{OrgID: orgID, Name: "device-1", UpdateAvailable: true, ImageID: imageV1.ID, UUID: deviceUUID}
 
-				ctx := dependencies.ContextWithServices(req.Context(), mockServices)
-				req = req.WithContext(ctx)
-				handler.ServeHTTP(rr, req)
-				Expect(rr.Code).To(Equal(http.StatusOK))
-			})
-		})
-		When("filter by image-id", func() {
-			It("should return devices with given image-id", func() {
-				image_id := "2"
+		device2 := models.Device{OrgID: orgID, Name: "device-2", UpdateAvailable: false, ImageID: 99, UUID: "aaa-aaa-aaa-aaa"}
 
-				req, err := http.NewRequest("GET", fmt.Sprintf("/devices/devicesview?image_id=%s", image_id), nil)
-				if err != nil {
-					Expect(err).ToNot(HaveOccurred())
-				}
-				rr := httptest.NewRecorder()
-				handler := http.HandlerFunc(routes.GetDevicesView)
+		result = db.DB.Create(&device1)
+		Expect(result.Error).To(BeNil())
+		result = db.DB.Create(&device2)
+		Expect(result.Error).To(BeNil())
 
-				ctx := dependencies.ContextWithServices(req.Context(), mockServices)
-				req = req.WithContext(ctx)
-				handler.ServeHTTP(rr, req)
-				Expect(rr.Code).To(Equal(http.StatusOK))
-			})
-		})
+	})
+	It("when filter by name, return devices with given name", func() {
+		name := "device-1"
+		var devicesFilters = common.ComposeFilters(
+			// Filter handler for "name"
+			common.ContainFilterHandler(&common.Filter{
+				QueryParam: "name",
+				DBField:    "devices.name",
+			}),
+		)
+
+		req, err := http.NewRequest("GET", fmt.Sprintf("/?name=%s", name), nil)
+		Expect(err).ToNot(HaveOccurred())
+		dbFilters := devicesFilters(req, db.DB)
+		devices := []models.Device{}
+		dbFilters.Find(&devices)
+		Expect(len(devices)).To(Equal(1))
+		Expect(devices[0].Name).To(Equal(name))
+	})
+	It("when filter by update_available, return devices with given value", func() {
+		var devicesFilters = common.ComposeFilters(
+			// Filter handler for "update_available"
+			common.BoolFilterHandler(&common.Filter{
+				QueryParam: "update_available",
+				DBField:    "devices.update_available",
+			}),
+		)
+
+		req, err := http.NewRequest("GET", "/?update_available=true", nil)
+		Expect(err).ToNot(HaveOccurred())
+		dbFilters := devicesFilters(req, db.DB)
+		devices := []models.Device{}
+		dbFilters.Find(&devices)
+		Expect(len(devices)).ToNot(Equal(0))
+		for _, device := range devices {
+			Expect(device.UpdateAvailable).To(Equal(true))
+		}
+	})
+	It("when filter by uuid, return devices with given uuid", func() {
+		var devicesFilters = common.ComposeFilters(
+			// Filter handler for "uuid"
+			common.ContainFilterHandler(&common.Filter{
+				QueryParam: "uuid",
+				DBField:    "devices.uuid",
+			}),
+		)
+
+		req, err := http.NewRequest("GET", fmt.Sprintf("/?uuid=%s", deviceUUID), nil)
+		Expect(err).ToNot(HaveOccurred())
+		dbFilters := devicesFilters(req, db.DB)
+		devices := []models.Device{}
+		dbFilters.Find(&devices)
+		Expect(len(devices)).To(Equal(1))
+		Expect(devices[0].UUID).To(Equal(deviceUUID))
+	})
+	It("when filter by image_id, return devices with given image_id", func() {
+		var devicesFilters = common.ComposeFilters(
+			// Filter handler for "image_id"
+			common.IntegerNumberFilterHandler(&common.Filter{
+				QueryParam: "image_id",
+				DBField:    "devices.image_id",
+			}),
+		)
+
+		req, err := http.NewRequest("GET", fmt.Sprintf("/?image_id=%d", imageV1.ID), nil)
+		Expect(err).ToNot(HaveOccurred())
+		dbFilters := devicesFilters(req, db.DB)
+		devices := []models.Device{}
+		dbFilters.Find(&devices)
+		Expect(len(devices)).To(Equal(1))
+		Expect(devices[0].ImageID).To(Equal(imageV1.ID))
 	})
 })

--- a/pkg/routes/devices_test.go
+++ b/pkg/routes/devices_test.go
@@ -13,6 +13,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/redhatinsights/edge-api/pkg/dependencies"
 	"github.com/redhatinsights/edge-api/pkg/models"
 	"github.com/redhatinsights/edge-api/pkg/routes"
@@ -196,6 +197,78 @@ var _ = Describe("Devices View Router", func() {
 				handler.ServeHTTP(rr, req)
 				Expect(rr.Code).To(Equal(http.StatusOK))
 
+			})
+		})
+	})
+	Context("Filters", func() {
+		BeforeEach(func() {
+			mockDeviceService.EXPECT().GetDevicesCount(gomock.Any()).Return(int64(0), nil)
+			mockDeviceService.EXPECT().GetDevicesView(gomock.Any(), gomock.Any(), gomock.Any()).Return(&models.DeviceViewList{}, nil)
+
+		})
+
+		When("filter by name", func() {
+			It("should return devices with given name", func() {
+				name := "device-1"
+				req, err := http.NewRequest("GET", fmt.Sprintf("/devices/devicesview?name=%s", name), nil)
+				if err != nil {
+					Expect(err).ToNot(HaveOccurred())
+				}
+				rr := httptest.NewRecorder()
+				handler := http.HandlerFunc(routes.GetDevicesView)
+
+				ctx := dependencies.ContextWithServices(req.Context(), mockServices)
+				req = req.WithContext(ctx)
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(http.StatusOK))
+			})
+		})
+		When("filter by update_available", func() {
+			It("should return devices with update_available as true", func() {
+				req, err := http.NewRequest("GET", "/devices/devicesview?update_available=trues", nil)
+				if err != nil {
+					Expect(err).ToNot(HaveOccurred())
+				}
+				rr := httptest.NewRecorder()
+				handler := http.HandlerFunc(routes.GetDevicesView)
+
+				ctx := dependencies.ContextWithServices(req.Context(), mockServices)
+				req = req.WithContext(ctx)
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(http.StatusOK))
+			})
+		})
+		When("filter by uuid", func() {
+			It("should return devices with given uuid", func() {
+				uuid := "bbb-bbb-bbb-bbb"
+				req, err := http.NewRequest("GET", fmt.Sprintf("/devices/devicesview?uuid=%s", uuid), nil)
+				if err != nil {
+					Expect(err).ToNot(HaveOccurred())
+				}
+				rr := httptest.NewRecorder()
+				handler := http.HandlerFunc(routes.GetDevicesView)
+
+				ctx := dependencies.ContextWithServices(req.Context(), mockServices)
+				req = req.WithContext(ctx)
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(http.StatusOK))
+			})
+		})
+		When("filter by image-id", func() {
+			It("should return devices with given image-id", func() {
+				image_id := "2"
+
+				req, err := http.NewRequest("GET", fmt.Sprintf("/devices/devicesview?image_id=%s", image_id), nil)
+				if err != nil {
+					Expect(err).ToNot(HaveOccurred())
+				}
+				rr := httptest.NewRecorder()
+				handler := http.HandlerFunc(routes.GetDevicesView)
+
+				ctx := dependencies.ContextWithServices(req.Context(), mockServices)
+				req = req.WithContext(ctx)
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(http.StatusOK))
 			})
 		})
 	})


### PR DESCRIPTION
# Description

fixed the filter-by-image-id option for devicesview endpoint and added unit-tests to verify the query params available are accepted.

also added myself to CODEOWNERS

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
