### PR TITLE
fix tx.Error panic in checksum func

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -883,7 +883,7 @@ func (s *ImageService) calculateChecksum(isoPath string, image *models.Image) er
 	s.log.WithField("checksum", image.Installer.Checksum).Info("Checksum calculated")
 	tx := db.DB.Save(&image.Installer)
 	if tx.Error != nil {
-		s.log.WithField("error", err.Error()).Error("Error saving installer")
+		s.log.WithField("error", tx.Error.Error()).Error("Error saving installer")
 		return tx.Error
 	}
 


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Fix error message panic in Image checksum code with tx.Error.Error()

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
