### PR TITLE
[THEEDGE-2844] fixed image-set view sort_by params

### DIFF
--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -29,6 +29,7 @@ type imageSetImageTypeKey int
 const imageSetKey imageSetTypeKey = iota
 const imageSetImageKey imageSetImageTypeKey = iota
 
+var sortImageSetImageOption = []string{"created_at", "name", "version"}
 var sortOption = []string{"created_at", "updated_at", "name"}
 var statusOption = []string{models.ImageStatusCreated, models.ImageStatusBuilding, models.ImageStatusError, models.ImageStatusSuccess}
 
@@ -40,7 +41,7 @@ func MakeImageSetsRouter(sub chi.Router) {
 		r.Use(ImageSetCtx)
 		r.With(validateFilterParams).With(common.Paginate).Get("/", GetImageSetsByID)
 	})
-	sub.With(validateFilterParams).Route("/view/{imageSetID}", func(r chi.Router) {
+	sub.With(ValidateQueryParams("imagesetimageview")).With(validateFilterParams).Route("/view/{imageSetID}", func(r chi.Router) {
 		r.Use(ImageSetViewCtx)
 		r.With(ValidateGetAllImagesSearchParams).With(common.Paginate).Get("/", GetImageSetViewByID)
 		r.With(ValidateGetAllImagesSearchParams).With(common.Paginate).Get("/versions", GetAllImageSetImagesView)
@@ -347,8 +348,14 @@ func validateFilterParams(next http.Handler) http.Handler {
 			if string(val[0]) == "-" {
 				name = val[1:]
 			}
-			if !contains(sortOption, name) {
-				errs = append(errs, common.ValidationError{Key: "sort_by", Reason: fmt.Sprintf("%s is not a valid sort_by. Sort-by must %v", name, strings.Join(sortOption, " or "))})
+			if strings.Contains(r.URL.RequestURI(), "/view/") {
+				if !contains(sortImageSetImageOption, name) {
+					errs = append(errs, common.ValidationError{Key: "sort_by", Reason: fmt.Sprintf("%s is not a valid sort_by. Sort-by must %v", name, strings.Join(sortImageSetImageOption, " or "))})
+				}
+			} else {
+				if !contains(sortOption, name) {
+					errs = append(errs, common.ValidationError{Key: "sort_by", Reason: fmt.Sprintf("%s is not a valid sort_by. Sort-by must %v", name, strings.Join(sortOption, " or "))})
+				}
 			}
 		}
 

--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -41,13 +41,13 @@ func MakeImageSetsRouter(sub chi.Router) {
 		r.Use(ImageSetCtx)
 		r.With(validateFilterParams).With(common.Paginate).Get("/", GetImageSetsByID)
 	})
-	sub.With(ValidateQueryParams("imagesetimageview")).With(validateFilterParams).Route("/view/{imageSetID}", func(r chi.Router) {
+	sub.Route("/view/{imageSetID}", func(r chi.Router) {
 		r.Use(ImageSetViewCtx)
-		r.With(ValidateGetAllImagesSearchParams).With(common.Paginate).Get("/", GetImageSetViewByID)
-		r.With(ValidateGetAllImagesSearchParams).With(common.Paginate).Get("/versions", GetAllImageSetImagesView)
+		r.With(ValidateQueryParams("imagesetimageview")).With(validateFilterParams).With(common.Paginate).Get("/", GetImageSetViewByID)
+		r.With(ValidateQueryParams("imagesetimageview")).With(validateFilterParams).With(common.Paginate).Get("/versions", GetAllImageSetImagesView)
 		r.Route("/versions/{imageID}", func(rVersion chi.Router) {
 			rVersion.Use(ImageSetImageViewCtx)
-			rVersion.Get("/", GetImageSetImageView)
+			rVersion.With(ValidateQueryParams("imagesetimageview")).With(validateFilterParams).Get("/", GetImageSetImageView)
 		})
 	})
 }

--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -43,11 +43,11 @@ func MakeImageSetsRouter(sub chi.Router) {
 	})
 	sub.Route("/view/{imageSetID}", func(r chi.Router) {
 		r.Use(ImageSetViewCtx)
-		r.With(ValidateQueryParams("imagesetimageview")).With(validateFilterParams).With(common.Paginate).Get("/", GetImageSetViewByID)
-		r.With(ValidateQueryParams("imagesetimageview")).With(validateFilterParams).With(common.Paginate).Get("/versions", GetAllImageSetImagesView)
+		r.With(ValidateQueryParams("imagesetimageview")).With(validateImageFilterParams).With(common.Paginate).Get("/", GetImageSetViewByID)
+		r.With(ValidateQueryParams("imagesetimageview")).With(validateImageFilterParams).With(common.Paginate).Get("/versions", GetAllImageSetImagesView)
 		r.Route("/versions/{imageID}", func(rVersion chi.Router) {
 			rVersion.Use(ImageSetImageViewCtx)
-			rVersion.With(ValidateQueryParams("imagesetimageview")).With(validateFilterParams).Get("/", GetImageSetImageView)
+			rVersion.With(ValidateQueryParams("imagesetimageview")).With(validateImageFilterParams).Get("/", GetImageSetImageView)
 		})
 	})
 }
@@ -348,14 +348,8 @@ func validateFilterParams(next http.Handler) http.Handler {
 			if string(val[0]) == "-" {
 				name = val[1:]
 			}
-			if strings.Contains(r.URL.RequestURI(), "/view/") {
-				if !contains(sortImageSetImageOption, name) {
-					errs = append(errs, common.ValidationError{Key: "sort_by", Reason: fmt.Sprintf("%s is not a valid sort_by. Sort-by must %v", name, strings.Join(sortImageSetImageOption, " or "))})
-				}
-			} else {
-				if !contains(sortOption, name) {
-					errs = append(errs, common.ValidationError{Key: "sort_by", Reason: fmt.Sprintf("%s is not a valid sort_by. Sort-by must %v", name, strings.Join(sortOption, " or "))})
-				}
+			if !contains(sortOption, name) {
+				errs = append(errs, common.ValidationError{Key: "sort_by", Reason: fmt.Sprintf("%s is not a valid sort_by. Sort-by must %v", name, strings.Join(sortOption, " or "))})
 			}
 		}
 
@@ -366,10 +360,83 @@ func validateFilterParams(next http.Handler) http.Handler {
 			}
 		}
 
+		if val := r.URL.Query().Get("limit"); val != "" {
+			_, err := strconv.Atoi(val)
+			if err != nil {
+				errs = append(errs, common.ValidationError{Key: "limit", Reason: fmt.Sprintf("%s is not a valid limit type, limit must be an integer", val)})
+			}
+
+		}
+
+		if val := r.URL.Query().Get("offset"); val != "" {
+			_, err := strconv.Atoi(val)
+			if err != nil {
+				errs = append(errs, common.ValidationError{Key: "offset", Reason: fmt.Sprintf("%s is not a valid offset type, offset must be an integer", val)})
+			}
+
+		}
+
 		if val := r.URL.Query().Get("id"); val != "" {
 			_, err := strconv.Atoi(val)
 			if err != nil {
 				errs = append(errs, common.ValidationError{Key: "id", Reason: fmt.Sprintf("%s is not a valid id type, id must be an integer", val)})
+			}
+
+		}
+
+		if len(errs) == 0 {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		w.WriteHeader(http.StatusBadRequest)
+		if err := json.NewEncoder(w).Encode(&errs); err != nil {
+			services := dependencies.ServicesFromContext(r.Context())
+			services.Log.WithField("error", errs).Error("Error while trying to encode")
+		}
+	})
+}
+
+func validateImageFilterParams(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		errs := []common.ValidationError{}
+		if statuses, ok := r.URL.Query()["status"]; ok {
+			for _, status := range statuses {
+				if !contains(statusOption, strings.ToUpper(status)) {
+					errs = append(errs, common.ValidationError{Key: "status", Reason: fmt.Sprintf("%s is not a valid status. Status must be %s", status, strings.Join(validStatuses, " or "))})
+				}
+			}
+		}
+		if val := r.URL.Query().Get("sort_by"); val != "" {
+			name := val
+			if string(val[0]) == "-" {
+				name = val[1:]
+			}
+			if !contains(sortImageSetImageOption, name) {
+				errs = append(errs, common.ValidationError{Key: "sort_by", Reason: fmt.Sprintf("%s is not a valid sort_by. Sort-by must %v", name, strings.Join(sortImageSetImageOption, " or "))})
+			}
+		}
+
+		if val := r.URL.Query().Get("version"); val != "" {
+			_, err := strconv.Atoi(val)
+			if err != nil {
+				errs = append(errs, common.ValidationError{Key: "version", Reason: fmt.Sprintf("%s is not a valid version type, version must be number", val)})
+			}
+		}
+
+		if val := r.URL.Query().Get("limit"); val != "" {
+			_, err := strconv.Atoi(val)
+			if err != nil {
+				errs = append(errs, common.ValidationError{Key: "limit", Reason: fmt.Sprintf("%s is not a valid limit type, limit must be an integer", val)})
+			}
+
+		}
+
+		if val := r.URL.Query().Get("offset"); val != "" {
+			_, err := strconv.Atoi(val)
+			if err != nil {
+				errs = append(errs, common.ValidationError{Key: "offset", Reason: fmt.Sprintf("%s is not a valid offset type, offset must be an integer", val)})
 			}
 
 		}

--- a/pkg/routes/query_params.go
+++ b/pkg/routes/query_params.go
@@ -24,6 +24,7 @@ func initalizeQueryParamsArray() map[string][]string {
 		m["image-sets"] = []string{"id", "limit", "offset", "status", "name", "version", "sort_by"}
 		m["thirdpartyrepo"] = []string{"limit", "offset", "name", "created_at", "updated_at", "imageID", "sort_by"}
 		m["updates"] = []string{"limit", "offset", "created_at", "updated_at", "status", "sort_by"}
+		m["imagesetimageview"] = []string{"limit", "offset", "version", "status", "sort_by"}
 	}
 	return m
 }


### PR DESCRIPTION
# Description

the image-sets routes were not validating the query params correctly, for some of the endpoints it was not validated at all and for others it did not do it correctly.

to resolve this i had to split `sortOption` to two different variables and use the one corresponding to endpoint being tested in `validateFilterParams`

also added unit-tests for the query params in general and sort_by specifically 

Fixes # (issue)
[THEEDGE-2844](https://issues.redhat.com/browse/THEEDGE-2844)
## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
