### PR TITLE
Since sonarqube supports java >= 11, moving to 17

### DIFF
--- a/sonarqube.sh
+++ b/sonarqube.sh
@@ -58,7 +58,7 @@ export PATH="${PWD}/sonarqube/extract/${SONAR_SCANNER_NAME}/bin:${PATH}"
 
 COMMIT_SHORT=$(git rev-parse --short=7 HEAD)
 
-OPENJDK_CONTAINER_IMAGE='registry.redhat.io/ubi8/openjdk-11-runtime:latest'
+OPENJDK_CONTAINER_IMAGE='registry.redhat.io/ubi8/openjdk-17-runtime:latest'
 
 podman pull "${OPENJDK_CONTAINER_IMAGE}"
 


### PR DESCRIPTION
# Description

Change Sonarqube to use latest java, not just 11

Fixes # THEEDGE-2473

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
