### PR TITLE
add featureflags for device sync

### DIFF
--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -21,6 +21,8 @@ type Flag struct {
 	EnvVar string
 }
 
+// IMAGE FEATURE FLAGS
+
 // ImageCreateEDA is the feature flag for routes.CreateImage() EDA code
 var ImageCreateEDA = &Flag{Name: "edge-management.image_create", EnvVar: "FEATURE_IMAGECREATE"}
 
@@ -38,6 +40,20 @@ var ImageCreateKickstartEDA = &Flag{Name: "", EnvVar: "FEATURE_IMAGECREATE_KICKS
 
 // ImageCreateRepoEDA is the feature flag for routes.CreateRepo() EDA code
 var ImageCreateRepoEDA = &Flag{Name: "", EnvVar: "FEATURE_IMAGECREATE_REPO"}
+
+// DEVICE FEATURE FLAGS
+
+// DeviceSync is the feature flag for routes.CreateImageUpdate() EDA code
+var DeviceSync = &Flag{Name: "edge-management.device_sync", EnvVar: "DEVICE_SYNC"}
+
+// DeviceSyncCreate is the feature flag for routes.CreateImageUpdate() EDA code
+var DeviceSyncCreate = &Flag{Name: "edge-management.device_sync_create", EnvVar: "DEVICE_SYNC_CREATE"}
+
+// DeviceSyncDelete is the feature flag for routes.CreateImageUpdate() EDA code
+var DeviceSyncDelete = &Flag{Name: "edge-management.device_sync_delete", EnvVar: "DEVICE_SYNC_DELETE"}
+
+// (ADD FEATURE FLAGS ABOVE)
+// FEATURE FLAG CHECK CODE
 
 // CheckFeature checks to see if a given feature is available
 func CheckFeature(feature string) bool {


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description
Adding feature flags for device sync
edge-management.device_sync to disable sync feature
edge-management.device_sync_create to only disable create call
edge-management.device_sync_delete to only disable delete call
All feature flags are available in stage and prod

Fixes # THEEDGE-2519

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
