### PR TITLE
remove support to account on notification event

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -1464,7 +1464,6 @@ func (s *ImageService) SendImageNotification(i *models.Image) (ImageNotification
 		recipients = append(recipients, recipient)
 
 		notify.OrgID = i.OrgID
-		notify.Account = i.Account
 		notify.Context = fmt.Sprintf("{  \"ImageName\" : \"%v\"}", i.Name)
 		notify.Events = events
 		notify.Recipients = recipients

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -502,7 +502,6 @@ func (s *UpdateService) SendDeviceNotification(i *models.UpdateTransaction) (Ima
 		recipients = append(recipients, recipient)
 
 		notify.OrgID = i.OrgID
-		notify.Account = i.Account
 		notify.Context = fmt.Sprintf("{  \"CommitID\" : \"%v\"}", i.CommitID)
 		notify.Events = events
 		notify.Recipients = recipients


### PR DESCRIPTION
# Description

As part of org-id migration, I'm removing the support to account on notification event

Fixes # ([issue](https://issues.redhat.com/browse/THEEDGE-2500))

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [X] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
