### PR TITLE
Make golangci-lint and golangci-lint-no-fdo targets, changed pre-comm…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -85,7 +85,7 @@ type playbookDispatcherConfig struct {
 	Status string `json:"status,omitempty"`
 }
 
-//
+// loggingConfig
 type loggingConfig struct {
 	AccessKeyID     string `json:"-"`
 	SecretAccessKey string `json:"-"`

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 // Package main Edge API
 //
-//  An API server for fleet edge management capabilities.
+// An API server for fleet edge management capabilities.
 // FIXME: golangci-lint
 // nolint:errcheck,revive,unused
 package main

--- a/pkg/models/thirdpartyrepo.go
+++ b/pkg/models/thirdpartyrepo.go
@@ -16,7 +16,6 @@ ThirdPartyRepo is a record of Third Party Repository or we can call it as Custom
 
 	Here, URL refers to the url of the third party repository, OrgID refers to the OrgID attached to the third party
 	repository.
-
 */
 type ThirdPartyRepo struct {
 	Model

--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -11,7 +11,6 @@ import (
 
 // UpdateTransaction represents the combination of an OSTree commit and a set of Inventory
 //	hosts that need to have the commit deployed to them
-//
 //	This will ultimately kick off a transaction where the old version(s) of
 //	OSTree commit that are currently deployed onto those devices are combined
 //	with the new commit into a new OSTree repo, static deltas are computed, and

--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -10,12 +10,12 @@ import (
 )
 
 // UpdateTransaction represents the combination of an OSTree commit and a set of Inventory
-//	hosts that need to have the commit deployed to them
-//	This will ultimately kick off a transaction where the old version(s) of
-//	OSTree commit that are currently deployed onto those devices are combined
-//	with the new commit into a new OSTree repo, static deltas are computed, and
-//	then the result is stored in a way that can be served(proxied) by a
-//	Server (pkg/repo/server.go).
+// hosts that need to have the commit deployed to them
+// This will ultimately kick off a transaction where the old version(s) of
+// OSTree commit that are currently deployed onto those devices are combined
+// with the new commit into a new OSTree repo, static deltas are computed, and
+// then the result is stored in a way that can be served(proxied) by a
+// Server (pkg/repo/server.go).
 type UpdateTransaction struct {
 	Model
 	Commit          *Commit          `json:"Commit"`

--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -149,7 +149,7 @@ type CreateImageRequest struct {
 }
 
 // GetImageWithIdentity pre-populates the image with Account, OrgID, requestID and also returns an identity header
-//	This is used by every image endpoint, so it reduces copy/paste risk
+// This is used by every image endpoint, so it reduces copy/paste risk
 func GetImageWithIdentity(w http.ResponseWriter, r *http.Request) (*models.Image, identity.XRHID, error) {
 	ctxServices := dependencies.ServicesFromContext(r.Context())
 

--- a/pkg/services/imagesets.go
+++ b/pkg/services/imagesets.go
@@ -151,7 +151,7 @@ func (s *ImageSetsService) GetImageSetsView(limit int, offset int, tx *gorm.DB) 
 	// get the latest installer iso url for each image-set
 	// get the image-set ids
 	var imageSetIDS []uint
-	//get image status and avoid slow query
+	// get image status and avoid slow query
 	var imageIDS []uint
 	for _, imageSetRow := range imageSetsRows {
 		imageSetIDS = append(imageSetIDS, imageSetRow.ID)
@@ -160,7 +160,7 @@ func (s *ImageSetsService) GetImageSetsView(limit int, offset int, tx *gorm.DB) 
 
 	var imgs []models.Image
 	db.DB.Debug().Where("ID in ?", imageIDS).Find(&imgs)
-	//build set of image status
+	// build set of image status
 	imageSetToStatus := make(map[uint]string)
 	for _, image := range imgs {
 		if _, ok := imageSetToStatus[image.ID]; !ok {

--- a/pkg/services/repobuilder.go
+++ b/pkg/services/repobuilder.go
@@ -390,8 +390,8 @@ func (rb *RepoBuilder) ExtractVersionRepo(c *models.Commit, tarFileName string, 
 }
 
 // RepoPullLocalStaticDeltas pull local repo into the new update repo and compute static deltas
-//  uprepo should be where the update commit lives, u is the update commit
-//  oldrepo should be where the old commit lives, o is the commit to be merged
+// uprepo should be where the update commit lives, u is the update commit
+// oldrepo should be where the old commit lives, o is the commit to be merged
 func (rb *RepoBuilder) repoPullLocalStaticDeltas(u *models.Commit, o *models.Commit, uprepo string, oldrepo string) error {
 	err := os.Chdir(uprepo)
 	if err != nil {


### PR DESCRIPTION
…it to use golangci-lint-no-fdo

# Description

1) Working Makefile "golangci-lint" target
2) Working Makefile "golangci-lint-no-fdo" target
3) Changed Makefile "pre-commit' target to use "golangci-lint-no-fdo" instead of fmt/vet

N.B. There were some minor formatting errors caught by Github Action Lint, those are corrected in this PR

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
