### PR TITLE
update dev config file reader to workaround upstream issue

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -91,6 +92,11 @@ type loggingConfig struct {
 }
 
 var config *EdgeConfig
+
+// DevConfigFile is a wrapper for local dev kafka config
+type DevConfigFile struct {
+	Kafka clowder.KafkaConfig
+}
 
 // Init configuration for service
 func Init() {
@@ -271,21 +277,19 @@ func Init() {
 	// this is different than Local due to code in services/files.go
 	if config.Dev {
 		configFile := os.Getenv("EDGEMGMT_CONFIG")
-		options.SetConfigFile(configFile)
 
-		if configfileErr := options.MergeInConfig(); configfileErr != nil {
-			fmt.Println("Error reading config file")
-			fmt.Println(configfileErr.Error())
-		}
-		kafkaJSON, err := json.Marshal(options.Get("kafka"))
+		// SOMETHING CHANGED with upstream SetConfigFile or Unmarshal that caused Unmarshal
+		// to freak out on mixedCase being translated to lowercase by SetConfigFile
+		devConfigFile, err := os.ReadFile(configFile)
 		if err != nil {
-			fmt.Println("KafkaConfig marshal error")
+			log.WithField("error", err.Error()).Error("Error reading local dev config file")
 		}
-		kafkaConfig := clowder.KafkaConfig{}
-		if err := json.Unmarshal(kafkaJSON, &kafkaConfig); err != nil {
-			fmt.Println("KafkaConfig unmarshal error")
+		devConfig := DevConfigFile{}
+		if err := json.Unmarshal(devConfigFile, &devConfig); err != nil {
+			log.WithField("error", err.Error()).Error("Dev config unmarshal error")
 		}
-		config.KafkaConfig = &kafkaConfig
+
+		config.KafkaConfig = &devConfig.Kafka
 	}
 
 	if config.KafkaConfig != nil {

--- a/podman/container-compose-api.yml
+++ b/podman/container-compose-api.yml
@@ -4,6 +4,7 @@ secrets:
     file: $PWD/podman/env/edgemgmt_config.json
 services:
     edge-api-service:
+      container_name: edge-api-service
       image: localhost/edge-api:localdev
       restart: always
       privileged: true
@@ -11,12 +12,10 @@ services:
         - 3000:3000
       env_file:
         - env/edge-api.env
-#      depends-on: postgresql
       volumes:
         - $PWD:/opt/app-root/src:z
         - $HOME/go:/go
-#      working_dir: /opt/app-root
-#      working_dir: /opt/app-root/src
+
       command: ["go", "run", "main.go"]
       secrets:
         - source: edgemgmt_config

--- a/podman/container-compose-dependencies.yml
+++ b/podman/container-compose-dependencies.yml
@@ -1,0 +1,45 @@
+version: '2'
+services:
+  postgresql:
+  container_name: postgresql
+    image: registry.redhat.io/rhel8/postgresql-10:1-173.1647451846
+    restart: unless-stopped
+    ports:
+      - 5432:5432
+    env_file:
+      - env/edge-api.env
+    volumes:
+      - ~/dev/postgresql:/var/lib/pgsql:Z
+
+  kafka:
+    container_name: kafka
+    image: quay.io/strimzi/kafka:latest-kafka-2.8.1-amd64
+    restart: unless-stopped
+    command:
+      [
+        "sh",
+        "-c",
+        "export CLUSTER_ID=$$(bin/kafka-storage.sh random-uuid) && bin/kafka-storage.sh format -t $$CLUSTER_ID --ignore-formatted -c config/kraft/server.properties && bin/kafka-server-start.sh config/kraft/server.properties --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override listener.security.protocol.map=$${KAFKA_LISTENER_SECURITY_PROTOCOL_MAP} --override listeners=$${KAFKA_LISTENERS}",
+      ]
+    ports:
+      - "9092:9092"
+    environment:
+      LOG_DIR: "/tmp/logs"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://:29092,PLAINTEXT_HOST://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://kafka:9092
+    volumes:
+       - ~/dev/kafkadata/kraft-combined-logs:/tmp/kraft-combined-logs:Z
+       - ~/dev/kafkadata/logs:/tmp/logs:Z
+
+  kafka-ui:
+    container_name: kafka-ui
+    image: docker.io/provectuslabs/kafka-ui
+    ports:
+      - "8090:8080"
+    restart: unless-stopped
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=local
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:9092
+    depends_on:
+      - "kafka"

--- a/podman/container-compose-services.yml
+++ b/podman/container-compose-services.yml
@@ -12,16 +12,17 @@ version: '2'
 #
 secrets:
   edgemgmt_config:
-    file: $DEVDIR/config/files/edgemgmt_config.json
+    file: $PWD/podman/env/edgemgmt_config.json
 services:
     edge-api-images-build:
+      container_name: edge-api-images-build
       image: localhost/edge-api:localdev
       restart: unless-stopped
       privileged: true
       env_file:
         - env/edge-api.env
       volumes:
-        - $DEVDIR:/opt/app-root/src:z
+        - $PWD:/opt/app-root/src:z
         - $HOME/go:/go
       command: go run /opt/app-root/src/pkg/services/images_build/main.go
       secrets:
@@ -40,7 +41,7 @@ services:
         - env/edge-api.env
 #      depends-on: postgresql
       volumes:
-        - $DEVDIR:/opt/app-root/src:z
+        - $PWD:/opt/app-root/src:z
         - $HOME/go:/go
       #working_dir: /opt/app-root/src
       command: go run /opt/app-root/src/cmd/kafka/main.go

--- a/podman/container-compose-ui.yml
+++ b/podman/container-compose-ui.yml
@@ -1,6 +1,7 @@
 version: '2'
 services:
     edge-ui:
+        container_name: edge-ui
         image: localhost/edge-frontend:podmandevx
 #        image: quay.io/loadtheaccumulator/edge-frontend:podmandev
         restart: unless-stopped

--- a/podman/env/edgemgmt_config.json
+++ b/podman/env/edgemgmt_config.json
@@ -3,15 +3,14 @@
         "brokers": [
             {
                 "hostname": "kafka",
-                "port": 9092
+                "port": 9092,
+                "requestedName": "platform.edge.fleetmgmt.image-build"
             }
         ],
         "topics": [
             {
                 "requestedName": "platform.edge.fleetmgmt.image-build",
-                "name": "platform.edge.fleetmgmt.image-build",
-                "consumerGroupName": "edgemgmt-image-build"
-            }
+                "name": "platform.edge.fleetmgmt.image-build"            }
         ]
     }
 }


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description
Workaround for an upstream viper/unmarshal case sensitivity issue when reading a dev config file for local work.
Edits to example podman compose files.
Added a dependency compose file.
Added kafka web UI app for topic and message management in dev
NOTE: working toward consolidating them into a single experience.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
