### PR TITLE
rearranged commit validation for devices update

### DIFF
--- a/pkg/routes/updates_test.go
+++ b/pkg/routes/updates_test.go
@@ -479,6 +479,28 @@ var _ = Describe("Update routes", func() {
 				Expect(string(respBody)).To(ContainSubstring("Commit %d does not belong to the same image-set as devices", updateCommit.ID))
 			})
 		})
+		When("CommitID provided by user does not exist", func() {
+			It("should not allow to update with commitID that dose not exist", func() {
+				non_existant_commit := uint(99999999)
+				updateData, err := json.Marshal(models.DevicesUpdate{CommitID: non_existant_commit, DevicesUUID: []string{device3.UUID}})
+				Expect(err).To(BeNil())
+
+				req, err := http.NewRequest(http.MethodPost, "/", bytes.NewBuffer(updateData))
+				Expect(err).To(BeNil())
+
+				ctx := dependencies.ContextWithServices(req.Context(), edgeAPIServices)
+				req = req.WithContext(ctx)
+
+				responseRecorder := httptest.NewRecorder()
+
+				handler := http.HandlerFunc(AddUpdate)
+				handler.ServeHTTP(responseRecorder, req)
+
+				respBody, err := ioutil.ReadAll(responseRecorder.Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(respBody)).To(ContainSubstring("No commit found for CommitID %d", non_existant_commit))
+			})
+		})
 	})
 
 	Context("get all updates with filter parameters", func() {


### PR DESCRIPTION
# Description

the validation for commit provided by the user checked that the commit matches the image-set before it checked that it actually exists, this PR changes it so that the existence of the commit is validated first

also added unit-test for the case where the commit-id provided dose not exist  

Fixes # (issue)
[THEEDGE-2623](https://issues.redhat.com/browse/THEEDGE-2623)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
