### PR TITLE
add account id to notification topic

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -1459,6 +1459,7 @@ func (s *ImageService) SendImageNotification(i *models.Image) (ImageNotification
 		recipients = append(recipients, recipient)
 
 		notify.OrgID = i.OrgID
+		notify.Account = i.Account
 		notify.Context = fmt.Sprintf("{  \"ImageName\" : \"%v\"}", i.Name)
 		notify.Events = events
 		notify.Recipients = recipients

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/redhatinsights/edge-api/pkg/routes/common"
 	"io"
 	"net/http"
 	"os"
@@ -14,6 +13,8 @@ import (
 	"syscall"
 	"text/template"
 	"time"
+
+	"github.com/redhatinsights/edge-api/pkg/routes/common"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
@@ -489,6 +490,7 @@ func (s *UpdateService) SendDeviceNotification(i *models.UpdateTransaction) (Ima
 		recipients = append(recipients, recipient)
 
 		notify.OrgID = i.OrgID
+		notify.Account = i.Account
 		notify.Context = fmt.Sprintf("{  \"CommitID\" : \"%v\"}", i.CommitID)
 		notify.Events = events
 		notify.Recipients = recipients


### PR DESCRIPTION
# Description

Notification process still need the account id to be processed, adding back and should be revisited when they complete the migration

Fixes # ([issue](https://issues.redhat.com/browse/THEEDGE-2462))

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
