### PR TITLE
should save a device to a update transaction regardless to disconnect

### DIFF
--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -682,6 +682,7 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 					"deviceUUID": device.ID,
 				}).Info("Device is disconnected")
 				update.Status = models.UpdateStatusDeviceDisconnected
+				update.Devices = append(update.Devices, *updateDevice)
 				if result := db.DB.Create(&update); result.Error != nil {
 					return nil, result.Error
 				}

--- a/pkg/services/updates_test.go
+++ b/pkg/services/updates_test.go
@@ -884,7 +884,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 				Expect((*updates)[0].Status).Should(Equal(models.UpdateStatusDeviceDisconnected))
 				Expect((*updates)[0].Repo).Should(BeNil())
 
-				Expect(len((*updates)[0].Devices)).Should(Equal(0))
+				Expect(len((*updates)[0].Devices)).Should(Equal(1))
 			})
 		})
 


### PR DESCRIPTION
# Description

When we run an update transaction we must save the relation to the device. We should not have an orphan update transaction. 

Fixes # (issue)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
