### PR TITLE
edge2261: expose the GetComposeStatus method and fix typo

### DIFF
--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -1,3 +1,4 @@
+// Package imagebuilder provides Image Builder API client functions
 // FIXME: golangci-lint
 // nolint:errcheck,govet,revive
 package imagebuilder
@@ -105,7 +106,7 @@ type ImageStatus struct {
 type imageStatusValue string
 
 const (
-	imageStatusBulding     imageStatusValue = "building"
+	imageStatusBuilding    imageStatusValue = "building"
 	imageStatusFailure     imageStatusValue = "failure"
 	imageStatusPending     imageStatusValue = "pending"
 	imageStatusRegistering imageStatusValue = "registering"
@@ -312,7 +313,8 @@ func (c *Client) ComposeInstaller(image *models.Image) (*models.Image, error) {
 	return image, nil
 }
 
-func (c *Client) getComposeStatus(jobID string) (*ComposeStatus, error) {
+// GetComposeStatus returns a compose job status given a specific ID
+func (c *Client) GetComposeStatus(jobID string) (*ComposeStatus, error) {
 	cs := &ComposeStatus{}
 	cfg := config.Get()
 	url := fmt.Sprintf("%s/api/image-builder/v1/composes/%s", cfg.ImageBuilderConfig.URL, jobID)
@@ -355,7 +357,7 @@ func (c *Client) getComposeStatus(jobID string) (*ComposeStatus, error) {
 
 // GetCommitStatus gets the Commit status on Image Builder
 func (c *Client) GetCommitStatus(image *models.Image) (*models.Image, error) {
-	cs, err := c.getComposeStatus(image.Commit.ComposeJobID)
+	cs, err := c.GetComposeStatus(image.Commit.ComposeJobID)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +376,7 @@ func (c *Client) GetCommitStatus(image *models.Image) (*models.Image, error) {
 
 // GetInstallerStatus gets the Installer status on Image Builder
 func (c *Client) GetInstallerStatus(image *models.Image) (*models.Image, error) {
-	cs, err := c.getComposeStatus(image.Installer.ComposeJobID)
+	cs, err := c.GetComposeStatus(image.Installer.ComposeJobID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Exposing the GetComposeStatus method so it can be called directly from the Image Builder compose status loop.
The calls for commit and installer are identical for that purpose and there is no need to go through the 
GetCommitStatus() and GetInstallerStatus() abstraction methods for this purpose.

Also fixes a typo and missing Package comment

Fixes # (issue) THEEDGE-2261

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
