### PR TITLE
Add indexes for created_at and updated_at

### DIFF
--- a/pkg/models/base.go
+++ b/pkg/models/base.go
@@ -10,8 +10,8 @@ import (
 // Model is a basic GoLang struct based on gorm.Model with the JSON tags for openapi3gen
 type Model struct {
 	ID        uint           `gorm:"primarykey" json:"ID,omitempty"`
-	CreatedAt EdgeAPITime    `json:"CreatedAt,omitempty"`
-	UpdatedAt EdgeAPITime    `json:"UpdatedAt,omitempty"`
+	CreatedAt EdgeAPITime    `gorm:"index" json:"CreatedAt,omitempty"`
+	UpdatedAt EdgeAPITime    `gorm:"index" json:"UpdatedAt,omitempty"`
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"DeletedAt,omitempty"`
 }
 


### PR DESCRIPTION
# Description

Add indexes for `created_at` and `updated_at`.
Optimize database queries since there are queries that use `created_at` and `updated_at` for sorting.


## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
