### PR TITLE
Fix mergify rule for removing 'waiting for review' label

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -112,7 +112,7 @@ pull_request_rules:
   # Detect when PR received review and remove label
   - name: remove waiting for review label if not needed
     conditions:
-      - "#commented-reviews-by>=1"
+      - "#commented-reviews-by>=2"
       - -draft
     actions:
       label:


### PR DESCRIPTION
# Description

The current rules for adding and removing the `waiting for review` label overlap, causing continuous adding and removing of the label. This PR fixes the mergify config.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
