### PR TITLE
Fix regular expressions in mergify config

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -122,7 +122,7 @@ pull_request_rules:
   # Detect when PR includes a bug fix and add label
   - name: add bug fix label
     conditions:
-      - body~=(?m)^\[X\] Bug fix (non-breaking change which fixes an issue)
+      - body~=(?m)^- \[[xX]\] Bug fix \(non-breaking change which fixes an issue\)
     actions:
       label:
         add:
@@ -131,7 +131,7 @@ pull_request_rules:
   # Detect when PR includes new feature and add label
   - name: add new feature label
     conditions:
-      - body~=(?m)^\[X\] New feature (non-breaking change which adds functionality)
+      - body~=(?m)^- \[[xX]\] New feature \(non-breaking change which adds functionality\)
     actions:
       label:
         add:
@@ -140,7 +140,7 @@ pull_request_rules:
   # Detect when PR includes documentation updates and add label
   - name: add documentation label
     conditions:
-      - body~=(?m)^\[X\] Documentation update
+      - body~=(?m)^- \[[xX]\] Documentation update
     actions:
       label:
         add:
@@ -149,16 +149,17 @@ pull_request_rules:
   # Detect when PR includes tests update and add label
   - name: add test update label
     conditions:
-      - body~=(?m)^\[X\] Tests update
+      - body~=(?m)^- \[[xX]\] Tests update
     actions:
       label:
         add:
           - test update
+
   #
   # Detect when PR no longer includes bug fix and remove label
   - name: remove bug fix label
     conditions:
-      - body~=(?m)^\[ \] Bug fix (non-breaking change which fixes an issue)
+      - body~=(?m)^- \[ \] Bug fix \(non-breaking change which fixes an issue\)
     actions:
       label:
         remove:
@@ -167,7 +168,7 @@ pull_request_rules:
   # Detect when PR no longer includes new feature and remove label
   - name: remove new feature label
     conditions:
-      - body~=(?m)^\[ \] New feature (non-breaking change which adds functionality)
+      - body~=(?m)^- \[ \] New feature \(non-breaking change which adds functionality\)
     actions:
       label:
         remove:
@@ -176,7 +177,7 @@ pull_request_rules:
   # Detect when PR no longer includes documentation updates and remove label
   - name: remove documentation label
     conditions:
-      - body~=(?m)^\[ \] Documentation update
+      - body~=(?m)^- \[ \] Documentation update
     actions:
       label:
         remove:
@@ -185,7 +186,7 @@ pull_request_rules:
   # Detect when PR no longer includes tests update and remove label
   - name: remove test update label
     conditions:
-      - body~=(?m)^\[ \] Tests update
+      - body~=(?m)^- \[ \] Tests update
     actions:
       label:
         remove:
@@ -194,11 +195,11 @@ pull_request_rules:
   # Detect when PR is ready and add label
   - name: add ready label
     conditions:
-      - body~=(?m)^\[X\] I have commented my code, particularly in hard-to-understand areas
-      - body~=(?m)^\[X\] I have made corresponding changes to the documentation
-      - body~=(?m)^\[X\] I have added tests that prove my fix is effective or that my feature works
-      - body~=(?m)^\[X\] New and existing unit tests pass locally with my changes
-      - body~=(?m)^\[X\]  I run make pre-commit to check fmt/vet/lint/test-no-fdo
+      - body~=(?m)^- \[[xX]\] I have commented my code, particularly in hard-to-understand areas
+      - body~=(?m)^- \[[xX]\] I have made corresponding changes to the documentation
+      - body~=(?m)^- \[[xX]\] I have added tests that prove my fix is effective or that my feature works
+      - body~=(?m)^- \[[xX]\] New and existing unit tests pass locally with my changes
+      - body~=(?m)^- \[[xX]\] I run `make pre-commit` to check fmt\/vet\/lint\/test-no-fdo
     actions:
       label:
         add:


### PR DESCRIPTION
# Description

This PR fixes some issues with the mergify config. The regular expressions used for matching the `body` attribute were incorrect:
 1. Both `x` and `X` can be used to check a checkbox in the description markdown.
 2. The initial hyphen and space for the checklist entries were not included in the regular expressions.
 3. Parentheses and forward slashes in the checklist entries were not properly escaped.

With this fix, the corresponding rules will now work as expected, and the `bug fix`, `new feature`, `documentation`, `test update`. and `ready` labels will be added to or removed from PRs correctly.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
