### PR TITLE
Add check that no unresolved conversation threads in PR before merging

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -24,6 +24,17 @@ pull_request_rules:
         message: New commit(s) added, removing existing approval(s)
         when: synchronize
   #
+  # Require all conversations to be resolved
+  - name: Check for unresolved conversations before merging
+    conditions:
+      - "#review-threads-unresolved=0"
+    actions:
+      comment:
+        message: "This pull request needs all conversation threads to be resolved. Could you fix it @{{author}}? 🙏"
+      label:
+        add:
+          - question
+  #
   # Dependabot PR merge rule
   - name: Automatic merge for Dependabot pull requests
     conditions:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,6 +8,8 @@ queue_rules:
     conditions:
       - base=main
       - "#approved-reviews-by>=2"
+      - "#changes-requested-reviews-by=0"
+      - "#review-threads-unresolved=0"
 #
 # Pull request rules https://docs.mergify.com/configuration/#pull-request-rules
 # N.B. Evaluated in order defined
@@ -27,7 +29,7 @@ pull_request_rules:
   # Require all conversations to be resolved
   - name: Check for unresolved conversations before merging
     conditions:
-      - "#review-threads-unresolved=0"
+      - "#review-threads-unresolved>0"
     actions:
       comment:
         message: "This pull request needs all conversation threads to be resolved. Could you fix it @{{author}}? 🙏"
@@ -35,11 +37,21 @@ pull_request_rules:
         add:
           - question
   #
+  # If all conversations to be resolved, remove question label
+  - name: Check for unresolved conversations before merging
+    conditions:
+      - "#review-threads-unresolved=0"
+    actions:
+      label:
+        remove:
+          - question
+  #
   # Dependabot PR merge rule
   - name: Automatic merge for Dependabot pull requests
     conditions:
       - author~=^dependabot(|-preview)\[bot\]$
       - "#approved-reviews-by>=2"
+      - "#review-threads-unresolved=0"
       - check-success=Lint
       # - check-success=Travis CI - Pull Request
     actions:
@@ -55,6 +67,7 @@ pull_request_rules:
           - base=main
           - "#changes-requested-reviews-by=0"
           - "#approved-reviews-by>=2"
+          - "#review-threads-unresolved=0"
           - label!=work in progress
           - label!=do not merge
           - updated-at<1 days ago
@@ -75,6 +88,7 @@ pull_request_rules:
       - base=main
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
+      - "#review-threads-unresolved=0"
       - check-success=Lint
       # - check-success=Travis CI - Pull Request
       - check-success=ci.int.devshift.net PR build


### PR DESCRIPTION
# Description

Require all conversations about a new PR to be resolved before merging
 (as we discussed in the meeting this week)

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

yamllint and merifyio configuration editor validated syntax was correct
