### PR TITLE
Remove fmt and vet from github action (now done in golangci-lint)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,22 +26,11 @@ jobs:
         run: |
           [ $(go get -a | wc -l) -eq 0 ]
 
-      - name: fmt
-        run: |
-          [ $(go fmt ./... | wc -l) -eq 0 ]
-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
           args: --max-same-issues 20 --timeout 5m0s
-
-      - name: Vet
-        uses: addnab/docker-run-action@v3
-        with:
-          image: quay.io/fleet-management/libfdo-data:latest
-          options: -v ${{ github.workspace }}:/edge-api
-          run: make -C edge-api vet
 
       - name: Set up python3
         uses: actions/setup-python@v2


### PR DESCRIPTION
# Description

Since golangci-lint includes gofmt and govet, remove the separate steps.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [X] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
