### PR TITLE
migrate OrgId at all Models struct to 'create' instead of account

### DIFF
--- a/pkg/models/commits.go
+++ b/pkg/models/commits.go
@@ -30,7 +30,7 @@ type Commit struct {
 	Model
 	Name                 string
 	Account              string             `json:"Account"`
-	OrgID                string             `json:"org_id" gorm:"index"`
+	OrgID                string             `json:"org_id" gorm:"index;<-:create"`
 	ImageBuildHash       string             `json:"ImageBuildHash"`
 	ImageBuildParentHash string             `json:"ImageBuildParentHash"`
 	ImageBuildTarURL     string             `json:"ImageBuildTarURL"`

--- a/pkg/models/devicegroups.go
+++ b/pkg/models/devicegroups.go
@@ -15,8 +15,8 @@ import (
 // Type is the device group type and must be "static" or "dynamic"
 type DeviceGroup struct {
 	Model
-	Account     string   `json:"Account" gorm:"index;<-:create"`
-	OrgID       string   `json:"org_id" gorm:"index"`
+	Account     string   `json:"Account" gorm:"index"`
+	OrgID       string   `json:"org_id" gorm:"index;<-:create"`
 	Name        string   `json:"Name"`
 	Type        string   `json:"Type" gorm:"default:static;<-:create"`
 	Devices     []Device `faker:"-" json:"Devices" gorm:"many2many:device_groups_devices;"`

--- a/pkg/models/devicegroups_test.go
+++ b/pkg/models/devicegroups_test.go
@@ -41,7 +41,7 @@ func TestGroupCreateUpdateConstraint(t *testing.T) {
 	groupInitialAccount := "1111111"
 	groupInitialName := "test_group"
 	groupInitialType := DeviceGroupTypeDynamic
-	groupNewAccount := "222222"
+	groupNewOrgID := "222222"
 	groupInitialOrgID := "1111111"
 
 	groupNewType := DeviceGroupTypeStatic
@@ -63,7 +63,7 @@ func TestGroupCreateUpdateConstraint(t *testing.T) {
 		t.Errorf("Failed to retrieve the created DeviceGroup: %q", result.Error)
 	}
 
-	savedGroup.Account = groupNewAccount
+	savedGroup.OrgID = groupNewOrgID
 	savedGroup.Type = groupNewType
 	savedGroup.Name = groupNewName
 
@@ -78,8 +78,8 @@ func TestGroupCreateUpdateConstraint(t *testing.T) {
 		t.Errorf("Failed to retrieve the updated DeviceGroup: %q", result.Error)
 	}
 	// The group Account should not be updated
-	if updatedGroup.Account != groupInitialAccount {
-		t.Errorf("The group Account has been updated expected: %q  but found %q", groupInitialAccount, updatedGroup.Account)
+	if updatedGroup.OrgID != groupInitialOrgID {
+		t.Errorf("The org id has been updated expected: %q  but found %q", groupInitialOrgID, updatedGroup.OrgID)
 	}
 	// The group Type should not be updated
 	if updatedGroup.Type != groupInitialType {

--- a/pkg/models/devices.go
+++ b/pkg/models/devices.go
@@ -92,7 +92,7 @@ type Device struct {
 	LastSeen          EdgeAPITime          `json:"LastSeen"`
 	CurrentHash       string               `json:"CurrentHash,omitempty"`
 	Account           string               `gorm:"index" json:"Account"`
-	OrgID             string               `json:"org_id" gorm:"index"`
+	OrgID             string               `json:"org_id" gorm:"index;<-:create"`
 	ImageID           uint                 `json:"ImageID"`
 	UpdateAvailable   bool                 `json:"UpdateAvailable"`
 	DevicesGroups     []DeviceGroup        `faker:"-" gorm:"many2many:device_groups_devices;save_association:false" json:"DevicesGroups"`

--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -19,7 +19,7 @@ type ImageSet struct {
 	Name    string  `json:"Name"`
 	Version int     `json:"Version" gorm:"default:1"`
 	Account string  `json:"Account"`
-	OrgID   string  `json:"org_id" gorm:"index"`
+	OrgID   string  `json:"org_id" gorm:"index;<-:create"`
 	Images  []Image `json:"Images"`
 }
 

--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -28,7 +28,7 @@ type Image struct {
 	Model
 	Name                   string           `json:"Name"`
 	Account                string           `json:"Account"`
-	OrgID                  string           `json:"org_id" gorm:"index"`
+	OrgID                  string           `json:"org_id" gorm:"index;<-:create"`
 	Distribution           string           `json:"Distribution"`
 	Description            string           `json:"Description"`
 	Status                 string           `json:"Status"`

--- a/pkg/models/installers.go
+++ b/pkg/models/installers.go
@@ -11,7 +11,7 @@ import (
 type Installer struct {
 	Model
 	Account          string `json:"Account"`
-	OrgID            string `json:"org_id" gorm:"index"`
+	OrgID            string `json:"org_id" gorm:"index;<-:create"`
 	ImageBuildISOURL string `json:"ImageBuildISOURL"`
 	ComposeJobID     string `json:"ComposeJobID"`
 	Status           string `json:"Status"`

--- a/pkg/models/thirdpartyrepo.go
+++ b/pkg/models/thirdpartyrepo.go
@@ -23,7 +23,7 @@ type ThirdPartyRepo struct {
 	URL         string `json:"URL"`
 	Description string `json:"Description,omitempty"`
 	Account     string
-	OrgID       string  `json:"org_id" gorm:"index"`
+	OrgID       string  `json:"org_id" gorm:"index;<-:create"`
 	Images      []Image `faker:"-" json:"Images,omitempty" gorm:"many2many:images_repos;"`
 }
 

--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -21,7 +21,7 @@ type UpdateTransaction struct {
 	Commit          *Commit          `json:"Commit"`
 	CommitID        uint             `json:"CommitID"`
 	Account         string           `json:"Account"`
-	OrgID           string           `json:"org_id" gorm:"index"`
+	OrgID           string           `json:"org_id" gorm:"index;<-:create"`
 	OldCommits      []Commit         `gorm:"many2many:updatetransaction_commits;" json:"OldCommits"`
 	Devices         []Device         `gorm:"many2many:updatetransaction_devices;save_association:false" json:"Devices"`
 	Tag             string           `json:"Tag"`


### PR DESCRIPTION
Signed-off-by: Adelia Ferreira <tay.figueira@gmail.com>

 - Task: THEEDGE-2399

Migrate OrgId at all Models struct to 'create' instead of account

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
