### PR TITLE
fix condition on delete devices on sync process

### DIFF
--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -985,7 +985,7 @@ func (s *DeviceService) syncDevicesWithInventory(orgID string) {
 
 	var insightsCount int64
 	var edgeCount int64
-	for int64(offset) < total {
+	for int64(offset) <= total {
 		s.log.WithFields(log.Fields{"offset": int64(offset), "total": total}).Debug("Comparing offset to total")
 		if res := db.Org(orgID, "").Debug().Limit(limit).Offset(offset).Find(&edgeDevices); res.Error != nil {
 			s.log.WithField("error", res.Error.Error()).Error("Error getting devices in device sync")
@@ -1027,7 +1027,7 @@ func (s *DeviceService) syncDevicesWithInventory(orgID string) {
 	// Delete invalid devices
 	s.log.WithFields(log.Fields{"edge_count": edgeCount, "insights_count": insightsCount, "devicesToBeDeleted size": len(devicesToBeDeleted)}).Debug("Comparing inventory counts before device deletion")
 
-	if edgeCount > insightsCount {
+	if len(devicesToBeDeleted) > 0 {
 		s.log.WithFields(log.Fields{"edge_count": edgeCount, "insights_count": insightsCount}).Debug("Inventory counts do not match. Going through delete list")
 
 		if feature.DeviceSyncDelete.IsEnabled() {
@@ -1092,6 +1092,7 @@ func (s *DeviceService) syncInventoryWithDevices(orgID string) {
 		for _, inDevice := range inventoryDevices.Result {
 			inveDeviceIds = append(inveDeviceIds, inDevice.ID)
 		}
+
 		var dbDevices []models.Device
 		if res := db.Org(orgID, "").Debug().Where("UUID IN ?", inveDeviceIds).Find(&dbDevices); res.Error != nil {
 			s.log.WithField("error", res.Error.Error()).Error("Error getting devices in device sync")


### PR DESCRIPTION
# Description

The condition was conidering just the edge and insights count and we were feeling an array never validated, changing it to delete if devicesToBeDeleted was filled up

Fixes # (THEEDGE-2643)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
