### PR TITLE
Set auto-fix to false

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,6 +38,7 @@ jobs:
           # Args should be the same as Makefile
           args: >
             --enable=errcheck,gocritic,gofmt,goimports,gosec,gosimple,govet,ineffassign,revive,staticcheck,typecheck,unused
+            --fix=false
             --max-same-issues=20
             --print-issued-lines=true
             --print-linter-name=true

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ BUILD_TAGS=-tags=fdo
 
 GOLANGCI_LINT_COMMON_OPTIONS=\
 			--enable=errcheck,gocritic,gofmt,goimports,gosec,gosimple,govet,ineffassign,revive,staticcheck,typecheck,unused \
+			--fix=false \
 			--max-same-issues=20 \
 			--print-issued-lines=true \
 			--print-linter-name=true \


### PR DESCRIPTION
# Description

Ensure golangci-lint does not make changes to edge-api, only reports issues

Fixes # (issue)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
