### PR TITLE
Remove unused org_id parameter in SQL queries

### DIFF
--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -167,7 +167,7 @@ func ListAllImageSets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	countResult := imageSetFilters(r, db.OrgDB(orgID, db.DB, "Image_Sets").Debug().Model(&models.ImageSet{})).
-		Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id`, orgID).Distinct("image_sets.id").Count(&count)
+		Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id`).Distinct("image_sets.id").Count(&count)
 
 	if countResult.Error != nil {
 		s.Log.WithField("error", countResult.Error.Error()).Error("Error counting results for image sets list")
@@ -196,7 +196,7 @@ func ListAllImageSets(w http.ResponseWriter, r *http.Request) {
 			Preload("Images.Commit").
 			Preload("Images.Installer").
 			Preload("Images.Commit.Repo").
-			Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id`, orgID).
+			Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id`).
 			Joins("Commit").Joins("Installer").
 			Find(&imageSet)
 

--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -186,7 +186,7 @@ func ListAllImageSets(w http.ResponseWriter, r *http.Request) {
 			Preload("Images.Commit").
 			Preload("Images.Installer").
 			Preload("Images.Commit.Repo").
-			Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id `, orgID).
+			Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id`).
 			Find(&imageSet)
 	} else {
 		// this code is no longer run, but would be used if sorting by status is re-implemented.


### PR DESCRIPTION
# Description
Remove unused `org_id` parameter in SQL queries

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
