### PR TITLE
THEEDGE-2523 changed unit-tests to test a range of minutes

### DIFF
--- a/pkg/routes/devices_test.go
+++ b/pkg/routes/devices_test.go
@@ -338,7 +338,8 @@ var _ = Describe("Devices View Filters", func() {
 		Expect(devices[0].CreatedAt.Time.Month()).To(Equal(deviceCreateedAt.Month()))
 		Expect(devices[0].CreatedAt.Time.Day()).To(Equal(deviceCreateedAt.Day()))
 		Expect(devices[0].CreatedAt.Time.Hour()).To(Equal(deviceCreateedAt.Hour()))
-		Expect(devices[0].CreatedAt.Time.Minute()).To(Equal(deviceCreateedAt.Minute()))
+		minutesArray := [3]int{deviceCreateedAt.Minute() - 1, deviceCreateedAt.Minute(), deviceCreateedAt.Minute() + 1}
+		Expect(minutesArray).To(ContainElement(devices[0].CreatedAt.Time.Minute()))
 	})
 })
 


### PR DESCRIPTION
# Description

it seems that unit-test for filtering the devicesview endpoint by "created_at" can potentially fail as a result of time not being consistent when testing minutes, this PR fixes it by comparing to a range of minutes instead of expecting the exact same minute 

Fixes # (issue)
[THEEDGE-2523](https://issues.redhat.com/browse/THEEDGE-2523)
## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
