### PR TITLE
device-update: remove account from DispatcherPayload.

### DIFF
--- a/pkg/clients/playbookdispatcher/client.go
+++ b/pkg/clients/playbookdispatcher/client.go
@@ -36,7 +36,6 @@ func InitClient(ctx context.Context, log *log.Entry) *Client {
 type DispatcherPayload struct {
 	Recipient   string `json:"recipient"`
 	PlaybookURL string `json:"url"`
-	Account     string `json:"account"`
 	OrgID       string `json:"org_id"`
 }
 

--- a/pkg/services/updates_test.go
+++ b/pkg/services/updates_test.go
@@ -198,7 +198,6 @@ var _ = Describe("UpdateService Basic functions", func() {
 					mockPlaybookClient.EXPECT().ExecuteDispatcher(playbookdispatcher.DispatcherPayload{
 						Recipient:   device.RHCClientID,
 						PlaybookURL: playbookURL,
-						Account:     update.Account,
 						OrgID:       update.OrgID,
 					}).Return([]playbookdispatcher.Response{
 						{
@@ -244,7 +243,6 @@ var _ = Describe("UpdateService Basic functions", func() {
 					mockPlaybookClient.EXPECT().ExecuteDispatcher(playbookdispatcher.DispatcherPayload{
 						Recipient:   device.RHCClientID,
 						PlaybookURL: playbookURL,
-						Account:     update.Account,
 						OrgID:       update.OrgID,
 					}).Return([]playbookdispatcher.Response{
 						{
@@ -289,7 +287,6 @@ var _ = Describe("UpdateService Basic functions", func() {
 					mockPlaybookClient.EXPECT().ExecuteDispatcher(playbookdispatcher.DispatcherPayload{
 						Recipient:   device.RHCClientID,
 						PlaybookURL: playbookURL,
-						Account:     update.Account,
 						OrgID:       update.OrgID,
 					}).Return(nil, errors.New("error on playbook dispatcher client"))
 


### PR DESCRIPTION
Encountering errors when calling palybook dispatcher with account in the payload
```text
{\"message\":\"Request body has an error: doesn't match the schema: Error at \\\"/0/account\\\": Minimum string length is 1\"}\n","file":"updates.go:201","func":"CreateUpdate","level":"error","msg":"Error on playbook-dispatcher
```

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
