### PR TITLE
Use specific branches when updating sonarqube.

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -2,6 +2,8 @@
 
 set -exv
 
+export PR_CHECK="false" # Only used when doing a PR check from Github.
+
 IMAGE="quay.io/cloudservices/edge-api"
 
 # Determine Git commit hash (7 hex characters)

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -44,3 +44,8 @@ for tag in $(echo $TAGS); do
     podman tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${tag}"
     podman push "${IMAGE}:${tag}"
 done
+
+# Generate coverate report for sonarqube
+make coverage-no-fdo
+# Generate sonarqube reports
+make scan_project

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -3,6 +3,8 @@
 export GOROOT="/opt/go/1.17.7" # Force Jenkins to use Go 1.17.7 since we don't have 1.18 yet
 export PATH="${GOROOT}/bin:${PATH}"
 
+export PR_CHECK=true # Only used when doing a PR check from Github.
+
 export APP_NAME="edge"  # name of app-sre "application" folder this component lives in
 export COMPONENT_NAME="edge-api"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 export IMAGE="quay.io/cloudservices/edge-api"  # image location on quay
@@ -40,3 +42,5 @@ source $CICD_ROOT/post_test_results.sh
 
 # Generate coverate report for sonarqube
 make coverage-no-fdo
+# Generate sonarqube reports
+make scan_project

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -3,7 +3,7 @@
 export GOROOT="/opt/go/1.17.7" # Force Jenkins to use Go 1.17.7 since we don't have 1.18 yet
 export PATH="${GOROOT}/bin:${PATH}"
 
-export PR_CHECK=true # Only used when doing a PR check from Github.
+export PR_CHECK="true" # Only used when doing a PR check from Github.
 
 export APP_NAME="edge"  # name of app-sre "application" folder this component lives in
 export COMPONENT_NAME="edge-api"  # name of app-sre "resourceTemplate" in deploy.yaml for this component

--- a/sonarqube.sh
+++ b/sonarqube.sh
@@ -10,7 +10,7 @@ COMMIT_SHORT=$(git rev-parse --short=7 HEAD)
 # Both ${GIT_BRANCH}  and ${ghprbPullId} are provided by App-Interface's Jenkins.
 # SonarQube parameters can be found below:
 #   https://sonarqube.corp.redhat.com/documentation/analysis/pull-request/
-if [ $PR_CHECK -eq "true"]; then
+if [[ $PR_CHECK -eq "true"]]; then
     PR_CHECK_OPTS="-Dsonar.pullrequest.branch=${GIT_BRANCH} -Dsonar.pullrequest.key=${ghprbPullId}";
 fi
 

--- a/sonarqube.sh
+++ b/sonarqube.sh
@@ -10,8 +10,8 @@ COMMIT_SHORT=$(git rev-parse --short=7 HEAD)
 # Both ${GIT_BRANCH}  and ${ghprbPullId} are provided by App-Interface's Jenkins.
 # SonarQube parameters can be found below:
 #   https://sonarqube.corp.redhat.com/documentation/analysis/pull-request/
-if [[ $PR_CHECK -eq "true"]]; then
-    PR_CHECK_OPTS="-Dsonar.pullrequest.branch=${GIT_BRANCH} -Dsonar.pullrequest.key=${ghprbPullId}";
+if [ "${PR_CHECK}" = "true" ]; then
+    export PR_CHECK_OPTS="-Dsonar.pullrequest.branch=${GIT_BRANCH} -Dsonar.pullrequest.key=${ghprbPullId}";
 fi
 
 podman run \

--- a/sonarqube.sh
+++ b/sonarqube.sh
@@ -4,10 +4,21 @@ set -o nounset
 
 COMMIT_SHORT=$(git rev-parse --short=7 HEAD)
 
+# When doing a PR check, send sonarqube results to a separate branch.
+# Otherwise, send it to the default 'master' branch.
+# The variable $PR_CHECK is only used when doing a PR check (see pr_check.sh).
+# Both ${GIT_BRANCH}  and ${ghprbPullId} are provided by App-Interface's Jenkins.
+# SonarQube parameters can be found below:
+#   https://sonarqube.corp.redhat.com/documentation/analysis/pull-request/
+if [ $PR_CHECK -eq "true"]; then
+    PR_CHECK_OPTS="-Dsonar.pullrequest.branch=${GIT_BRANCH} -Dsonar.pullrequest.key=${ghprbPullId}";
+fi
+
 podman run \
 --pull=always --rm \
 -v "${PWD}":/usr/src:z   \
 -e SONAR_SCANNER_OPTS="-Dsonar.scm.provider=git \
+ ${PR_CHECK_OPTS} \
  -Dsonar.working.directory=/tmp \
  -Dsonar.projectKey=console.redhat.com:fleet-management \
  -Dsonar.projectVersion=${COMMIT_SHORT} \

--- a/sonarqube.sh
+++ b/sonarqube.sh
@@ -10,7 +10,7 @@ COMMIT_SHORT=$(git rev-parse --short=7 HEAD)
 # Both ${GIT_BRANCH}  and ${ghprbPullId} are provided by App-Interface's Jenkins.
 # SonarQube parameters can be found below:
 #   https://sonarqube.corp.redhat.com/documentation/analysis/pull-request/
-if [ "${PR_CHECK}" = "true" ]; then
+if [[ "${PR_CHECK}" = "true" ]]; then
     export PR_CHECK_OPTS="-Dsonar.pullrequest.branch=${GIT_BRANCH} -Dsonar.pullrequest.key=${ghprbPullId}";
 fi
 


### PR DESCRIPTION
# Description

When we do a PR check, we run `sonar-scanner` and the results are uploaded to our SonarQube instance using the default `master` branch. We should, instead, upload these results to their own separate branch and only upload to `master` when the PR is actually merged.

Please note that there will be a separate PR for App-Interface which I'll post here, but it doesn't block this from being merged once I remove the DONOTMERGE label.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
