### PR TITLE
fix featureflag config and add logging

### DIFF
--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Unleash/unleash-client-go/v3"
 	unleashCTX "github.com/Unleash/unleash-client-go/v3/context"
 	"github.com/redhatinsights/edge-api/config"
+	log "github.com/sirupsen/logrus"
 )
 
 //FeatureCustomRepos is the const of the custom repo feature flag
@@ -63,8 +64,14 @@ func (ff *Flag) IsEnabled() bool {
 
 	// if either is enabled, make it so
 	if ffServiceEnabled || ffEnvEnabled {
+		log.WithFields(log.Fields{"feature": ff.Name,
+			"unleash": ffServiceEnabled, "environment": ffEnvEnabled,
+			"status": "enabled"}).Debug("Feature flag status")
 		return true
 	}
 
+	log.WithFields(log.Fields{"feature": ff.Name,
+		"unleash": ffServiceEnabled, "environment": ffEnvEnabled,
+		"status": "enabled"}).Debug("Feature flag status")
 	return false
 }


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Feature flag config items are read after edge config is set.
This switches that order.
Also added some logging for the feature flag server/env checks

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
