### PR TITLE
For openapi-spec-validator: remove from travis and update github actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,9 +33,9 @@ jobs:
           args: --max-same-issues 20 --timeout 5m0s
 
       - name: Set up python3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install openapi-spec-validator
         run: pip install openapi-spec-validator

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,6 @@ jobs:
     # - name: "Golang Security Checker"
     #   script:
     #   - docker run --rm -v $(pwd):/edge-api -w /edge-api ${LIBFDO_IMAGE} /bin/sh -c "gosec ./..."
-    # TODO: We can get this back as soon as we add python on the testing container
-    # - name: "Validate spec-file"
-    #   language: python
-    #   python: 3.9
-    #   install: pip install openapi-spec-validator
-    #   script: python3 -m openapi_spec_validator ./cmd/spec/openapi.json
     # - name: "Coverage Testing"
     #   script:
     #     - docker run --rm -v $(pwd):/edge-api ${LIBFDO_IMAGE}


### PR DESCRIPTION
# Description

For openapi-spec-validator: Update the Github action and remove the commented out section from Travis

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [X] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
