### PR TITLE
refactor packageDiff sturcture in case there is no changes when comapring packages

### DIFF
--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -274,7 +274,7 @@ func (s *DeviceService) GetUpdateAvailableForDevice(device inventory.Device, lat
 }
 
 func getPackageDiff(a, b []models.InstalledPackage) []models.InstalledPackage {
-	var diff []models.InstalledPackage
+	diff := make([]models.InstalledPackage, 0)
 	pkgs := make(map[string]models.InstalledPackage)
 	for _, pkg := range b {
 		pkgs[pkg.Name] = pkg

--- a/pkg/services/devices_test.go
+++ b/pkg/services/devices_test.go
@@ -272,6 +272,10 @@ var _ = Describe("DfseviceService", func() {
 								Name:    "vim",
 								Version: "2.0.0",
 							},
+							{
+								Name:    "git",
+								Version: "2.0.0",
+							},
 						},
 						OrgID: orgID,
 					},
@@ -289,7 +293,7 @@ var _ = Describe("DfseviceService", func() {
 				newUpdate := updatesAvailable[0]
 				Expect(newUpdate.Image.ID).To(Equal(newImage.ID))
 				Expect(newUpdate.PackageDiff.Upgraded).To(HaveLen(1))
-				Expect(newUpdate.PackageDiff.Added).To(HaveLen(1))
+				Expect(newUpdate.PackageDiff.Added).To(HaveLen(2))
 				Expect(newUpdate.PackageDiff.Removed).To(HaveLen(1))
 			})
 			It("should return updates", func() {
@@ -494,11 +498,44 @@ var _ = Describe("DfseviceService", func() {
 			},
 			OrgID: orgID,
 		}
-		It("should return diff", func() {
-			deltaDiff := services.GetDiffOnUpdate(oldImage, newImage)
-			Expect(deltaDiff.Added).To(HaveLen(1))
-			Expect(deltaDiff.Removed).To(HaveLen(2))
-			Expect(deltaDiff.Upgraded).To(HaveLen(1))
+		newImageWithoutChanges := models.Image{
+			Commit: &models.Commit{
+				InstalledPackages: []models.InstalledPackage{
+					{
+						Name:    "vim",
+						Version: "2.2",
+					},
+					{
+						Name:    "ansible",
+						Version: "1",
+					},
+					{
+						Name:    "yum",
+						Version: "2:6.0-1",
+					},
+					{
+						Name:    "dnf",
+						Version: "2:6.0-1",
+					},
+				},
+				OrgID: orgID,
+			},
+			OrgID: orgID,
+		}
+		When("check package different between version", func() {
+			It("should return different in case there are changes between version", func() {
+				deltaDiff := services.GetDiffOnUpdate(oldImage, newImage)
+				Expect(deltaDiff.Added).To(HaveLen(1))
+				Expect(deltaDiff.Removed).To(HaveLen(2))
+				Expect(deltaDiff.Upgraded).To(HaveLen(1))
+			})
+
+			It("should not return different in case there is no changes between version", func() {
+				deltaDiff := services.GetDiffOnUpdate(oldImage, newImageWithoutChanges)
+				Expect(deltaDiff.Added).To(HaveLen(0))
+				Expect(deltaDiff.Removed).To(HaveLen(0))
+				Expect(deltaDiff.Upgraded).To(HaveLen(0))
+			})
 		})
 	})
 	Context("GetImageForDeviceByUUID", func() {


### PR DESCRIPTION
related to bug -[THEEDGE-2578](https://issues.redhat.com/browse/THEEDGE-2578) in case we dont have any changes when comparing packages, I want to see 0 instead of null
 related to bug of pacakageDiff

Signed-off-by: mgold1234 <mgold@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
