### PR TITLE
fix slow queries on image-sets endpoint

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -87,9 +87,15 @@ func OrgDB(orgID string, gormDB *gorm.DB, table string) *gorm.DB {
 	if table != "" {
 		orgIDName = fmt.Sprintf("%s.%s", table, orgIDName)
 	}
-	sqlText := fmt.Sprintf(
-		"(%s = ? AND (%s != '' AND %s IS NOT NULL))",
-		orgIDName, orgIDName, orgIDName,
+	if orgIDName == "" {
+		return nil
+	}
+	var sqlText string
+
+	sqlText = fmt.Sprintf(
+		"(%s = ? )",
+		orgIDName,
 	)
+
 	return gormDB.Where(sqlText, orgID)
 }

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Db", func() {
 			sql := db.DB.ToSQL(func(gormDB *gorm.DB) *gorm.DB {
 				return db.OrgDB("00000000", gormDB, "").Find(&device)
 			})
-			Expect(sql).To(ContainSubstring("(org_id = \"00000000\" AND (org_id != '' AND org_id IS NOT NULL))"))
+			Expect(sql).To(ContainSubstring("org_id = \"00000000\""))
 		})
 	})
 	Context("get orgID from images table", func() {
@@ -32,7 +32,7 @@ var _ = Describe("Db", func() {
 			sql := db.DB.ToSQL(func(gormDB *gorm.DB) *gorm.DB {
 				return db.OrgDB("00000000", gormDB, "images").Find(&images)
 			})
-			Expect(sql).To(ContainSubstring("(images.org_id = \"00000000\" AND (images.org_id != '' AND images.org_id IS NOT NULL))"))
+			Expect(sql).To(ContainSubstring("images.org_id = \"00000000\""))
 		})
 	})
 })

--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -166,8 +166,9 @@ func ListAllImageSets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	countResult := imageSetFilters(r, db.OrgDB(orgID, db.DB, "Image_Sets").Model(&models.ImageSet{})).
-		Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id AND Images.id = (Select Max(id) from Images where Images.image_set_id = Image_Sets.id)`).Count(&count)
+	countResult := imageSetFilters(r, db.OrgDB(orgID, db.DB, "Image_Sets").Debug().Model(&models.ImageSet{})).
+		Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id`, orgID).Distinct("Image_Sets.ID").Count(&count)
+
 	if countResult.Error != nil {
 		s.Log.WithField("error", countResult.Error.Error()).Error("Error counting results for image sets list")
 		countErr := errors.NewInternalServerError()
@@ -179,23 +180,23 @@ func ListAllImageSets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.URL.Query().Get("sort_by") != "-status" && r.URL.Query().Get("sort_by") != "status" {
-		result = imageSetFilters(r, db.OrgDB(orgID, db.DB, "Image_Sets").Debug().Model(&models.ImageSet{})).
+		result = imageSetFilters(r, db.OrgDB(orgID, db.DB, "Image_Sets").Debug().Model(&models.ImageSet{})).Distinct("Image_Sets.*").
 			Limit(pagination.Limit).Offset(pagination.Offset).
 			Preload("Images").
 			Preload("Images.Commit").
 			Preload("Images.Installer").
 			Preload("Images.Commit.Repo").
-			Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id AND Images.id = (Select Max(id) from Images where Images.image_set_id = Image_Sets.id)`).
+			Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id `, orgID).
 			Find(&imageSet)
 	} else {
 		// this code is no longer run, but would be used if sorting by status is re-implemented.
-		result = imageStatusFilters(r, db.OrgDB(orgID, db.DB, "Image_Sets").Debug().Model(&models.ImageSet{})).
+		result = imageStatusFilters(r, db.OrgDB(orgID, db.DB, "Image_Sets").Debug().Model(&models.ImageSet{})).Distinct("Image_Sets.*").
 			Limit(pagination.Limit).Offset(pagination.Offset).
 			Preload("Images", "lower(status) in (?)", strings.ToLower(r.URL.Query().Get("status"))).
 			Preload("Images.Commit").
 			Preload("Images.Installer").
 			Preload("Images.Commit.Repo").
-			Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id AND Images.id = (Select Max(id) from Images where Images.image_set_id = Image_Sets.id)`).
+			Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id`, orgID).
 			Joins("Commit").Joins("Installer").
 			Find(&imageSet)
 


### PR DESCRIPTION
# Description

Removing sub queries and add condition to clean and performance

Fixes # (issue)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [X] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
