### PR TITLE
update: make update to use the simple content reader end-point.

### DIFF
--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -308,9 +308,13 @@ func (s *UpdateService) WriteTemplate(templateInfo TemplateRemoteInfo, orgID str
 		GoTemplateRemoteName: templateInfo.RemoteName,
 		UpdateNumber:         strconv.FormatUint(uint64(templateInfo.UpdateTransactionID), 10),
 		RepoURL:              repoURL,
-		RepoContentURL:       fmt.Sprintf("%s/content", repoURL),
-		RemoteOstreeUpdate:   templateInfo.RemoteOstreeUpdate,
-		OSTreeRef:            templateInfo.OSTreeRef,
+		// encountering SSl Connection error when pulling too many files with content end-point (signed url redirect),
+		// this is raising when updating major version eg: rhel-8.6 -> rhel-9.0
+		// this need more investigations.
+		// RepoContentURL:     fmt.Sprintf("%s/content", repoURL),
+		RepoContentURL:     repoURL,
+		RemoteOstreeUpdate: templateInfo.RemoteOstreeUpdate,
+		OSTreeRef:          templateInfo.OSTreeRef,
 	}
 
 	// TODO change the same time as line 231

--- a/templates/template_playbook_dispatcher_ostree_rebase_payload.test.yml
+++ b/templates/template_playbook_dispatcher_ostree_rebase_payload.test.yml
@@ -5,7 +5,7 @@
   vars:
     update_number: "1000"
     repo_url: "http://cert.localhost:3000/api/edge/v1/storage/update-repos/1000"
-    repo_content_url: "http://cert.localhost:3000/api/edge/v1/storage/update-repos/1000/content"
+    repo_content_url: "http://cert.localhost:3000/api/edge/v1/storage/update-repos/1000"
     ostree_remote_name: "remote-name"
     ostree_changes_refs: "true"
     os_tree_ref: "rhel/9/x86_64/edge"

--- a/templates/template_playbook_dispatcher_ostree_upgrade_payload.test.yml
+++ b/templates/template_playbook_dispatcher_ostree_upgrade_payload.test.yml
@@ -5,7 +5,7 @@
   vars:
     update_number: "1000"
     repo_url: "http://cert.localhost:3000/api/edge/v1/storage/update-repos/1000"
-    repo_content_url: "http://cert.localhost:3000/api/edge/v1/storage/update-repos/1000/content"
+    repo_content_url: "http://cert.localhost:3000/api/edge/v1/storage/update-repos/1000"
     ostree_remote_name: "remote-name"
     ostree_changes_refs: "false"
     os_tree_ref: "rhel/8/x86_64/edge"


### PR DESCRIPTION
encountering SSl Connection error when pulling too many files with content end-point (signed url redirect), this is raising when updating major version eg: rhel-8.6 -> rhel-9.0 this behavior needs more investigations.

Fixes #THEEDGE-2489

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
