### PR TITLE
update: FIX update change refs variable.

### DIFF
--- a/pkg/services/files/utils.go
+++ b/pkg/services/files/utils.go
@@ -21,14 +21,14 @@ func sanitizePath(destination string, filePath string) (destpath string, err err
 	return
 }
 
-//objectIsWithinMemoryLimit returns a bool result from compare an object with Cloudwatch Maximum Log Message Size
+// objectIsWithinMemoryLimit returns a bool result from compare an object with Cloudwatch Maximum Log Message Size
 func objectIsWithinMemoryLimit(object interface{}) bool {
 	objReflection := reflect.ValueOf(object)
 	len, _ := Sizeof(objReflection)
 	return len < CloudwatchMaximumLogMessageSize
 }
 
-//Sizeof receive a reflect value and returns the length and capacity of an object in memory using in Kb
+// Sizeof receive a reflect value and returns the length and capacity of an object in memory using in Kb
 func Sizeof(rv reflect.Value) (int, int) {
 	rt := rv.Type()
 	if rt.Kind() == reflect.Slice {

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -785,7 +785,7 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 					if uError != nil {
 						s.log.WithField("error", err.Error()).Error("Error returning current image ostree checksum")
 					}
-					if currentImage.Distribution != updatedImage.Distribution {
+					if config.DistributionsRefs[currentImage.Distribution] != config.DistributionsRefs[updatedImage.Distribution] {
 						update.ChangesRefs = true
 					}
 				}


### PR DESCRIPTION
The current problem is that when a dist 8.5 and we update to 8.6 the change refs is True and the playbook will fail as the ref has not changed.

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
