### PR TITLE
updated spec-file description for /devices order_how query param

### DIFF
--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -634,7 +634,7 @@ paths:
             type: string
         - name: order_how
           in: query
-          description: "field: choose to order ASC or DESC"
+          description: "field: choose to order ASC or DESC when order_by is being used"
           schema:
             type: string
         - name: hostname_or_id


### PR DESCRIPTION
# Description

updated the spec-file to better describe the fact that order_how can only be used together with order_by
 

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
