### PR TITLE
fix deviceview filter by created_at

### DIFF
--- a/pkg/routes/devices.go
+++ b/pkg/routes/devices.go
@@ -79,7 +79,7 @@ var devicesFilters = common.ComposeFilters(
 		DBField:    "devices.update_available",
 	}),
 	// Filter handler for "created_at"
-	common.BoolFilterHandler(&common.Filter{
+	common.CreatedAtFilterHandler(&common.Filter{
 		QueryParam: "created_at",
 		DBField:    "devices.created_at",
 	}),

--- a/pkg/routes/devices_test.go
+++ b/pkg/routes/devices_test.go
@@ -321,9 +321,9 @@ var _ = Describe("Devices View Filters", func() {
 	It("when filter by created_at, return devices with matching value", func() {
 		var devicesFilters = common.ComposeFilters(
 			// Filter handler for "image_id"
-			common.IntegerNumberFilterHandler(&common.Filter{
-				QueryParam: "image_id",
-				DBField:    "devices.image_id",
+			common.CreatedAtFilterHandler(&common.Filter{
+				QueryParam: "created_at",
+				DBField:    "devices.created_at",
 			}),
 		)
 

--- a/pkg/routes/query_params.go
+++ b/pkg/routes/query_params.go
@@ -17,7 +17,7 @@ func initalizeQueryParamsArray() map[string][]string {
 		m = make(map[string][]string)
 		m["device-groups"] = []string{"limit", "offset", "name", "created_at", "updated_at", "sort_by"}
 		m["devices"] = []string{"per_page", "page", "sort_by", "order_how", "hostname_or_id"}
-		m["devicesview"] = []string{"limit", "offset", "name", "uuid", "update_available", "image_id", "sort_by"}
+		m["devicesview"] = []string{"limit", "offset", "name", "uuid", "update_available", "image_id", "sort_by", "created_at"}
 		m["images"] = []string{"limit", "offset", "status", "name", "distribution", "created_at", "sort_by"}
 		m["image-sets"] = []string{"limit", "offset", "status", "name", "version", "sort_by"}
 		m["thirdpartyrepo"] = []string{"limit", "offset", "name", "created_at", "updated_at", "imageID", "sort_by"}


### PR DESCRIPTION
# Description

fixed the /devicesview endpoint filter by "created_at" functionality.

also added a unit-test for this filter

Fixes # (issue)
[THEEDGE-2431](https://issues.redhat.com/browse/THEEDGE-2431)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
