### PR TITLE
image update: FIXES #THEEDGE-2732 parent ref when upgrading to major version.

### DIFF
--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -46,7 +46,7 @@ func InitClient(ctx context.Context, log *log.Entry) *Client {
 type OSTree struct {
 	URL       string `json:"url,omitempty"`
 	Ref       string `json:"ref"`
-	ParentRef string `json:"parent"`
+	ParentRef string `json:"parent,omitempty"`
 }
 
 // Customizations is made of the packages that are baked into an image
@@ -252,7 +252,10 @@ func (c *Client) ComposeCommit(image *models.Image) (*models.Image, error) {
 			req.ImageRequests[0].Ostree = &OSTree{}
 		}
 		req.ImageRequests[0].Ostree.URL = image.Commit.OSTreeParentCommit
-		req.ImageRequests[0].Ostree.ParentRef = image.Commit.OSTreeParentRef
+
+		if image.Commit.OSTreeRef != "" && image.Commit.OSTreeParentRef != "" && image.Commit.OSTreeRef != image.Commit.OSTreeParentRef {
+			req.ImageRequests[0].Ostree.ParentRef = image.Commit.OSTreeParentRef
+		}
 	}
 
 	cr, err := c.compose(req)

--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bxcodec/faker/v3"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -122,6 +123,175 @@ var _ = Describe("Image Builder Client Test", func() {
 		Expect(img).ToNot(BeNil())
 		Expect(img.Commit.ComposeJobID).To(Equal("compose-job-id-returned-from-image-builder"))
 	})
