### PR TITLE
image-builder: use storage/images-repos/{imageID} end-point in image-builder requests.

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -340,15 +340,23 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 		}
 	}
 	if previousSuccessfulImage != nil {
-		// Always get the repo URL from the previous successful Image's commit
-		repo, err := s.RepoService.GetRepoByID(previousSuccessfulImage.Commit.RepoID)
-		if err != nil {
-			s.log.WithField("error", err.Error()).Error("Commit repo wasn't found on the database")
-			err := errors.NewBadRequest(fmt.Sprintf("Commit repo wasn't found in the database: #%v", image.Commit.ID))
-			return err
+		if feature.StorageImagesRepos.IsEnabled() {
+			image.Commit.OSTreeParentCommit = fmt.Sprintf(
+				"%s/api/edge/v1/storage/images-repos/%d",
+				config.Get().EdgeCertAPIBaseURL,
+				previousSuccessfulImage.ID,
+			)
+		} else {
+			// Always get the repo URL from the previous successful Image's commit
+			repo, err := s.RepoService.GetRepoByID(previousSuccessfulImage.Commit.RepoID)
+			if err != nil {
+				s.log.WithField("error", err.Error()).Error("Commit repo wasn't found on the database")
+				err := errors.NewBadRequest(fmt.Sprintf("Commit repo wasn't found in the database: #%v", image.Commit.ID))
+				return err
+			}
+			image.Commit.OSTreeParentCommit = repo.URL
 		}
 
-		image.Commit.OSTreeParentCommit = repo.URL
 		if config.DistributionsRefs[previousSuccessfulImage.Distribution] != config.DistributionsRefs[image.Distribution] {
 			image.Commit.ChangesRefs = true
 		}

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -64,6 +64,9 @@ var DeviceSyncCreate = &Flag{Name: "edge-management.device_sync_create", EnvVar:
 // DeviceSyncDelete is the feature flag for routes.CreateImageUpdate() EDA code
 var DeviceSyncDelete = &Flag{Name: "edge-management.device_sync_delete", EnvVar: "DEVICE_SYNC_DELETE"}
 
+// StorageImagesRepos is the feature flag to use storage.images-repos when updating images or creating ISO artifacts
+var StorageImagesRepos = &Flag{Name: "edge-management.storage_images_repos", EnvVar: "STORAGE_IMAGES_REPOS"}
+
 // (ADD FEATURE FLAGS ABOVE)
 // FEATURE FLAG CHECK CODE
 


### PR DESCRIPTION
Fixes THEEDGE-2730.

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [X] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
