### PR TITLE
remove image-build consumer from Edge API consumers

### DIFF
--- a/main.go
+++ b/main.go
@@ -181,7 +181,6 @@ func main() {
 	consumers := []services.ConsumerService{
 		services.NewKafkaConsumerService(cfg.KafkaConfig, "platform.playbook-dispatcher.runs"),
 		services.NewKafkaConsumerService(cfg.KafkaConfig, "platform.inventory.events"),
-		//		services.NewKafkaConsumerService(cfg.KafkaConfig, "platform.edge.fleetmgmt.image-build"),
 	}
 	webServer := serveWeb(cfg, consumers)
 	metricsServer := serveMetrics(cfg.MetricsPort)

--- a/pkg/services/consumers_test.go
+++ b/pkg/services/consumers_test.go
@@ -12,8 +12,7 @@ var _ = Describe("ConsumerService basic functions", func() {
 	Describe("creation of the service", func() {
 		port := 9092
 		config := &v1.KafkaConfig{Brokers: []v1.BrokerConfig{{Hostname: "localhost", Port: &port}}}
-		topics := []string{"platform.playbook-dispatcher.runs",
-			"platform.inventory.events", "platform.edge.fleetmgmt.image-build"}
+		topics := []string{"platform.playbook-dispatcher.runs", "platform.inventory.events"}
 		nonRealTopic := faker.DomainName()
 		Context("returns a correct instance", func() {
 			for _, topic := range topics {


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Removing unused consumer from Edge API.
Will replace with new Consumer router code when needed.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
