### PR TITLE
removed query validation from GetImageSetViewByID

### DIFF
--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -912,31 +912,6 @@ paths:
           description: the image-set id
           schema:
             type: integer
-        - name: sort_by
-          in: query
-          description: "Define sort fields: created_at, version, To sort DESC use -"
-          schema:
-            type: string
-        - name: status
-          in: query
-          description: "field: filter by status"
-          schema:
-            type: string
-        - name: version
-          in: query
-          description: 'field: filter by version'
-          schema:
-            type: string
-        - name: limit
-          in: query
-          description: "field: return number of images until limit is reached. Default is 100."
-          schema:
-            type: integer
-        - name: offset
-          in: query
-          description: "field: return number of images beginning at the offset."
-          schema:
-            type: integer
       responses:
         "200":
           content:

--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -43,7 +43,7 @@ func MakeImageSetsRouter(sub chi.Router) {
 	})
 	sub.Route("/view/{imageSetID}", func(r chi.Router) {
 		r.Use(ImageSetViewCtx)
-		r.With(ValidateQueryParams("imagesetimageview")).With(validateImageFilterParams).With(common.Paginate).Get("/", GetImageSetViewByID)
+		r.Get("/", GetImageSetViewByID)
 		r.With(ValidateQueryParams("imagesetimageview")).With(validateImageFilterParams).With(common.Paginate).Get("/versions", GetAllImageSetImagesView)
 		r.Route("/versions/{imageID}", func(rVersion chi.Router) {
 			rVersion.Use(ImageSetImageViewCtx)

--- a/pkg/routes/imagesets_test.go
+++ b/pkg/routes/imagesets_test.go
@@ -730,7 +730,7 @@ var _ = Describe("ImageSets Route Test", func() {
 		Context("imageSetIDView", func() {
 
 			It("The imageSetView end point is working as expected", func() {
-				req, err := http.NewRequest("GET", fmt.Sprintf("/image-sets/view/%d?limit=30&offset=0", imageSet1.ID), nil)
+				req, err := http.NewRequest("GET", fmt.Sprintf("/image-sets/view/%d", imageSet1.ID), nil)
 				Expect(err).ToNot(HaveOccurred())
 				mockImageSetService.EXPECT().GetImageSetViewByID(imageSet1.ID, 30, 0, gomock.Any()).Return(&services.ImageSetIDView{}, nil)
 
@@ -755,60 +755,13 @@ var _ = Describe("ImageSets Route Test", func() {
 				Expect(rr.Code).To(Equal(http.StatusNotFound))
 			})
 			It("The imageSetView end point return not found when image not found", func() {
-				req, err := http.NewRequest("GET", fmt.Sprintf("/image-sets/view/%d?limit=30&offset=0", imageSet1.ID), nil)
+				req, err := http.NewRequest("GET", fmt.Sprintf("/image-sets/view/%d", imageSet1.ID), nil)
 				Expect(err).ToNot(HaveOccurred())
 				mockImageSetService.EXPECT().GetImageSetViewByID(imageSet1.ID, 30, 0, gomock.Any()).Return(nil, new(services.ImageNotFoundError))
 
 				rr := httptest.NewRecorder()
 				router.ServeHTTP(rr, req)
 				Expect(rr.Code).To(Equal(http.StatusNotFound))
-			})
-			It("should get an error passing unsuported query param", func() {
-				req, err := http.NewRequest("GET", fmt.Sprintf("/image-sets/view/%d?query=%s", imageSet1.ID, "some_string"), nil)
-				Expect(err).ToNot(HaveOccurred())
-
-				rr := httptest.NewRecorder()
-				router.ServeHTTP(rr, req)
-				Expect(rr.Code).To(Equal(http.StatusBadRequest))
-
-				var responseError []validationError
-				respBody, err := ioutil.ReadAll(rr.Body)
-
-				err = json.Unmarshal(respBody, &responseError)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(len(responseError)).To(Equal(1))
-				Expect(responseError[0].Reason).To(Equal("query is not a valid query param, supported query params: [limit offset version status sort_by]"))
-				Expect(responseError[0].Key).To(Equal("query"))
-			})
-			It("should get an error passing unsuported sort_by param", func() {
-				req, err := http.NewRequest("GET", fmt.Sprintf("/image-sets/view/%d?sort_by=%s", imageSet1.ID, "some_string"), nil)
-				Expect(err).ToNot(HaveOccurred())
-
-				rr := httptest.NewRecorder()
-				router.ServeHTTP(rr, req)
-				Expect(rr.Code).To(Equal(http.StatusBadRequest))
-
-				var responseError []validationError
-				respBody, err := ioutil.ReadAll(rr.Body)
-
-				err = json.Unmarshal(respBody, &responseError)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(len(responseError)).To(Equal(1))
-				Expect(responseError[0].Reason).To(Equal("some_string is not a valid sort_by. Sort-by must created_at or name or version"))
-				Expect(responseError[0].Key).To(Equal("sort_by"))
-			})
-			It("the image set view image version sort is responding as expected", func() {
-				sort_args := []string{"created_at", "name", "version"}
-				for _, sort_arg := range sort_args {
-					req, err := http.NewRequest("GET", fmt.Sprintf("/image-sets/view/%d?sort_by=%s", imageSet1.ID, sort_arg), nil)
-					Expect(err).ToNot(HaveOccurred())
-
-					mockImageSetService.EXPECT().GetImageSetViewByID(imageSet1.ID, 30, 0, gomock.Any()).Return(&services.ImageSetIDView{}, nil)
-
-					rr := httptest.NewRecorder()
-					router.ServeHTTP(rr, req)
-					Expect(rr.Code).To(Equal(http.StatusOK))
-				}
 			})
 		})
 


### PR DESCRIPTION
# Description

GetImageSetViewByID endpoint dose not return any object that can be filtered/sorted.
with that in mind i removed all query validations from this endpoint(since it dose not use query params) and updated the spec file and unit-tests accordingly.

Fixes # (issue)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
