### PR TITLE
edge2408: facilitate config allow list for app startups

### DIFF
--- a/cmd/kafka/main.go
+++ b/cmd/kafka/main.go
@@ -72,27 +72,7 @@ func main() {
 	config.Init()
 	l.InitLogger()
 	cfg := config.Get()
-	log.WithFields(log.Fields{
-		"Hostname":                 cfg.Hostname,
-		"Auth":                     cfg.Auth,
-		"WebPort":                  cfg.WebPort,
-		"MetricsPort":              cfg.MetricsPort,
-		"LogLevel":                 cfg.LogLevel,
-		"Debug":                    cfg.Debug,
-		"BucketName":               cfg.BucketName,
-		"BucketRegion":             cfg.BucketRegion,
-		"RepoTempPath ":            cfg.RepoTempPath,
-		"OpenAPIFilePath ":         cfg.OpenAPIFilePath,
-		"ImageBuilderURL":          cfg.ImageBuilderConfig.URL,
-		"InventoryURL":             cfg.InventoryConfig.URL,
-		"PlaybookDispatcherConfig": cfg.PlaybookDispatcherConfig.URL,
-		"TemplatesPath":            cfg.TemplatesPath,
-		"DatabaseType":             cfg.Database.Type,
-		"DatabaseName":             cfg.Database.Name,
-		"EdgeAPIURL":               cfg.EdgeAPIBaseURL,
-		"EdgeAPIServiceHost":       cfg.EdgeAPIServiceHost,
-		"EdgeAPIServicePort":       cfg.EdgeAPIServicePort,
-	}).Info("Configuration Values:")
+	config.LogConfigAtStartup(cfg)
 	db.InitDB()
 
 	log.Info("Entering the infinite loop...")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,31 @@
+// Package config sets up the application configuration from env, file, etc.
+// FIXME: golangci-lint
+// nolint:errcheck,gocritic,gosimple,govet,revive, gosec
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestRedactPasswordFromURL(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	urlWithPassword := "https://zaphod:password@example.com/?this=that&thisone=theother"
+	urlWithoutPassword := "https://example.com/?this=that&thisone=theother"
+	stringNotURLWithDividers := "the=quick_brown+fox%jumped@over;the:lazy-dog"
+	stringNotURLWithSpaces := "the quick brown fox jumped over the lazy dog"
+	stringNotURLWithoutSpaces := "TheQuickBrownFoxJumpedOverTheLazyDog"
+
+	g.Expect(redactPasswordFromURL(urlWithPassword)).To(Equal("https://zaphod:xxxxx@example.com/?this=that&thisone=theother"),
+		"URL with password does not match expected output")
+	g.Expect(redactPasswordFromURL(urlWithoutPassword)).To(Equal(urlWithoutPassword),
+		"URL without password does not match expected output")
+	g.Expect(redactPasswordFromURL(stringNotURLWithDividers)).To(Equal(stringNotURLWithDividers),
+		"Non URL-formatted string does not match expected output")
+	g.Expect(redactPasswordFromURL(stringNotURLWithSpaces)).To(Equal(stringNotURLWithSpaces),
+		"Non URL-formatted string does not match expected output")
+	g.Expect(redactPasswordFromURL(stringNotURLWithoutSpaces)).To(Equal(stringNotURLWithoutSpaces),
+		"Non URL-formatted string does not match expected output")
+}

--- a/main.go
+++ b/main.go
@@ -161,7 +161,9 @@ func main() {
 	var configValues map[string]interface{}
 	cfgBytes, _ := json.Marshal(cfg)
 	_ = json.Unmarshal(cfgBytes, &configValues)
+	// TODO: remove this next line once we have all allowed config values moved to config.LogConfigAtStartup
 	log.WithFields(configValues).Info("Configuration Values")
+	config.LogConfigAtStartup(cfg)
 
 	if featureFlagsConfigPresent() {
 		err := unleash.Initialize(

--- a/pkg/services/images_build/main.go
+++ b/pkg/services/images_build/main.go
@@ -38,29 +38,8 @@ func main() {
 	config.Init()
 	l.InitLogger()
 	cfg := config.Get()
-	// TODO: update these fields
-	mslog.WithFields(log.Fields{
-		"Hostname":                 cfg.Hostname,
-		"Auth":                     cfg.Auth,
-		"WebPort":                  cfg.WebPort,
-		"MetricsPort":              cfg.MetricsPort,
-		"LogLevel":                 cfg.LogLevel,
-		"Debug":                    cfg.Debug,
-		"BucketName":               cfg.BucketName,
-		"BucketRegion":             cfg.BucketRegion,
-		"RepoTempPath ":            cfg.RepoTempPath,
-		"OpenAPIFilePath ":         cfg.OpenAPIFilePath,
-		"ImageBuilderURL":          cfg.ImageBuilderConfig.URL,
-		"InventoryURL":             cfg.InventoryConfig.URL,
-		"PlaybookDispatcherConfig": cfg.PlaybookDispatcherConfig.URL,
-		"TemplatesPath":            cfg.TemplatesPath,
-		"DatabaseType":             cfg.Database.Type,
-		"DatabaseName":             cfg.Database.Name,
-		"EdgeAPIURL":               cfg.EdgeAPIBaseURL,
-		"EdgeCertAPIURL":           cfg.EdgeCertAPIBaseURL,
-		"EdgeAPIServiceHost":       cfg.EdgeAPIServiceHost,
-		"EdgeAPIServicePort":       cfg.EdgeAPIServicePort,
-	}).Info("Configuration Values:")
+	config.LogConfigAtStartup(cfg)
+
 	db.InitDB()
 
 	if cfg.KafkaConfig.Brokers != nil {

--- a/pkg/services/images_iso/main.go
+++ b/pkg/services/images_iso/main.go
@@ -28,10 +28,8 @@ func main() {
 	mslog.Info("Microservice started")
 	config.Init()
 	cfg := config.Get()
-	var configValues map[string]interface{}
-	cfgBytes, _ := json.Marshal(cfg)
-	_ = json.Unmarshal(cfgBytes, &configValues)
-	log.WithFields(configValues).Info("Configuration Values")
+	config.LogConfigAtStartup(cfg)
+
 	db.InitDB()
 
 	if cfg.KafkaConfig.Brokers == nil {


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Add a startup log function to only log non-sensitive EdgeConfig fields and redact passwords from REST URLs

Fixes # (issue) THEEDGE-2408

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