+
+	Context("compose image commit with ChangesRefs values", func() {
+		dist := "rhel-86"
+		repoURL := faker.URL()
+		var originalImageBuilderURL string
+		conf := config.Get()
+
+		BeforeEach(func() {
+			// save the original image builder url
+			originalImageBuilderURL = conf.ImageBuilderConfig.URL
+		})
+
+		AfterEach(func() {
+			// restore the original image builder url
+			conf.ImageBuilderConfig.URL = originalImageBuilderURL
+		})
+
+		When("change ref is true", func() {
+			// this happens when upgrading an image to a different major version, example: form 8.6 to 9.0
+			newDist := "rhel-90"
+			composeJobID := faker.UUIDHyphenated()
+			It("parent ref is present in the request ", func() {
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					var req ComposeRequest
+					body, err := io.ReadAll(r.Body)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(body).ToNot(BeNil())
+					err = json.Unmarshal(body, &req)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(req.ImageRequests[0].Ostree).ToNot(BeNil())
+					Expect(req.ImageRequests[0].Ostree.URL).To(Equal(repoURL))
+					Expect(req.ImageRequests[0].Ostree.Ref).To(Equal(config.DistributionsRefs[newDist]))
+					Expect(req.ImageRequests[0].Ostree.ParentRef).To(Equal(config.DistributionsRefs[dist]))
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusCreated)
+					_, err = fmt.Fprintf(w, `{"id": "%s"}`, composeJobID)
+					Expect(err).ToNot(HaveOccurred())
+
+				}))
+				defer ts.Close()
+
+				Expect(dist).ToNot(Equal(newDist))
+				Expect(config.DistributionsRefs[dist]).ToNot(BeEmpty())
+				Expect(config.DistributionsRefs[newDist]).ToNot(BeEmpty())
+				Expect(config.DistributionsRefs[newDist]).ToNot(Equal(config.DistributionsRefs[dist]))
+
+				config.Get().ImageBuilderConfig.URL = ts.URL
+				img := &models.Image{Distribution: dist,
+					Commit: &models.Commit{
+						Arch:               "x86_64",
+						Repo:               &models.Repo{},
+						OSTreeRef:          config.DistributionsRefs[newDist],
+						OSTreeParentRef:    config.DistributionsRefs[dist],
+						ChangesRefs:        true,
+						OSTreeParentCommit: repoURL,
+					}}
+				img, err := client.ComposeCommit(img)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(img).ToNot(BeNil())
+				Expect(img.Commit.ComposeJobID).To(Equal(composeJobID))
+			})
+		})
+
+		When("change ref is false", func() {
+			dist := "rhel-85"
+			newDist := "rhel-86"
+			composeJobID := faker.UUIDHyphenated()
+			type TestOSTree struct {
+				URL       *string `json:"url,omitempty"`
+				Ref       string  `json:"ref"`
+				ParentRef *string `json:"parent"`
+			}
+
+			type TestImageRequest struct {
+				Architecture  string         `json:"architecture"`
+				ImageType     string         `json:"image_type"`
+				Ostree        *TestOSTree    `json:"ostree,omitempty"`
+				UploadRequest *UploadRequest `json:"upload_request"`
+			}
+
+			type TestComposeRequest struct {
+				Customizations *Customizations    `json:"customizations"`
+				Distribution   string             `json:"distribution"`
+				ImageRequests  []TestImageRequest `json:"image_requests"`
+			}
+
+			It("parent ref is not present in the request when parent ref equal to current ref ", func() {
+				// this happens when updating an image within the same major version
+				// example: form 8.5 to 8.5 to change the installed packages collections or updating from 8.5 to 8.6
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					var req TestComposeRequest
+					body, err := io.ReadAll(r.Body)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(body).ToNot(BeNil())
+					err = json.Unmarshal(body, &req)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(req.ImageRequests[0].Ostree).ToNot(BeNil())
+					Expect(*req.ImageRequests[0].Ostree.URL).To(Equal(repoURL))
+					Expect(req.ImageRequests[0].Ostree.Ref).To(Equal(config.DistributionsRefs[newDist]))
+					Expect(req.ImageRequests[0].Ostree.ParentRef).To(BeNil())
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusCreated)
+					_, err = fmt.Fprintf(w, `{"id": "%s"}`, composeJobID)
+					Expect(err).ToNot(HaveOccurred())
+
+				}))
+				defer ts.Close()
+
+				Expect(dist).ToNot(Equal(newDist))
+				Expect(config.DistributionsRefs[dist]).ToNot(BeEmpty())
+				Expect(config.DistributionsRefs[newDist]).ToNot(BeEmpty())
+				Expect(config.DistributionsRefs[newDist]).To(Equal(config.DistributionsRefs[dist]))
+
+				config.Get().ImageBuilderConfig.URL = ts.URL
+				img := &models.Image{Distribution: dist,
+					Commit: &models.Commit{
+						Arch:               "x86_64",
+						Repo:               &models.Repo{},
+						OSTreeRef:          config.DistributionsRefs[newDist],
+						OSTreeParentRef:    config.DistributionsRefs[dist],
+						ChangesRefs:        false,
+						OSTreeParentCommit: repoURL,
+					}}
+				img, err := client.ComposeCommit(img)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(img).ToNot(BeNil())
+				Expect(img.Commit.ComposeJobID).To(Equal(composeJobID))
+			})
+
+			It("parent ref and url are not present in the request when parent repo url is empty", func() {
+				// this happens when creating a new image
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					var req TestComposeRequest
+					body, err := io.ReadAll(r.Body)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(body).ToNot(BeNil())
+					err = json.Unmarshal(body, &req)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(req.ImageRequests[0].Ostree).ToNot(BeNil())
+					Expect(req.ImageRequests[0].Ostree.Ref).To(Equal(config.DistributionsRefs[newDist]))
+					Expect(req.ImageRequests[0].Ostree.URL).To(BeNil())
+					Expect(req.ImageRequests[0].Ostree.ParentRef).To(BeNil())
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusCreated)
+					_, err = fmt.Fprintf(w, `{"id": "%s"}`, composeJobID)
+					Expect(err).ToNot(HaveOccurred())
+				}))
+				defer ts.Close()
+
+				Expect(config.DistributionsRefs[newDist]).ToNot(BeEmpty())
+
+				config.Get().ImageBuilderConfig.URL = ts.URL
+				img := &models.Image{Distribution: dist,
+					Commit: &models.Commit{
+						Arch:               "x86_64",
+						Repo:               &models.Repo{},
+						OSTreeRef:          config.DistributionsRefs[newDist],
+						OSTreeParentRef:    "",
+						ChangesRefs:        false,
+						OSTreeParentCommit: "",
+					}}
+				img, err := client.ComposeCommit(img)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(img).ToNot(BeNil())
+				Expect(img.Commit.ComposeJobID).To(Equal(composeJobID))
+			})
+		})
+	})
+
 	It("test compose installer", func() {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -308,7 +308,7 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 		}
 
 		image.Commit.OSTreeParentCommit = repo.URL
-		if previousImage.Distribution != image.Distribution {
+		if config.DistributionsRefs[previousImage.Distribution] != config.DistributionsRefs[image.Distribution] {
 			image.Commit.ChangesRefs = true
 		}
 		var refs string
@@ -321,7 +321,7 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 		if image.Commit.OSTreeRef == "" {
 			image.Commit.OSTreeRef = refs
 		}
-		if previousImage.Commit.OSTreeRef == "" {
+		if image.Commit.OSTreeParentRef == "" {
 			image.Commit.OSTreeParentRef = config.DistributionsRefs[previousImage.Distribution]
 		}
 

--- a/pkg/services/images_test.go
+++ b/pkg/services/images_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhatinsights/edge-api/config"
 	imageBuilderClient "github.com/redhatinsights/edge-api/pkg/clients/imagebuilder"
 	"github.com/redhatinsights/edge-api/pkg/clients/imagebuilder/mock_imagebuilder"
 	"github.com/redhatinsights/edge-api/pkg/db"
@@ -207,6 +208,7 @@ var _ = Describe("Image Service Test", func() {
 				image := models.Image{
 					OrgID:                  orgID,
 					Name:                   name,
+					Distribution:           "rhel-90",
 					ThirdPartyRepositories: repos,
 				}
 				error := service.CreateImage(&image)
@@ -302,6 +304,141 @@ var _ = Describe("Image Service Test", func() {
 				Expect(image.Commit.OSTreeParentRef).To(Equal("rhel/8/x86_64/edge"))
 				Expect(image.Commit.OSTreeRef).To(Equal("rhel/8/x86_64/edge"))
 			})
+
+			When("updating major version, from 8.6 to 9.0", func() {
+				orgID := faker.UUIDHyphenated()
+				imageSet := &models.ImageSet{OrgID: orgID}
+				dist := "rhel-86"
+				newDist := "rhel-90"
+				imageSetResult := db.DB.Create(imageSet)
+				repo := models.Repo{URL: faker.URL(), Status: models.RepoStatusSuccess}
+				repoResult := db.DB.Create(&repo)
+				previousImage := &models.Image{
+					OrgID:  orgID,
+					Status: models.ImageStatusSuccess,
+					Commit: &models.Commit{
+						Repo:  &models.Repo{URL: faker.URL(), Status: models.RepoStatusSuccess},
+						OrgID: orgID,
+					},
+					Version:      1,
+					Distribution: dist,
+					Name:         faker.Name(),
+					ImageSetID:   &imageSet.ID,
+				}
+				previousImageResult := db.DB.Create(previousImage)
+				image := &models.Image{
+					OrgID:        orgID,
+					Commit:       &models.Commit{},
+					OutputTypes:  []string{models.ImageTypeCommit},
+					Version:      2,
+					Distribution: newDist,
+					Name:         previousImage.Name,
+				}
+				It("should have parent ref and url defined when updating major version", func() {
+					Expect(repoResult.Error).ToNot(HaveOccurred())
+					Expect(imageSetResult.Error).ToNot(HaveOccurred())
+					Expect(previousImageResult.Error).ToNot(HaveOccurred())
+					Expect(dist).NotTo(Equal(newDist))
+					osTreeParentRef := config.DistributionsRefs[dist]
+					osTreeRef := config.DistributionsRefs[newDist]
+					Expect(osTreeRef).ToNot(Equal(osTreeParentRef))
+
+					// simulate error building image to analyse the image values only
+					expectedErr := fmt.Errorf("Failed creating commit for image")
+					mockImageBuilderClient.EXPECT().ComposeCommit(image).Return(image, expectedErr)
+					mockRepoService.EXPECT().GetRepoByID(previousImage.Commit.RepoID).Return(&repo, nil)
+					actualErr := service.UpdateImage(image, previousImage)
+					Expect(actualErr).To(HaveOccurred())
+					Expect(actualErr).To(MatchError(expectedErr))
+
+					Expect(image.Commit.OSTreeParentCommit).To(Equal(repo.URL))
+					Expect(image.Commit.OSTreeRef).To(Equal(osTreeRef))
+					Expect(image.Commit.OSTreeParentRef).To(Equal(osTreeParentRef))
+					Expect(image.Commit.ChangesRefs).To(BeTrue())
+				})
+
+				When("previous image commit has osTree Refs defined", func() {
+					previousImage.Commit.OSTreeRef = config.DistributionsRefs[dist]
+					previousImage.Commit.OSTreeParentRef = config.DistributionsRefs[dist]
+					result := db.DB.Save(&previousImage.Commit)
+
+					It("should have parent ref and url defined when updating major version", func() {
+						Expect(result.Error).ToNot(HaveOccurred())
+						Expect(dist).NotTo(Equal(newDist))
+						osTreeParentRef := config.DistributionsRefs[dist]
+						osTreeRef := config.DistributionsRefs[newDist]
+						Expect(osTreeRef).ToNot(Equal(osTreeParentRef))
+
+						// simulate error building image to analyse the image values only
+						expectedErr := fmt.Errorf("Failed creating commit for image")
+						mockImageBuilderClient.EXPECT().ComposeCommit(image).Return(image, expectedErr)
+						mockRepoService.EXPECT().GetRepoByID(previousImage.Commit.RepoID).Return(&repo, nil)
+						actualErr := service.UpdateImage(image, previousImage)
+						Expect(actualErr).To(HaveOccurred())
+						Expect(actualErr).To(MatchError(expectedErr))
+
+						Expect(image.Commit.OSTreeParentCommit).To(Equal(repo.URL))
+						Expect(image.Commit.OSTreeRef).To(Equal(osTreeRef))
+						Expect(image.Commit.OSTreeParentRef).To(Equal(osTreeParentRef))
+						Expect(image.Commit.ChangesRefs).To(BeTrue())
+					})
+				})
+			})
+			When("not updating major version, from 8.5 to 8.6", func() {
+				orgID := faker.UUIDHyphenated()
+				imageSet := &models.ImageSet{OrgID: orgID}
+				dist := "rhel-85"
+				newDist := "rhel-86"
+				imageSetResult := db.DB.Create(imageSet)
+				repo := models.Repo{URL: faker.URL(), Status: models.RepoStatusSuccess}
+				repoResult := db.DB.Create(&repo)
+				previousImage := &models.Image{
+					OrgID:  orgID,
+					Status: models.ImageStatusSuccess,
+					Commit: &models.Commit{
+						Repo:  &models.Repo{URL: faker.URL(), Status: models.RepoStatusSuccess},
+						OrgID: orgID,
+					},
+					Version:      1,
+					Distribution: dist,
+					Name:         faker.Name(),
+					ImageSetID:   &imageSet.ID,
+				}
+				previousImageResult := db.DB.Create(previousImage)
+				image := &models.Image{
+					OrgID:        orgID,
+					Commit:       &models.Commit{},
+					OutputTypes:  []string{models.ImageTypeCommit},
+					Version:      2,
+					Distribution: newDist,
+					Name:         previousImage.Name,
+				}
+				It("should have parent ref and ref to be equal and url defined when not updating major version", func() {
+					Expect(repoResult.Error).ToNot(HaveOccurred())
+					Expect(imageSetResult.Error).ToNot(HaveOccurred())
+					Expect(previousImageResult.Error).ToNot(HaveOccurred())
+					Expect(dist).NotTo(Equal(newDist))
+					osTreeParentRef := config.DistributionsRefs[dist]
+					osTreeRef := config.DistributionsRefs[newDist]
+					Expect(osTreeRef).To(Equal(osTreeParentRef))
+
+					// simulate error building image to analyse the image values only
+					expectedErr := fmt.Errorf("Failed creating commit for image")
+					mockImageBuilderClient.EXPECT().ComposeCommit(image).Return(image, expectedErr)
+					mockRepoService.EXPECT().GetRepoByID(previousImage.Commit.RepoID).Return(&repo, nil)
+					actualErr := service.UpdateImage(image, previousImage)
+					Expect(actualErr).To(HaveOccurred())
+					Expect(actualErr).To(MatchError(expectedErr))
+
+					Expect(image.Commit.OSTreeParentCommit).To(Equal(repo.URL))
+					Expect(image.Commit.OSTreeRef).To(Equal(osTreeRef))
+					Expect(image.Commit.OSTreeParentRef).To(Equal(osTreeParentRef))
+					Expect(image.Commit.OSTreeRef).To(Equal(image.Commit.OSTreeParentRef))
+					Expect(image.Commit.ChangesRefs).To(BeFalse())
+				})
+
+			})
+
 		})
 
 		Context("when previous image has success status", func() {


### PR DESCRIPTION
This bug prevented upgrading image from 8.6 to 9.0

Fixes #THEEDGE-2732

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
