### PR TITLE
scrub sensitive data from configs

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -158,10 +157,9 @@ func main() {
 
 	initDependencies()
 	cfg := config.Get()
-	var configValues map[string]interface{}
-	cfgBytes, _ := json.Marshal(cfg)
-	_ = json.Unmarshal(cfgBytes, &configValues)
-	log.WithFields(configValues).Info("Configuration Values")
+
+	newLogData := config.Scrub(*cfg)
+	log.WithFields(newLogData).Info("Configuration values")
 
 	if featureFlagsConfigPresent() {
 		err := unleash.Initialize(

--- a/pkg/common/kafka/topics.go
+++ b/pkg/common/kafka/topics.go
@@ -31,8 +31,8 @@ func GetTopic(requested string) (string, error) {
 	cfg := config.Get()
 	if cfg.KafkaConfig != nil {
 		topics := cfg.KafkaConfig.Topics
+		log.WithField("requestedName", requested).Debug("looking up actual topic")
 		for _, topic := range topics {
-			log.WithField("requestedName", requested).Debug("looking up actual topic")
 			if topic.RequestedName == requested {
 				log.WithFields(log.Fields{"requestedName": requested, "Name": topic.Name}).Debug("Found the actual topic name")
 


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Add a function to scrub sensitive fields from the configs.
Also moved a log line outside a loop to fix redundant messages.

NOTE: this gets the service startup log message back to where it was, but with fields scrubbed.
The json "-" method is an option, but we might not want all structs to lose the json definition, and we can extend this to walk the struct and log all items.
Recommend logging individual lines instead of one long line to avoid truncation by the logging facilities.
This does not scrub structs defined upstream.

Fixes # (issue) THEEDGE-2408

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
