### PR TITLE
Change "go get" to "go install"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ test-no-fdo:
 	go test $$(go list ./... | grep -v /test/) $(TEST_OPTIONS)
 
 vet:
+	go mod tidy
 	go install -a
 	go vet $(BUILD_TAGS) $$(go list $(BUILD_TAGS) ./... | grep -v /vendor/)
 

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ test-no-fdo:
 	go test $$(go list ./... | grep -v /test/) $(TEST_OPTIONS)
 
 vet:
-	go get -a
+	go install -a
 	go vet $(BUILD_TAGS) $$(go list $(BUILD_TAGS) ./... | grep -v /vendor/)
 
 vet-no-fdo:


### PR DESCRIPTION
# Description

Update Makefile to use "go install" instead of "go get" (per https://go.dev/doc/go-get-install-deprecation)
Fixes # (issue)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
