### PR TITLE
Remove gosec/staticheck/gofmt comments from Travis since they are don…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,20 +41,10 @@ jobs:
     #     - docker build -t ${EDGE_API_IMAGE} -f ./Dockerfile .
     #     - docker login quay.io -u ${FLEETER_BOT:-${FLEETER_BOT_PR}} -p ${FLEETER_PASS:-${FLEETER_PASS_PR}} >/dev/null 2>&1
     #     - docker push ${EDGE_API_IMAGE}
-    # - name: "Static Code Analysis"
-    #   script:
-    #     - docker run --rm -w /edge-api -v $(pwd):/edge-api ${LIBFDO_IMAGE} /bin/sh -c "staticcheck -go 1.15 -f stylish ./..."
-    # - name: "Golang Security Checker"
-    #   script:
-    #   - docker run --rm -v $(pwd):/edge-api -w /edge-api ${LIBFDO_IMAGE} /bin/sh -c "gosec ./..."
     # - name: "Coverage Testing"
     #   script:
     #     - docker run --rm -v $(pwd):/edge-api ${LIBFDO_IMAGE}
     #     - bash <(curl -s https://codecov.io/bash)
-    # - name: "Code Formatting"
-    #   script:
-    #     - go fmt ./...
-    #     - "[ $(go fmt ./... | wc -l) -eq 0 ]"
     - name: "Code Linting"
       script:
         - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.49.0


### PR DESCRIPTION
…e in Github actions golangci-lint

# Description

Remove gosec, gofmt, and staticcheck comments from Tavis since they are all done in Github actions golangci-lint

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [X] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
