### PR TITLE
add image completion producers

### DIFF
--- a/pkg/models/events.go
+++ b/pkg/models/events.go
@@ -39,6 +39,13 @@ const (
 	EventTypeEdgeImageUpdateRequested string = "com.redhat.console.edge.api.image.update.requested"
 	// EventTypeEdgeImageISORequested indicates an image update has been requested
 	EventTypeEdgeImageISORequested string = "com.redhat.console.edge.api.image.iso.requested"
+
+	// EventTypeEdgeCommitCompleted indicates a commit has completed
+	EventTypeEdgeCommitCompleted string = "com.redhat.console.edge.api.image.commit.completed"
+	// EventTypeEdgeOstreeRepoCompleted indicates an ostree repo has completed
+	EventTypeEdgeOstreeRepoCompleted string = "com.redhat.console.edge.api.image.repo.completed"
+	// EventTypeEdgeInstallerCompleted indicates an installer has completed
+	EventTypeEdgeInstallerCompleted string = "com.redhat.console.edge.api.image.installer.completed"
 )
 
 // CRCCloudEvent is a standard event schema that wraps the Edge-specific "Data" payload
@@ -116,6 +123,24 @@ type EdgeImageUpdateRequestedEventPayload struct {
 
 // EdgeImageISORequestedEventPayload provides edge-specific data when an image iso is requested
 type EdgeImageISORequestedEventPayload struct {
+	EdgeBasePayload
+	NewImage Image `json:"new_image"`
+}
+
+// EdgeCommitCompletedEventPayload provides image data when a commit is complete
+type EdgeCommitCompletedEventPayload struct {
+	EdgeBasePayload
+	NewImage Image `json:"new_image"`
+}
+
+// EdgeOstreeRepoCompletedEventPayload provides image data when an ostree repo is complete
+type EdgeOstreeRepoCompletedEventPayload struct {
+	EdgeBasePayload
+	NewImage Image `json:"new_image"`
+}
+
+// EdgeInstallerCompletedEventPayload provides image data when an installer is complete
+type EdgeInstallerCompletedEventPayload struct {
 	EdgeBasePayload
 	NewImage Image `json:"new_image"`
 }

--- a/pkg/routes/common/identity.go
+++ b/pkg/routes/common/identity.go
@@ -4,7 +4,11 @@ package common
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
+
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
 type rhIdentityKeyType string
@@ -24,4 +28,25 @@ func GetOriginalIdentity(ctx context.Context) (string, error) {
 // SetOriginalIdentity set the original identity data to the context
 func SetOriginalIdentity(ctx context.Context, value string) context.Context {
 	return context.WithValue(ctx, rhIdentityKey, value)
+}
+
+// GetIdentityInstanceFromContext returns an instances of identity.XRHID from Base64 encoded ident in context
+func GetIdentityInstanceFromContext(ctx context.Context) (identity.XRHID, error) {
+	ident64, err := GetOriginalIdentity(ctx)
+	if err != nil {
+		return identity.XRHID{}, err
+	}
+
+	identBytes, err := base64.StdEncoding.DecodeString(ident64)
+	if err != nil {
+		return identity.XRHID{}, err
+	}
+
+	var ident identity.XRHID
+	err = json.Unmarshal(identBytes, &ident)
+	if err != nil {
+		return identity.XRHID{}, err
+	}
+
+	return ident, nil
 }

--- a/pkg/routes/common/identity_test.go
+++ b/pkg/routes/common/identity_test.go
@@ -1,0 +1,23 @@
+// FIXME: golangci-lint
+// nolint:govet,revive
+package common
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/magiconair/properties/assert"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+func TestGetIdentityInstanceFromContext(t *testing.T) {
+	identity := identity.XRHID{Identity: identity.Identity{OrgID: DefaultOrgID}}
+	identityBytes, _ := json.Marshal(identity)
+	base64Identity := base64.StdEncoding.EncodeToString(identityBytes)
+	ctx := SetOriginalIdentity(context.Background(), base64Identity)
+
+	ident, _ := GetIdentityInstanceFromContext(ctx)
+	assert.Equal(t, ident.Identity.OrgID, DefaultOrgID, "OrgIDs do not match. Identity not decoded correctly")
+}

--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -251,7 +251,7 @@ func CreateImage(w http.ResponseWriter, r *http.Request) {
 	// FALL THROUGH IF NOT EDA
 
 	// TODO: this is going to go away with EDA
-	ctxServices.ImageService.ProcessImage(image)
+	ctxServices.ImageService.ProcessImage(r.Context(), image)
 
 	ctxServices.Log.WithFields(log.Fields{
 		"imageId": image.ID,
@@ -328,7 +328,7 @@ func CreateImageUpdate(w http.ResponseWriter, r *http.Request) {
 	// FALL THROUGH IF NOT EDA
 
 	// TODO: this is going to go away with EDA
-	ctxServices.ImageService.ProcessImage(image)
+	ctxServices.ImageService.ProcessImage(r.Context(), image)
 
 	w.WriteHeader(http.StatusOK)
 	respondWithJSONBody(w, ctxServices.Log, image)
@@ -551,7 +551,7 @@ func CreateInstallerForImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	image, _, err := ctxServices.ImageService.CreateInstallerForImage(image)
+	image, _, err := ctxServices.ImageService.CreateInstallerForImage(r.Context(), image)
 	if err != nil {
 		ctxServices.Log.WithField("error", err).Error("Failed to create installer")
 		err := errors.NewInternalServerError()
@@ -568,9 +568,9 @@ func CreateRepoForImage(w http.ResponseWriter, r *http.Request) {
 	image := getImage(w, r)
 
 	go func(id uint, ctx context.Context) {
-		services := dependencies.ServicesFromContext(r.Context())
-		var i *models.Image
-		result := db.DB.Joins("Commit").Joins("Installer").First(&i, id)
+		services := dependencies.ServicesFromContext(ctx)
+		var img *models.Image
+		result := db.DB.Joins("Commit").Joins("Installer").First(&img, id)
 		if result.Error != nil {
 			services.Log.WithField("error", result.Error.Error()).Debug("Query error")
 			err := errors.NewBadRequest(result.Error.Error())
@@ -580,8 +580,8 @@ func CreateRepoForImage(w http.ResponseWriter, r *http.Request) {
 			}
 			return
 		}
-		db.DB.First(&i.Commit, i.CommitID)
-		if _, err := services.ImageService.CreateRepoForImage(i); err != nil {
+		db.DB.First(&img.Commit, img.CommitID)
+		if _, err := services.ImageService.CreateRepoForImage(ctx, img); err != nil {
 			services.Log.WithField("error", err).Error("Failed to create repo")
 		}
 	}(image.ID, r.Context())
@@ -668,7 +668,7 @@ func CheckImageName(w http.ResponseWriter, r *http.Request) {
 func RetryCreateImage(w http.ResponseWriter, r *http.Request) {
 	if image := getImage(w, r); image != nil {
 		ctxServices := dependencies.ServicesFromContext(r.Context())
-		err := ctxServices.ImageService.RetryCreateImage(image)
+		err := ctxServices.ImageService.RetryCreateImage(r.Context(), image)
 		if err != nil {
 			ctxServices.Log.WithField("error", err.Error()).Error("Failed to retry to create image")
 			err := errors.NewInternalServerError()
@@ -716,7 +716,7 @@ func ResumeCreateImage(w http.ResponseWriter, r *http.Request) {
 		// TODO: consider a bitwise& param to only add needed ctxServices
 
 		// use the new ctxServices w/ context to make the imageService.ResumeCreateImage call
-		err := ctxServices.ImageService.ResumeCreateImage(image)
+		err := ctxServices.ImageService.ResumeCreateImage(ctx, image)
 
 		// finish out the original API call
 		if err != nil {

--- a/pkg/routes/images_test.go
+++ b/pkg/routes/images_test.go
@@ -117,7 +117,7 @@ func TestCreate(t *testing.T) {
 	defer ctrl.Finish()
 	mockImageService := mock_services.NewMockImageServiceInterface(ctrl)
 	mockImageService.EXPECT().CreateImage(gomock.Any()).Return(nil)
-	mockImageService.EXPECT().ProcessImage(gomock.Any()).Return(nil)
+	mockImageService.EXPECT().ProcessImage(gomock.Any(), gomock.Any()).Return(nil)
 	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		ImageService: mockImageService,
 		Log:          log.NewEntry(log.StandardLogger()),

--- a/pkg/services/image/event_image_requested.go
+++ b/pkg/services/image/event_image_requested.go
@@ -1,3 +1,4 @@
+// Package image contains image-related EDA functions
 // FIXME: golangci-lint
 // nolint:gosimple,revive
 package image
@@ -7,12 +8,17 @@ import (
 	"encoding/base64"
 	"encoding/json"
 
-	"github.com/redhatinsights/edge-api/pkg/dependencies"
 	"github.com/redhatinsights/edge-api/pkg/routes/common"
 
 	"github.com/redhatinsights/edge-api/pkg/models"
 	log "github.com/sirupsen/logrus"
 )
+
+// imageService is the interface representation of ImageService to facilitate testing
+type imageService interface {
+	ProcessImage(context.Context, *models.Image) error
+	SetLog(log *log.Entry)
+}
 
 // EventImageRequestedBuildHandlerDummy is a dummy placeholder to workaround the Golang struct vs json fun
 type EventImageRequestedBuildHandlerDummy struct {
@@ -27,7 +33,7 @@ type EventImageRequestedBuildHandler struct {
 }
 
 // Consume executes code against the data in the received event
-func (ev EventImageRequestedBuildHandler) Consume(ctx context.Context) {
+func (ev EventImageRequestedBuildHandler) Consume(ctx context.Context, imgService imageService) {
 	eventlog := GetLoggerFromContext(ctx)
 
 	eventlog.Info("Starting image build")
@@ -46,29 +52,28 @@ func (ev EventImageRequestedBuildHandler) Consume(ctx context.Context) {
 	ctx = common.SetOriginalIdentity(ctx, base64Identity)
 
 	// temporarily using some Marshal/Unmarshal conjuring to move our future EDA image back to models.Image world
-	var image *models.Image
+	var img *models.Image
 	imageString, err := json.Marshal(payload.NewImage)
 	if err != nil {
 		eventlog.Error("Error marshaling the image")
 		return
 	}
-	err = json.Unmarshal(imageString, &image)
+	err = json.Unmarshal(imageString, &img)
 	if err != nil {
 		eventlog.Error("Error unmarshaling the image")
 		return
 	}
-	log := eventlog.WithFields(log.Fields{
-		"requestId": image.RequestID,
-		"orgID":     image.OrgID,
-	})
 
-	// get the services from the context
-	edgeAPIServices := dependencies.ServicesFromContext(ctx)
-	imageService := edgeAPIServices.ImageService
-	err = imageService.ProcessImage(image)
+	// add fields to the eventlog logger and attach it to the service
+	log := eventlog.WithFields(log.Fields{
+		"requestId": img.RequestID,
+		"orgID":     img.OrgID,
+	})
+	imgService.SetLog(log)
+
+	// process the image
+	err = imgService.ProcessImage(ctx, img)
 	if err != nil {
 		log.Error("Error processing the image")
 	}
-
-	return
 }

--- a/pkg/services/image/event_image_requested_test.go
+++ b/pkg/services/image/event_image_requested_test.go
@@ -1,0 +1,97 @@
+package image
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhatinsights/edge-api/pkg/models"
+	"github.com/redhatinsights/edge-api/pkg/routes/common"
+
+	"github.com/redhatinsights/edge-api/pkg/services/mock_services"
+	log "github.com/sirupsen/logrus"
+)
+
+var _ = Describe("Event Image Build Requested Test", func() {
+	var ctx context.Context
+	var mockImageService *mock_services.MockImageServiceInterface
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		defer ctrl.Finish()
+		mockImageService = mock_services.NewMockImageServiceInterface(ctrl)
+
+		ctx = context.Background()
+		ctx = ContextWithLogger(ctx, log.NewEntry(log.StandardLogger()))
+	})
+	Describe("consume image build event", func() {
+		When("image build is requested", func() {
+			Context("image is processed successfully", func() {
+				It("should be ok", func() {
+					image := &models.Image{
+						OrgID:        faker.UUIDHyphenated(),
+						Commit:       &models.Commit{},
+						Distribution: "rhel-90",
+						OutputTypes:  []string{models.ImageTypeInstaller},
+						Version:      1,
+						Name:         faker.Name(),
+					}
+
+					ident, err := common.GetIdentityFromContext(ctx)
+					Expect(err).To(BeNil())
+
+					edgePayload := &models.EdgeImageRequestedEventPayload{
+						EdgeBasePayload: models.EdgeBasePayload{
+							Identity:       ident,
+							LastHandleTime: time.Now().Format(time.RFC3339),
+							RequestID:      image.RequestID,
+						},
+						NewImage: *image,
+					}
+					Expect(edgePayload).ToNot(BeNil())
+
+					mockImageService.EXPECT().SetLog(gomock.Any()).Return()
+					mockImageService.EXPECT().ProcessImage(gomock.Any(), gomock.Any()).Return(nil)
+					event := &EventImageRequestedBuildHandler{}
+					event.Data = *edgePayload
+					event.Consume(ctx, mockImageService)
+				})
+				Context("image process errors", func() {
+					It("should not be ok", func() {
+						orgID := faker.UUIDHyphenated()
+
+						image := &models.Image{
+							OrgID:        orgID,
+							Commit:       &models.Commit{},
+							Distribution: "rhel-90",
+							OutputTypes:  []string{models.ImageTypeInstaller},
+							Version:      1,
+							Name:         faker.Name(),
+						}
+
+						ident, err := common.GetIdentityFromContext(ctx)
+						Expect(err).To(BeNil())
+
+						edgePayload := &models.EdgeImageRequestedEventPayload{
+							EdgeBasePayload: models.EdgeBasePayload{
+								Identity:       ident,
+								LastHandleTime: time.Now().Format(time.RFC3339),
+								RequestID:      image.RequestID,
+							},
+							NewImage: *image,
+						}
+
+						mockImageService.EXPECT().SetLog(gomock.Any()).Return()
+						mockImageService.EXPECT().ProcessImage(gomock.Any(), gomock.Any()).Return(errors.New("this failed"))
+						event := &EventImageRequestedBuildHandler{}
+						event.Data = *edgePayload
+						event.Consume(ctx, mockImageService)
+					})
+				})
+			})
+		})
+	})
+})

--- a/pkg/services/image/event_image_update_requested.go
+++ b/pkg/services/image/event_image_update_requested.go
@@ -65,7 +65,7 @@ func (ev EventImageUpdateRequestedBuildHandler) Consume(ctx context.Context) {
 	// get the services from the context
 	edgeAPIServices := dependencies.ServicesFromContext(ctx)
 	imageService := edgeAPIServices.ImageService
-	err = imageService.ProcessImage(image)
+	err = imageService.ProcessImage(ctx, image)
 	if err != nil {
 		log.Error("Error processing the image")
 	}

--- a/pkg/services/image/events.go
+++ b/pkg/services/image/events.go
@@ -2,7 +2,11 @@
 // nolint:revive
 package image
 
+import (
+	"context"
+)
+
 // EdgeMgmtImageEventInterface is the interface for the image microservice(s)
 type EdgeMgmtImageEventInterface interface {
-	Consume() error // handles the execution of code against the data in the event
+	Consume(ctx context.Context, imgService imageService) error // handles the execution of code against the data in the event
 }

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -1,3 +1,4 @@
+// Package services handles all service-related features
 // FIXME: golangci-lint
 // nolint:errcheck,gocritic,govet,revive
 package services
@@ -16,7 +17,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"text/template"
 	"time"
@@ -37,28 +37,25 @@ import (
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 )
 
-// WaitGroup is the waitg roup for pending image builds
-// FIXME: this no longer applies to images. move to devices
-var WaitGroup sync.WaitGroup
-
 // ImageServiceInterface defines the interface that helps handle
-// the business logic of creating RHEL For Edge Images
+// the business logic of creating RHEL For Edge Images.
+// This interface is used for mock generation.
 type ImageServiceInterface interface {
 	CreateImage(image *models.Image) error
-	ProcessImage(image *models.Image) error
+	ProcessImage(context.Context, *models.Image) error
 	UpdateImage(image *models.Image, previousImage *models.Image) error
 	AddUserInfo(image *models.Image) error
 	UpdateImageStatus(image *models.Image) (*models.Image, error)
 	SetErrorStatusOnImage(err error, i *models.Image)
-	CreateRepoForImage(i *models.Image) (*models.Repo, error)
-	CreateInstallerForImage(i *models.Image) (*models.Image, chan error, error)
+	CreateRepoForImage(context.Context, *models.Image) (*models.Repo, error)
+	CreateInstallerForImage(context.Context, *models.Image) (*models.Image, chan error, error)
 	GetImageByID(id string) (*models.Image, error)
 	GetUpdateInfo(image models.Image) ([]models.ImageUpdateAvailable, error)
 	AddPackageInfo(image *models.Image) (ImageDetail, error)
 	GetImageByOSTreeCommitHash(commitHash string) (*models.Image, error)
 	CheckImageName(name, orgID string) (bool, error)
-	RetryCreateImage(image *models.Image) error
-	ResumeCreateImage(image *models.Image) error
+	RetryCreateImage(context.Context, *models.Image) error
+	ResumeCreateImage(context.Context, *models.Image) error
 	GetMetadata(image *models.Image) (*models.Image, error)
 	SetFinalImageStatus(i *models.Image)
 	CheckIfIsLatestVersion(previousImage *models.Image) error
@@ -69,6 +66,7 @@ type ImageServiceInterface interface {
 	ValidateImagePackage(pack string, image *models.Image) error
 	GetImagesViewCount(tx *gorm.DB) (int64, error)
 	GetImagesView(limit int, offset int, tx *gorm.DB) (*[]models.ImageView, error)
+	SetLog(*log.Entry)
 }
 
 // NewImageService gives a instance of the main implementation of a ImageServiceInterface
@@ -230,9 +228,9 @@ func (s *ImageService) CreateImage(image *models.Image) error {
 }
 
 // ProcessImage creates an Image for an OrgID on Image Builder and on our database
-func (s *ImageService) ProcessImage(image *models.Image) error {
-	// TODO: refactor this when EDA enabled
-	go s.postProcessImage(image.ID)
+func (s *ImageService) ProcessImage(ctx context.Context, img *models.Image) error {
+
+	go s.processImage(ctx, img.ID)
 
 	return nil
 }
@@ -394,7 +392,7 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 	return nil
 }
 
-func (s *ImageService) postProcessInstaller(image *models.Image) error {
+func (s *ImageService) processInstaller(ctx context.Context, image *models.Image) error {
 	s.log.Debug("Post processing the installer for the image")
 	for {
 		i, err := s.UpdateImageStatus(image)
@@ -454,11 +452,44 @@ func (s *ImageService) postProcessInstaller(image *models.Image) error {
 	// It updates the status across the image and not just the installer
 	s.log.Debug("Setting final image status")
 	s.SetFinalImageStatus(image)
+
+	// send an installer completed event
+	if feature.ImageCompletionEventsEDA.IsEnabled() {
+		s.log.Debug("Installer completed (EDA)")
+
+		// get the identity from the context
+		ident, err := common.GetIdentityInstanceFromContext(ctx)
+		if err != nil {
+			s.log.WithField("error", err.Error()).Error("Error getting identity from context")
+		}
+
+		// create payload for event
+		edgePayload := &models.EdgeInstallerCompletedEventPayload{
+			EdgeBasePayload: models.EdgeBasePayload{
+				Identity:       ident,
+				LastHandleTime: time.Now().Format(time.RFC3339),
+				RequestID:      image.RequestID,
+			},
+			NewImage: *image,
+		}
+
+		// create the edge event
+		edgeEvent := kafkacommon.CreateEdgeEvent(ident.Identity.OrgID, models.SourceEdgeEventAPI, image.RequestID,
+			models.EventTypeEdgeInstallerCompleted, image.Name, edgePayload)
+
+		// put the event on the bus
+		if err := kafkacommon.NewProducerService().ProduceEvent(kafkacommon.TopicFleetmgmtImageBuild, models.EventTypeEdgeInstallerCompleted, edgeEvent); err != nil {
+			log.WithField("request_id", edgeEvent.ID).Error("Producing the event failed")
+
+			return err
+		}
+	}
+
 	s.log.WithField("status", image.Status).Debug("Processing image installer is done")
 	return nil
 }
 
-func (s *ImageService) postProcessCommit(image *models.Image) error {
+func (s *ImageService) processCommit(ctx context.Context, image *models.Image) error {
 	s.log.Debug("Processing image build commit")
 	for {
 		i, err := s.UpdateImageStatus(image)
@@ -474,15 +505,48 @@ func (s *ImageService) postProcessCommit(image *models.Image) error {
 	}
 
 	if image.Commit.Status == models.ImageStatusSuccess {
-		i, err := s.ImageBuilder.GetMetadata(image)
+		imageWithMetaData, err := s.ImageBuilder.GetMetadata(image)
 		if err != nil {
 			s.log.WithField("error", err.Error()).Error("Failed getting metadata from image builder")
-			s.SetErrorStatusOnImage(err, i)
+			s.SetErrorStatusOnImage(err, imageWithMetaData)
 			return err
 		}
 
+		// send a commit completed event
+		if feature.ImageCompletionEventsEDA.IsEnabled() {
+
+			// get the identity from the context
+			ident, err := common.GetIdentityInstanceFromContext(ctx)
+			if err != nil {
+				s.log.WithField("error", err.Error()).Error("Error getting identity from context")
+
+				return err
+			}
+
+			// create payload for event
+			edgePayload := &models.EdgeCommitCompletedEventPayload{
+				EdgeBasePayload: models.EdgeBasePayload{
+					Identity:       ident,
+					LastHandleTime: time.Now().Format(time.RFC3339),
+					RequestID:      image.RequestID,
+				},
+				NewImage: *image,
+			}
+
+			// create the edge event
+			edgeEvent := kafkacommon.CreateEdgeEvent(ident.Identity.OrgID, models.SourceEdgeEventAPI, image.RequestID,
+				models.EventTypeEdgeCommitCompleted, image.Name, edgePayload)
+
+			// put the event on the bus
+			if err := kafkacommon.NewProducerService().ProduceEvent(kafkacommon.TopicFleetmgmtImageBuild, models.EventTypeEdgeCommitCompleted, edgeEvent); err != nil {
+				s.log.WithField("request_id", edgeEvent.ID).Error("Producing the event failed")
+
+				return err
+			}
+		}
+
 		// Create the repo for the image
-		_, err = s.CreateRepoForImage(image)
+		_, err = s.CreateRepoForImage(ctx, image)
 		if err != nil {
 			s.log.WithField("error", err.Error()).Error("Failed creating repo for image")
 			return err
@@ -494,6 +558,7 @@ func (s *ImageService) postProcessCommit(image *models.Image) error {
 		s.SetFinalImageStatus(image)
 		s.log.Debug("Processing image is done - no installer to create")
 	}
+
 	s.log.Debug("Processing commit is done")
 	return nil
 }
@@ -546,15 +611,12 @@ func (s *ImageService) SetFinalImageStatus(i *models.Image) {
 	}
 }
 
-func (s *ImageService) postProcessImage(id uint) {
-	// NOTE: Every log message in this method already has commit id and image id injected
-
+func (s *ImageService) processImage(ctx context.Context, id uint) {
 	s.log.Debug("Processing image build")
 	var image *models.Image
 
 	// setup a context and signal for SIGTERM
-	ctx := context.Background()
-	intctx, intcancel := context.WithCancel(ctx)
+	intctx, intcancel := context.WithCancel(context.Background())
 	sigint := make(chan os.Signal, 1)
 	signal.Notify(sigint, os.Interrupt, syscall.SIGTERM)
 
@@ -594,7 +656,7 @@ func (s *ImageService) postProcessImage(id uint) {
 
 	// Monitor the commit for completion
 	s.log.WithField("imageID", image.ID).Debug("Monitoring commit status for this image")
-	err := s.postProcessCommit(image)
+	err := s.processCommit(ctx, image)
 	if err != nil {
 		if image.Status == models.ImageStatusInterrupted {
 			return
@@ -609,7 +671,7 @@ func (s *ImageService) postProcessImage(id uint) {
 		// Request an installer ISO from Image Builder for the image
 		if image.HasOutputType(models.ImageTypeInstaller) {
 			s.log.WithField("imageID", image.ID).Debug("Creating an installer for this image")
-			image, c, err := s.CreateInstallerForImage(image)
+			image, c, err := s.CreateInstallerForImage(ctx, image)
 			/* CreateInstallerForImage is also called directly from an endpoint.
 			If called from the endpoint it will not block
 				the caller returns the channel output to _
@@ -631,7 +693,7 @@ func (s *ImageService) postProcessImage(id uint) {
 }
 
 // CreateRepoForImage creates the OSTree repo to host that image
-func (s *ImageService) CreateRepoForImage(i *models.Image) (*models.Repo, error) {
+func (s *ImageService) CreateRepoForImage(ctx context.Context, img *models.Image) (*models.Repo, error) {
 	s.log.Info("Creating OSTree repo for image")
 	repo := &models.Repo{
 		Status: models.RepoStatusBuilding,
@@ -643,10 +705,10 @@ func (s *ImageService) CreateRepoForImage(i *models.Image) (*models.Repo, error)
 	s.log = s.log.WithField("repoID", repo.ID)
 	s.log.Debug("OSTree repo is created on the database")
 
-	i.Commit.Repo = repo
-	i.Commit.RepoID = &repo.ID
+	img.Commit.Repo = repo
+	img.Commit.RepoID = &repo.ID
 
-	tx = db.DB.Save(i.Commit)
+	tx = db.DB.Save(img.Commit)
 	if tx.Error != nil {
 		return nil, tx.Error
 	}
@@ -656,6 +718,41 @@ func (s *ImageService) CreateRepoForImage(i *models.Image) (*models.Repo, error)
 	if err != nil {
 		return nil, err
 	}
+
+	// send a commit completed event
+	if feature.ImageCompletionEventsEDA.IsEnabled() {
+		s.log.Debug("Repo completed (EDA)")
+
+		// get the identity from the context
+		ident, err := common.GetIdentityInstanceFromContext(ctx)
+		if err != nil {
+			s.log.WithField("error", err.Error()).Error("Error getting identity from context")
+
+			return nil, err
+		}
+
+		// create payload for event
+		edgePayload := &models.EdgeOstreeRepoCompletedEventPayload{
+			EdgeBasePayload: models.EdgeBasePayload{
+				Identity:       ident,
+				LastHandleTime: time.Now().Format(time.RFC3339),
+				RequestID:      img.RequestID,
+			},
+			NewImage: *img,
+		}
+
+		// create the edge event
+		edgeEvent := kafkacommon.CreateEdgeEvent(ident.Identity.OrgID, models.SourceEdgeEventAPI,
+			img.RequestID, models.EventTypeEdgeOstreeRepoCompleted, img.Name, edgePayload)
+
+		// put the event on the bus
+		if err := kafkacommon.NewProducerService().ProduceEvent(kafkacommon.TopicFleetmgmtImageBuild, models.EventTypeEdgeOstreeRepoCompleted, edgeEvent); err != nil {
+			log.WithField("request_id", edgeEvent.ID).Error("Producing the event failed")
+
+			return nil, err
+		}
+	}
+
 	s.log.Info("OSTree repo is ready")
 
 	return repo, nil
@@ -1065,7 +1162,7 @@ func (s *ImageService) GetImageByOSTreeCommitHash(commitHash string) (*models.Im
 }
 
 // RetryCreateImage retries the whole post process of the image creation
-func (s *ImageService) RetryCreateImage(image *models.Image) error {
+func (s *ImageService) RetryCreateImage(ctx context.Context, image *models.Image) error {
 	s.log = s.log.WithFields(log.Fields{"imageID": image.ID, "commitID": image.Commit.ID})
 	// recompose commit
 	image, err := s.ImageBuilder.ComposeCommit(image)
@@ -1078,7 +1175,7 @@ func (s *ImageService) RetryCreateImage(image *models.Image) error {
 		s.log.WithField("error", err.Error()).Error("Failed setting image status")
 		return nil
 	}
-	go s.postProcessImage(image.ID)
+	go s.processImage(ctx, image.ID)
 	return nil
 }
 
@@ -1119,7 +1216,7 @@ func (s *ImageService) setInstallerStatus(image *models.Image, status string) er
 }
 
 // ResumeCreateImage retries the whole post process of the image creation
-func (s *ImageService) ResumeCreateImage(image *models.Image) error {
+func (s *ImageService) ResumeCreateImage(ctx context.Context, image *models.Image) error {
 	// add additional information to all log entries in this pipeline
 	s.log = s.log.WithField("originalRequestId", image.RequestID)
 	s.log = s.log.WithField("imageID", image.ID)
@@ -1131,20 +1228,19 @@ func (s *ImageService) ResumeCreateImage(image *models.Image) error {
 	}
 
 	// go routine so we can return to the API caller ASAP
-	go s.resumeProcessImage(image)
+	go s.resumeProcessImage(ctx, image)
 
 	return nil
 }
 
-func (s *ImageService) resumeProcessImage(image *models.Image) {
+func (s *ImageService) resumeProcessImage(ctx context.Context, image *models.Image) {
 	// NOTE: Every log message in this method already has commit id and image id injected
 	s.log.Debug("Processing image build from where it was interrupted")
 
 	id := image.ID
 
 	// setup a context and signal for SIGTERM
-	ctx := context.Background()
-	intctx, intcancel := context.WithCancel(ctx)
+	intctx, intcancel := context.WithCancel(context.Background())
 	sigint := make(chan os.Signal, 1)
 	signal.Notify(sigint, os.Interrupt, syscall.SIGTERM)
 
@@ -1185,7 +1281,7 @@ func (s *ImageService) resumeProcessImage(image *models.Image) {
 	if image.Commit.Status != models.ImageStatusSuccess {
 		// Request a commit from Image Builder for the image
 		s.log.Debug("Creating a commit for this image")
-		err := s.postProcessCommit(image)
+		err := s.processCommit(ctx, image)
 		if err != nil {
 			if image.Status == models.ImageStatusInterrupted {
 				return
@@ -1208,7 +1304,7 @@ func (s *ImageService) resumeProcessImage(image *models.Image) {
 
 		// Create the repo for the image
 		if image.Commit.Repo.Status != models.RepoStatusSuccess {
-			_, err := s.CreateRepoForImage(image)
+			_, err := s.CreateRepoForImage(ctx, image)
 			if err != nil {
 				s.log.WithField("error", err.Error()).Error("Failed creating repo for image")
 				return
@@ -1231,7 +1327,7 @@ func (s *ImageService) resumeProcessImage(image *models.Image) {
 		// skip if already set to success
 		if image.HasOutputType(models.ImageTypeInstaller) && image.Installer.Status != models.ImageStatusSuccess {
 			s.log.WithField("imageID", image.ID).Debug("Creating an installer for this image")
-			image2, c, err := s.CreateInstallerForImage(image)
+			image2, c, err := s.CreateInstallerForImage(ctx, image)
 			/* CreateInstallerForImage is also called directly from an endpoint.
 			If called from the endpoint it will not block
 				the caller returns the channel output to _
@@ -1373,7 +1469,7 @@ func (s *ImageService) GetMetadata(image *models.Image) (*models.Image, error) {
 }
 
 // CreateInstallerForImage creates a installer given an existing image
-func (s *ImageService) CreateInstallerForImage(image *models.Image) (*models.Image, chan error, error) {
+func (s *ImageService) CreateInstallerForImage(ctx context.Context, image *models.Image) (*models.Image, chan error, error) {
 	s.log.Debug("Creating installer for image")
 	c := make(chan error)
 
@@ -1394,7 +1490,7 @@ func (s *ImageService) CreateInstallerForImage(image *models.Image) (*models.Ima
 		return nil, c, err
 	}
 	go func(chan error) {
-		err := s.postProcessInstaller(image)
+		err := s.processInstaller(ctx, image)
 		c <- err
 	}(c)
 	return image, c, nil

--- a/pkg/services/images_build/main.go
+++ b/pkg/services/images_build/main.go
@@ -1,5 +1,5 @@
 // FIXME: golangci-lint
-// nolint:govet,revive,typecheck
+// nolint:govet,revive
 package main
 
 import (
@@ -13,6 +13,7 @@ import (
 	kafkacommon "github.com/redhatinsights/edge-api/pkg/common/kafka"
 	"github.com/redhatinsights/edge-api/pkg/dependencies"
 	"github.com/redhatinsights/edge-api/pkg/models"
+	"github.com/redhatinsights/edge-api/pkg/services"
 	"github.com/redhatinsights/edge-api/pkg/services/image"
 	log "github.com/sirupsen/logrus"
 
@@ -123,7 +124,8 @@ func main() {
 						ctx = image.ContextWithLogger(ctx, mslog)
 
 						// call the event's Consume method
-						go crcEvent.Consume(ctx)
+						imageService := services.NewImageService(ctx, mslog)
+						go crcEvent.Consume(ctx, imageService)
 					case models.EventTypeEdgeImageUpdateRequested:
 						crcEvent := &image.EventImageUpdateRequestedBuildHandler{}
 						err = json.Unmarshal(e.Value, crcEvent)

--- a/pkg/services/mock_services/images.go
+++ b/pkg/services/mock_services/images.go
@@ -5,11 +5,13 @@
 package mock_services
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/redhatinsights/edge-api/pkg/models"
 	services "github.com/redhatinsights/edge-api/pkg/services"
+	logrus "github.com/sirupsen/logrus"
 	gorm "gorm.io/gorm"
 )
 
@@ -109,9 +111,9 @@ func (mr *MockImageServiceInterfaceMockRecorder) CreateImage(image interface{}) 
 }
 
 // CreateInstallerForImage mocks base method.
-func (m *MockImageServiceInterface) CreateInstallerForImage(i *models.Image) (*models.Image, chan error, error) {
+func (m *MockImageServiceInterface) CreateInstallerForImage(arg0 context.Context, arg1 *models.Image) (*models.Image, chan error, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateInstallerForImage", i)
+	ret := m.ctrl.Call(m, "CreateInstallerForImage", arg0, arg1)
 	ret0, _ := ret[0].(*models.Image)
 	ret1, _ := ret[1].(chan error)
 	ret2, _ := ret[2].(error)
@@ -119,24 +121,24 @@ func (m *MockImageServiceInterface) CreateInstallerForImage(i *models.Image) (*m
 }
 
 // CreateInstallerForImage indicates an expected call of CreateInstallerForImage.
-func (mr *MockImageServiceInterfaceMockRecorder) CreateInstallerForImage(i interface{}) *gomock.Call {
+func (mr *MockImageServiceInterfaceMockRecorder) CreateInstallerForImage(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstallerForImage", reflect.TypeOf((*MockImageServiceInterface)(nil).CreateInstallerForImage), i)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstallerForImage", reflect.TypeOf((*MockImageServiceInterface)(nil).CreateInstallerForImage), arg0, arg1)
 }
 
 // CreateRepoForImage mocks base method.
-func (m *MockImageServiceInterface) CreateRepoForImage(i *models.Image) (*models.Repo, error) {
+func (m *MockImageServiceInterface) CreateRepoForImage(arg0 context.Context, arg1 *models.Image) (*models.Repo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRepoForImage", i)
+	ret := m.ctrl.Call(m, "CreateRepoForImage", arg0, arg1)
 	ret0, _ := ret[0].(*models.Repo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateRepoForImage indicates an expected call of CreateRepoForImage.
-func (mr *MockImageServiceInterfaceMockRecorder) CreateRepoForImage(i interface{}) *gomock.Call {
+func (mr *MockImageServiceInterfaceMockRecorder) CreateRepoForImage(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRepoForImage", reflect.TypeOf((*MockImageServiceInterface)(nil).CreateRepoForImage), i)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRepoForImage", reflect.TypeOf((*MockImageServiceInterface)(nil).CreateRepoForImage), arg0, arg1)
 }
 
 // GetImageByID mocks base method.
@@ -245,45 +247,45 @@ func (mr *MockImageServiceInterfaceMockRecorder) GetUpdateInfo(image interface{}
 }
 
 // ProcessImage mocks base method.
-func (m *MockImageServiceInterface) ProcessImage(image *models.Image) error {
+func (m *MockImageServiceInterface) ProcessImage(arg0 context.Context, arg1 *models.Image) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessImage", image)
+	ret := m.ctrl.Call(m, "ProcessImage", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ProcessImage indicates an expected call of ProcessImage.
-func (mr *MockImageServiceInterfaceMockRecorder) ProcessImage(image interface{}) *gomock.Call {
+func (mr *MockImageServiceInterfaceMockRecorder) ProcessImage(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessImage", reflect.TypeOf((*MockImageServiceInterface)(nil).ProcessImage), image)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessImage", reflect.TypeOf((*MockImageServiceInterface)(nil).ProcessImage), arg0, arg1)
 }
 
 // ResumeCreateImage mocks base method.
-func (m *MockImageServiceInterface) ResumeCreateImage(image *models.Image) error {
+func (m *MockImageServiceInterface) ResumeCreateImage(arg0 context.Context, arg1 *models.Image) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResumeCreateImage", image)
+	ret := m.ctrl.Call(m, "ResumeCreateImage", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ResumeCreateImage indicates an expected call of ResumeCreateImage.
-func (mr *MockImageServiceInterfaceMockRecorder) ResumeCreateImage(image interface{}) *gomock.Call {
+func (mr *MockImageServiceInterfaceMockRecorder) ResumeCreateImage(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResumeCreateImage", reflect.TypeOf((*MockImageServiceInterface)(nil).ResumeCreateImage), image)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResumeCreateImage", reflect.TypeOf((*MockImageServiceInterface)(nil).ResumeCreateImage), arg0, arg1)
 }
 
 // RetryCreateImage mocks base method.
-func (m *MockImageServiceInterface) RetryCreateImage(image *models.Image) error {
+func (m *MockImageServiceInterface) RetryCreateImage(arg0 context.Context, arg1 *models.Image) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RetryCreateImage", image)
+	ret := m.ctrl.Call(m, "RetryCreateImage", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RetryCreateImage indicates an expected call of RetryCreateImage.
-func (mr *MockImageServiceInterfaceMockRecorder) RetryCreateImage(image interface{}) *gomock.Call {
+func (mr *MockImageServiceInterfaceMockRecorder) RetryCreateImage(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetryCreateImage", reflect.TypeOf((*MockImageServiceInterface)(nil).RetryCreateImage), image)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetryCreateImage", reflect.TypeOf((*MockImageServiceInterface)(nil).RetryCreateImage), arg0, arg1)
 }
 
 // SendImageNotification mocks base method.
@@ -351,6 +353,18 @@ func (m *MockImageServiceInterface) SetFinalImageStatus(i *models.Image) {
 func (mr *MockImageServiceInterfaceMockRecorder) SetFinalImageStatus(i interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFinalImageStatus", reflect.TypeOf((*MockImageServiceInterface)(nil).SetFinalImageStatus), i)
+}
+
+// SetLog mocks base method.
+func (m *MockImageServiceInterface) SetLog(arg0 *logrus.Entry) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetLog", arg0)
+}
+
+// SetLog indicates an expected call of SetLog.
+func (mr *MockImageServiceInterfaceMockRecorder) SetLog(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLog", reflect.TypeOf((*MockImageServiceInterface)(nil).SetLog), arg0)
 }
 
 // UpdateImage mocks base method.

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -21,3 +21,8 @@ type ServiceInterface interface{}
 func NewService(ctx context.Context, log *log.Entry) Service {
 	return Service{ctx: ctx, log: log}
 }
+
+// SetLog sets a new log on the struct
+func (s *Service) SetLog(log *log.Entry) {
+	s.log = log
+}

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -1,3 +1,4 @@
+// Package services handles all service-related features
 // FIXME: golangci-lint
 // nolint:errcheck,gocritic,govet,revive
 package services
@@ -12,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"sync"
 	"syscall"
 	"text/template"
 	"time"
@@ -29,6 +31,9 @@ import (
 	"github.com/redhatinsights/edge-api/pkg/routes/common"
 	log "github.com/sirupsen/logrus"
 )
+
+// WaitGroup is the waitgroup for pending updates
+var WaitGroup sync.WaitGroup
 
 // UpdateServiceInterface defines the interface that helps
 // handle the business logic of sending updates to a edge device

--- a/podman/Containerfile-dev
+++ b/podman/Containerfile-dev
@@ -1,7 +1,7 @@
 ############################################
 # STEP 1: build executable edge-api binaries
 ############################################
-FROM registry.access.redhat.com/ubi8/go-toolset:latest
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18.4-8
 #WORKDIR $GOPATH/src/github.com/RedHatInsights/edge-api/
 COPY . .
 # Use go mod

--- a/podman/container-compose-api.yml
+++ b/podman/container-compose-api.yml
@@ -3,26 +3,30 @@ secrets:
   edgemgmt_config:
     file: $PWD/podman/env/edgemgmt_config.json
 services:
-    edge-api-service:
-      container_name: edge-api-service
-      image: localhost/edge-api:localdev
-      restart: unless-stopped
-      privileged: true
-      ports:
-        - 3000:3000
-      env_file:
-        - env/edge-api.env
-      volumes:
-        - $PWD:/opt/app-root/src:z
-        - $HOME/go:/go
-
-      command: ["go", "run", "main.go"]
-      secrets:
-        - source: edgemgmt_config
-          target: /tmp/edgemgmt_config.json
-      depends_on:
-        - "postgresql"
-        - "kafka"
+  edge-api-service:
+    container_name: edge-api-service
+    image: localhost/edge-api:localdev
+    restart: unless-stopped
+    privileged: true
+    ports:
+      - 3000:3000
+    env_file:
+      - env/edge-api.env
+    volumes:
+      - $PWD:/opt/app-root/src:z
+      - $HOME/go:/go
+      - $HOME/repos/:/tmp/repos:z
+    command: ["go", "run", "main.go"]
+    secrets:
+      - source: edgemgmt_config
+        target: /tmp/edgemgmt_config.json
+    depends_on:
+      - "postgresql"
+      - "kafka"
+    deploy:
+      resources:
+        limits:
+          memory: 4G
 
 #    edge-api-utility:
 #      image: localhost/edge-api:localdev

--- a/podman/container-compose-db.yml
+++ b/podman/container-compose-db.yml
@@ -1,12 +1,16 @@
 version: '2'
 services:
-    postgresql:
-      container_name: postgresql
-      image: registry.redhat.io/rhel8/postgresql-10:1-173.1647451846
-      restart: unless-stopped
-      ports:
-        - 5432:5432
-      env_file:
-        - env/edge-api.env
-      volumes:
-        - ~/dev/postgresql:/var/lib/pgsql:Z
+  postgresql:
+    container_name: postgresql
+    image: registry.redhat.io/rhel8/postgresql-10:1-173.1647451846
+    restart: unless-stopped
+    ports:
+      - 5432:5432
+    env_file:
+      - env/edge-api.env
+    volumes:
+      - ~/dev/postgresql:/var/lib/pgsql:Z
+    deploy:
+      resources:
+        limits:
+          memory: 1G

--- a/podman/container-compose-kafka.yml
+++ b/podman/container-compose-kafka.yml
@@ -21,6 +21,10 @@ services:
     volumes:
        - ~/dev/kafkadata/logs:/tmp/logs:z
        - ~/dev/kafkadata/kraft-combined-logs:/tmp/kraft-combined-logs:z
+    deploy:
+      resources:
+        limits:
+          memory: 4G
 
   kafka-ui:
     container_name: kafka-ui
@@ -33,3 +37,7 @@ services:
       - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:9092
     depends_on:
       - "kafka"
+    deploy:
+      resources:
+        limits:
+          memory: 1G

--- a/podman/container-compose-services.yml
+++ b/podman/container-compose-services.yml
@@ -14,41 +14,50 @@ secrets:
   edgemgmt_config:
     file: $PWD/podman/env/edgemgmt_config.json
 services:
-    edge-api-images-build:
-      container_name: edge-api-images-build
-      image: localhost/edge-api:localdev
-      restart: unless-stopped
-      privileged: true
-      env_file:
-        - env/edge-api.env
-      volumes:
-        - $PWD:/opt/app-root/src:z
-        - $HOME/go:/go
-      command: go run /opt/app-root/src/pkg/services/images_build/main.go
-      secrets:
-        - source: edgemgmt_config
-          target: /tmp/edgemgmt_config.json
-      depends_on:
-        - "kafka"
-        - "db"
-        - "edge-api-service"
+  edge-api-images-build:
+    container_name: edge-api-images-build
+    image: localhost/edge-api:localdev
+    restart: unless-stopped
+    privileged: true
+    env_file:
+      - env/edge-api.env
+    volumes:
+      - $PWD:/opt/app-root/src:z
+      - $HOME/go:/go
+      - $HOME/repos/:/tmp/repos:z
+    command: go run /opt/app-root/src/pkg/services/images_build/main.go
+    secrets:
+      - source: edgemgmt_config
+        target: /tmp/edgemgmt_config.json
+    depends_on:
+      - "kafka"
+      - "db"
+      - "edge-api-service"
+    deploy:
+      resources:
+        limits:
+          memory: 4G
 
-    edge-api-utility:
-      container_name: edge-api-utility
-      image: localhost/edge-api:localdev
-      restart: unless-stopped
-      privileged: true
-      env_file:
-        - env/edge-api.env
+  edge-api-utility:
+    container_name: edge-api-utility
+    image: localhost/edge-api:localdev
+    restart: unless-stopped
+    privileged: true
+    env_file:
+      - env/edge-api.env
 #      depends-on: postgresql
-      volumes:
-        - $PWD:/opt/app-root/src:z
-        - $HOME/go:/go
-      #working_dir: /opt/app-root/src
-      command: go run /opt/app-root/src/cmd/kafka/main.go
-      secrets:
-        - source: edgemgmt_config
-          target: /tmp/edgemgmt_config.json
+    volumes:
+      - $PWD:/opt/app-root/src:z
+      - $HOME/go:/go
+    #working_dir: /opt/app-root/src
+    command: go run /opt/app-root/src/cmd/kafka/main.go
+    secrets:
+      - source: edgemgmt_config
+        target: /tmp/edgemgmt_config.json
+    deploy:
+      resources:
+        limits:
+          memory: 500M
 
 #    edge-api-images-iso:
 #      image: localhost/edge-api:localdev

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -47,6 +47,9 @@ var ImageCreateKickstartEDA = &Flag{Name: "", EnvVar: "FEATURE_IMAGECREATE_KICKS
 // ImageCreateRepoEDA is the feature flag for routes.CreateRepo() EDA code
 var ImageCreateRepoEDA = &Flag{Name: "", EnvVar: "FEATURE_IMAGECREATE_REPO"}
 
+// ImageCompletionEventsEDA is the feature flag for routes.CreateRepo() EDA code
+var ImageCompletionEventsEDA = &Flag{Name: "edge-management.completion_events", EnvVar: "FEATURE_COMPLETION_EVENTS"}
+
 // ImageCreateISOEDA is the feature flag for routes.CreateCommit() EDA code
 var ImageCreateISOEDA = &Flag{Name: "edge-management.image_create_iso", EnvVar: "FEATURE_IMAGECREATE_ISO"}
 


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Add image step completion producers to service.Images for commit, repo, and installer.
Add context as first parameter of related imageservice methods.
NOTE: that is to pass the context with identity all the way through an event-driven request.
Add common.GetIdentityInstanceFromContext(ctx) to include identity in produced events.
Add test for new function GetIdentityInstanceFromContext(ctx).
Renamed postProcessX() methods to processX() for clarity (e.g., they are just processing not post processing)
Add a new interface for ImageService.ProcessImage().
Add test pkg/services/image/event_image_requested_test.go

NOTE: the three new producers are being moved to the utility microservice, so they will be condensed into a more functional single helper on the image package side in, not the next PR, but the one after that (i.e., the last one).

Fixes # (issue) THEEDGE-2261

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
