### PR TITLE
changed pulled kafka image

### DIFF
--- a/podman/container-compose-kafka.yml
+++ b/podman/container-compose-kafka.yml
@@ -2,7 +2,7 @@ version: "2"
 services:
   kafka:
     container_name: kafka
-    image: quay.io/strimzi/kafka:latest-kafka-2.8.1-amd64
+    image: quay.io/strimzi/kafka:latest-kafka-2.8.1
     restart: unless-stopped
     command:
       [


### PR DESCRIPTION
# Description

changed the kafka  image being pulled in [podman/container-compose-kafka.yml](https://github.com/RedHatInsights/edge-api/compare/fixes?expand=1#diff-a85eecf3ad945352a9e2a794e3ba6bb97fba0107f892348e4564a4f346657e0a) so that it is puling the matching image for the host running it instead of specifically the x86 image

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
