### PR TITLE
change the object of deviceImageInfo to deviceImageSetInfo,

### DIFF
--- a/pkg/services/devicegroups.go
+++ b/pkg/services/devicegroups.go
@@ -154,8 +154,12 @@ func (s *DeviceGroupsService) GetDeviceGroups(orgID string, limit int, offset in
 			}
 		}
 		var info []models.DeviceImageInfo
+		imgAdded := make(map[string]bool)
 		for i := range imgInfo {
-			info = append(info, imgInfo[i])
+			if _, ok := imgAdded[imgInfo[i].Name]; !ok {
+				info = append(info, imgInfo[i])
+				imgAdded[imgInfo[i].Name] = true
+			}
 		}
 		group.ValidUpdate, err = s.UpdateService.ValidateUpdateDeviceGroup(orgID, group.ID)
 		if err != nil {


### PR DESCRIPTION
to fix a bug that we see duplicate image in group data
when devices with same image
related to THEEDGE-2485

Signed-off-by: mgold1234 <mgold@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
