### PR TITLE
Remove Travis check from mergify since lint is done in Github action

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -19,7 +19,7 @@ pull_request_rules:
       - author~=^dependabot(|-preview)\[bot\]$
       - "#approved-reviews-by>=2"
       - check-success=Lint
-      - check-success=Travis CI - Pull Request
+      # - check-success=Travis CI - Pull Request
     actions:
       queue:
         name: edge-api
@@ -32,14 +32,14 @@ pull_request_rules:
       - and:
           - base=main
           - "#changes-requested-reviews-by=0"
-          - "#approved-reviews-by>=1"
+          - "#approved-reviews-by>=2"
           - label!=work in progress
           - label!=do not merge
           - updated-at<1 days ago
           - or:
               - -check-success=ci.int.devshift.net PR build
               - -check-success=Lint
-              - -check-success=Travis CI - Pull Request
+              # - -check-success=Travis CI - Pull Request
     actions:
       comment:
         message: "This pull request needs all pr-checks to run successfully. Could you fix it @{{author}}? 🙏"
@@ -54,7 +54,7 @@ pull_request_rules:
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       - check-success=Lint
-      - check-success=Travis CI - Pull Request
+      # - check-success=Travis CI - Pull Request
       - check-success=ci.int.devshift.net PR build
       - label!=work in progress
       - label!=do not merge


### PR DESCRIPTION
# Description

Comment out Travis from Mergify rules
Fixed typo where PR check rerun didn't require 2 approved-reviews

Fixes # (issue)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [X] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
