### PR TITLE
images: fixes images commit ostreeRef when previous image fail.

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -298,6 +298,17 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 		return err
 	}
 
+	var refs string
+	if image.Distribution == "" {
+		refs = config.DistributionsRefs[config.DefaultDistribution]
+	} else {
+		refs = config.DistributionsRefs[image.Distribution]
+	}
+
+	if image.Commit.OSTreeRef == "" {
+		image.Commit.OSTreeRef = refs
+	}
+
 	if previousImage.Status == models.ImageStatusSuccess {
 		// Always get the repo URL from the previous Image's commit
 		repo, err := s.RepoService.GetRepoByID(previousImage.Commit.RepoID)
@@ -311,16 +322,7 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 		if config.DistributionsRefs[previousImage.Distribution] != config.DistributionsRefs[image.Distribution] {
 			image.Commit.ChangesRefs = true
 		}
-		var refs string
-		if image.Distribution == "" {
-			refs = config.DistributionsRefs[config.DefaultDistribution]
-		} else {
-			refs = config.DistributionsRefs[image.Distribution]
-		}
 
-		if image.Commit.OSTreeRef == "" {
-			image.Commit.OSTreeRef = refs
-		}
 		if image.Commit.OSTreeParentRef == "" {
 			image.Commit.OSTreeParentRef = config.DistributionsRefs[previousImage.Distribution]
 		}


### PR DESCRIPTION
When previous image failed the image is left with commit ostree ref empty, that will cause the device update to fail when rebasing, we see in the logs: 
```log
Invoked with _raw_params=rpm-ostree rebase "" _uses_shell=True warn=False stdin_add_newline=True 
strip_empty_ends=True argv=None chdir=None executable=None creates=None removes=None stdin=None
```



## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
