### PR TITLE
Add unittests for pkg/services/errors.go

### DIFF
--- a/pkg/routes/updates_test.go
+++ b/pkg/routes/updates_test.go
@@ -386,7 +386,7 @@ var _ = Describe("Update routes", func() {
 				handler.ServeHTTP(rr, req)
 
 				var response common.APIResponse
-				respBody, err := ioutil.ReadAll(rr.Body)
+				respBody, _ := ioutil.ReadAll(rr.Body)
 				err = json.Unmarshal(respBody, &response)
 
 				Expect(rr.Code).To(Equal(http.StatusOK))
@@ -531,7 +531,7 @@ var _ = Describe("Update routes", func() {
 
 				respBody, err := ioutil.ReadAll(responseRecorder.Body)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(string(respBody)).To(ContainSubstring("Commit %d not valid to update", image.CommitID))
+				Expect(string(respBody)).To(ContainSubstring("%d Commit is not valid for update", image.CommitID))
 			})
 		})
 	})
@@ -603,8 +603,8 @@ var _ = Describe("Update routes", func() {
 				handler.ServeHTTP(rr, req)
 
 				var response common.APIResponse
-				respBody, err := ioutil.ReadAll(rr.Body)
-				err = json.Unmarshal(respBody, &response)
+				respBody, _ := ioutil.ReadAll(rr.Body)
+				_ = json.Unmarshal(respBody, &response)
 
 				responseRecorder := httptest.NewRecorder()
 				handler.ServeHTTP(responseRecorder, req)
@@ -631,7 +631,7 @@ var _ = Describe("Update routes", func() {
 				handler.ServeHTTP(rr, req)
 
 				var response common.APIResponse
-				respBody, err := ioutil.ReadAll(rr.Body)
+				respBody, _ := ioutil.ReadAll(rr.Body)
 				err = json.Unmarshal(respBody, &response)
 
 				Expect(rr.Code).To(Equal(http.StatusOK))
@@ -658,7 +658,7 @@ var _ = Describe("Update routes", func() {
 				handler.ServeHTTP(rr, req)
 
 				var response common.APIResponse
-				respBody, err := ioutil.ReadAll(rr.Body)
+				respBody, _ := ioutil.ReadAll(rr.Body)
 				err = json.Unmarshal(respBody, &response)
 
 				Expect(rr.Code).To(Equal(http.StatusOK))

--- a/pkg/services/commits_test.go
+++ b/pkg/services/commits_test.go
@@ -64,19 +64,19 @@ var _ = Describe("ValidateDevicesImageSetWithCommit", func() {
 		It("commit is invalid to update", func() {
 			err := commitService.ValidateDevicesImageSetWithCommit([]string{device.UUID}, commits[0].ID)
 			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).To(Equal("not valid to update"))
+			Expect(err.Error()).To(Equal(services.CommitNotValidMsg))
 		})
 
 		It("device not found for commit", func() {
 			err := commitService.ValidateDevicesImageSetWithCommit([]string{faker.UUIDHyphenated()}, commits[0].ID)
 			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).To(Equal("image-set was not found"))
+			Expect(err.Error()).To(Equal(services.ImageSetNotFoundErrorMsg))
 		})
 
 		It("commit not found for device", func() {
 			err := commitService.ValidateDevicesImageSetWithCommit([]string{device.UUID}, 9999999)
 			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).To(Equal("commit image does not found"))
+			Expect(err.Error()).To(Equal(services.CommitImageNotFoundMsg))
 		})
 
 		It("should not return error", func() {

--- a/pkg/services/errors.go
+++ b/pkg/services/errors.go
@@ -49,7 +49,6 @@ const SomeDevicesDoesNotExistsMsg = "image-set not found for all devices"
 const KafkaAllBrokersDownMsg = "Cannot connect to any Kafka brokers"
 const DBCommitErrorMsg = "Error searching for ImageSet of Device Images"
 
-
 // DeviceNotFoundError indicates the device was not found
 type DeviceNotFoundError struct{}
 

--- a/pkg/services/errors.go
+++ b/pkg/services/errors.go
@@ -4,179 +4,225 @@ package services
 
 import "errors"
 
+const DeviceNotFoundErrorMsg = "Device was not found"
+const UpdateNotFoundErrorMsg = "Update was not found"
+const ImageNotFoundErrorMsg = "image was not found"
+const ImageSetNotFoundErrorMsg = "image-set was not found"
+const AccountOrOrgIDNotSetMsg = "Account or orgID is not set"
+const AccountNotSetMsg = "Account is not set"
+const OrgIDNotSetMsg = "Org ID is not set"
+const IDMustBeIntegerMsg = "ID needs to be an integer"
+const ThirdPartyRepositoryNotFoundMsg = "third party repository was not found"
+const ThirdPartyRepositoryAlreadyExistsMsg = "custom repository already exists"
+const ThirdPartyRepositoryNameIsEmptyMsg = "custom repository name cannot be empty"
+const ThirdPartyRepositoryURLIsEmptyMsg = "custom repository URL cannot be empty"
+const ThirdPartyRepositoryInfoIsInvalidMsg = "custom repository info is invalid"
+const InvalidURLForCustomRepoMsg = "invalid URL"
+const ThirdPartyRepositoryImagesExistsMsg = "custom repository is used by some images"
+const ImageVersionAlreadyExistsMsg = "updated image version already exists"
+const ImageNameAlreadyExistsMsg = "image with supplied name already exists"
+const PackageNameDoesNotExistMsg = "package name doesn't exist"
+const ImageNameUndefinedMsg = "image name is not defined"
+const ImageSetUnDefinedMsg = "image-set is undefined"
+const ImageUnDefinedMsg = "image-set is undefined"
+const DeviceGroupNotFoundMsg = "device group was not found"
+const ImageSetAlreadyExistsMsg = "image set already exists"
+const ImageNotInErrorStateMsg = "image is not in error state"
+const DeviceGroupOrgIDDevicesNotFoundMsg = "devices not found among the device group orgID"
+const DeviceGroupDevicesNotFoundMsg = "devices not found in device group"
+const DeviceGroupAccountOrIDUndefinedMsg = "account or deviceGroupID undefined"
+const DeviceGroupDevicesNotSuppliedMsg = "devices must be supplied to be added to or removed from device group"
+const DeviceGroupDeviceNotSuppliedMsg = "device-group device must be supplied"
+const DeviceGroupAlreadyExistsMsg = "device group already exists"
+const DeviceGroupAccountOrNameUndefinedMsg = "device group account or name are undefined"
+const DeviceGroupMandatoryFieldsUndefinedMsg = "device group mandatory field are undefined"
+const DeviceHasImageUndefinedMsg = "device has image undefined"
+const DeviceHasNoImageUpdateMsg = "device has no image update"
+const DevicesHasMoreThanOneImageSetMsg = "device has more than one image-set"
+const ImageHasNoImageSetMsg = "Image has no image-set"
+const CommitNotFoundMsg = "Commit was not found"
+const CommitNotValidMsg = "Commit is not valid for update"
+const OstreeNotFoundMsg = "Ostree not found"
+const EntitiesImageSetsMismatchMsg = "does not belong to the same image-set as devices images"
+const CommitImageNotFoundMsg = "Commit image was not found"
+const SomeDevicesDoesNotExistsMsg = "image-set not found for all devices"
+const KafkaAllBrokersDownMsg = "Cannot connect to any Kafka brokers"
+const DBCommitErrorMsg = "Error searching for ImageSet of Device Images"
+
+
 // DeviceNotFoundError indicates the device was not found
 type DeviceNotFoundError struct{}
 
 func (e *DeviceNotFoundError) Error() string {
-	return "Device was not found"
+	return DeviceNotFoundErrorMsg
 }
 
 // UpdateNotFoundError indicates the update was not found
 type UpdateNotFoundError struct{}
 
 func (e *UpdateNotFoundError) Error() string {
-	return "Update was not found"
+	return UpdateNotFoundErrorMsg
 }
 
 // ImageNotFoundError indicates the image was not found
 type ImageNotFoundError struct{}
 
 func (e *ImageNotFoundError) Error() string {
-	return "image is not found"
+	return ImageNotFoundErrorMsg
 }
 
 // ImageSetNotFoundError indicates the image-set was not found
 type ImageSetNotFoundError struct{}
 
 func (e *ImageSetNotFoundError) Error() string {
-	return "image-set was not found"
+	return ImageSetNotFoundErrorMsg
 }
 
 // AccountOrOrgIDNotSet indicates the account or orgID was nil
 type AccountOrOrgIDNotSet struct{}
 
 func (e *AccountOrOrgIDNotSet) Error() string {
-	return "Account or orgID is not set"
+	return AccountOrOrgIDNotSetMsg
 }
 
 // AccountNotSet indicates the account was nil
 type AccountNotSet struct{}
 
 func (e *AccountNotSet) Error() string {
-	return "Account is not set"
+	return AccountNotSetMsg
 }
 
 // OrgIDNotSet indicates the account was nil
 type OrgIDNotSet struct{}
 
 func (e *OrgIDNotSet) Error() string {
-	return "Org ID is not set"
+	return OrgIDNotSetMsg
 }
 
 // IDMustBeInteger indicates the ID is required to be an integer value
 type IDMustBeInteger struct{}
 
 func (e *IDMustBeInteger) Error() string {
-	return "ID needs to be an integer"
+	return IDMustBeIntegerMsg
 }
 
 // ThirdPartyRepositoryNotFound indicates the Third Party Repository was not found
 type ThirdPartyRepositoryNotFound struct{}
 
 func (e *ThirdPartyRepositoryNotFound) Error() string {
-	return "third party repository was not found"
+	return ThirdPartyRepositoryNotFoundMsg
 }
 
 // ThirdPartyRepositoryAlreadyExists indicates the Third Party Repository already exists
 type ThirdPartyRepositoryAlreadyExists struct{}
 
 func (e *ThirdPartyRepositoryAlreadyExists) Error() string {
-	return "custom repository already exists"
+	return ThirdPartyRepositoryAlreadyExistsMsg
 }
 
 // ThirdPartyRepositoryNameIsEmpty indicates the Third Party Repository name is empty
 type ThirdPartyRepositoryNameIsEmpty struct{}
 
 func (e *ThirdPartyRepositoryNameIsEmpty) Error() string {
-	return "custom repository name cannot be empty"
+	return ThirdPartyRepositoryNameIsEmptyMsg
 }
 
 // ThirdPartyRepositoryURLIsEmpty indicates the Third Party Repository url is empty
 type ThirdPartyRepositoryURLIsEmpty struct{}
 
 func (e *ThirdPartyRepositoryURLIsEmpty) Error() string {
-	return "custom repository URL cannot be empty"
+	return ThirdPartyRepositoryURLIsEmptyMsg
 }
 
 // ThirdPartyRepositoryInfoIsInvalid indicates the Third Party Repository info is not valid
 type ThirdPartyRepositoryInfoIsInvalid struct{}
 
 func (e *ThirdPartyRepositoryInfoIsInvalid) Error() string {
-	return "custom repository info is invalid"
+	return ThirdPartyRepositoryInfoIsInvalidMsg
 }
 
 // InvalidURLForCustomRepo indicates the Third Party Repository url is invalid
 type InvalidURLForCustomRepo struct{}
 
 func (e *InvalidURLForCustomRepo) Error() string {
-	return "invalid URL"
+	return InvalidURLForCustomRepoMsg
 }
 
 // ThirdPartyRepositoryImagesExists indicates the Third Party Repository has been used in some images
 type ThirdPartyRepositoryImagesExists struct{}
 
 func (e *ThirdPartyRepositoryImagesExists) Error() string {
-	return "custom repository is used by some images"
+	return ThirdPartyRepositoryImagesExistsMsg
 }
 
 // ImageVersionAlreadyExists indicates the updated image version was already present
 type ImageVersionAlreadyExists struct{}
 
 func (e *ImageVersionAlreadyExists) Error() string {
-	return "updated image version already exists"
+	return ImageVersionAlreadyExistsMsg
 }
 
 // ImageNameAlreadyExists indicates the image with supplied name already exists
 type ImageNameAlreadyExists struct{}
 
 func (e *ImageNameAlreadyExists) Error() string {
-	return "image with supplied name already exists"
+	return ImageNameAlreadyExistsMsg
 }
 
 // PackageNameDoesNotExist indicates that package name doesn't exist
 type PackageNameDoesNotExist struct{}
 
 func (e *PackageNameDoesNotExist) Error() string {
-	return "package name doesn't exist"
+	return PackageNameDoesNotExistMsg
 }
 
 // ImageNameUndefined indicates the image name is not defined
 type ImageNameUndefined struct{}
 
 func (e *ImageNameUndefined) Error() string {
-	return "image name is not defined"
+	return ImageNameUndefinedMsg
 }
 
 // ImageSetUnDefined indicates the image has no imageSetDefined
 type ImageSetUnDefined struct{}
 
 func (e *ImageSetUnDefined) Error() string {
-	return "image-set is undefined"
+	return ImageSetUnDefinedMsg
 }
 
 // ImageUnDefined indicates the image is undefined in the db
 type ImageUnDefined struct{}
 
 func (e *ImageUnDefined) Error() string {
-	return "image-set is undefined"
+	return ImageUnDefinedMsg
 }
 
 // DeviceGroupNotFound indicates the Third Party Repository was not found
 type DeviceGroupNotFound struct{}
 
 func (e *DeviceGroupNotFound) Error() string {
-	return "device group was not found"
+	return DeviceGroupNotFoundMsg
 }
 
 // ImageSetAlreadyExists indicates the ImageSet attempting to be created already exists
 type ImageSetAlreadyExists struct{}
 
 func (e *ImageSetAlreadyExists) Error() string {
-	return "image set already exists"
+	return ImageSetAlreadyExistsMsg
 }
 
 // ImageSetAlreadyExists indicates the ImageSet attempting to be created already exists
 type ImageNotInErrorState struct{}
 
 func (e *ImageNotInErrorState) Error() string {
-	return "image is not in error state"
+	return ImageNotInErrorStateMsg
 }
 
 // DeviceGroupOrgIDDevicesNotFound indicates that devices not found among the device group OrgID
 type DeviceGroupOrgIDDevicesNotFound struct{}
 
 func (e *DeviceGroupOrgIDDevicesNotFound) Error() string {
-	return "devices not found among the device group orgID"
+	return DeviceGroupOrgIDDevicesNotFoundMsg
 
 }
 
@@ -184,77 +230,77 @@ func (e *DeviceGroupOrgIDDevicesNotFound) Error() string {
 type DeviceGroupDevicesNotFound struct{}
 
 func (e *DeviceGroupDevicesNotFound) Error() string {
-	return "devices not found in device group"
+	return DeviceGroupDevicesNotFoundMsg
 }
 
 // DeviceGroupAccountOrIDUndefined indicates that device group account or ID was not supplied
 type DeviceGroupAccountOrIDUndefined struct{}
 
 func (e *DeviceGroupAccountOrIDUndefined) Error() string {
-	return "account or deviceGroupID undefined"
+	return DeviceGroupAccountOrIDUndefinedMsg
 }
 
 // DeviceGroupDevicesNotSupplied indicates that device group devices was not supplied
 type DeviceGroupDevicesNotSupplied struct{}
 
 func (e *DeviceGroupDevicesNotSupplied) Error() string {
-	return "devices must be supplied to be added to or removed from device group"
+	return DeviceGroupDevicesNotSuppliedMsg
 }
 
 // DeviceGroupDeviceNotSupplied indicates that device group device was not supplied
 type DeviceGroupDeviceNotSupplied struct{}
 
 func (e *DeviceGroupDeviceNotSupplied) Error() string {
-	return "device-group device must be supplied"
+	return DeviceGroupDeviceNotSuppliedMsg
 }
 
 // DeviceGroupAlreadyExists indicates that device group already exists
 type DeviceGroupAlreadyExists struct{}
 
 func (e *DeviceGroupAlreadyExists) Error() string {
-	return "device group already exists"
+	return DeviceGroupAlreadyExistsMsg
 }
 
 // DeviceGroupAccountOrNameUndefined indicates that device group account or name are undefined
 type DeviceGroupAccountOrNameUndefined struct{}
 
 func (e *DeviceGroupAccountOrNameUndefined) Error() string {
-	return "device group account or name are undefined"
+	return DeviceGroupAccountOrNameUndefinedMsg
 }
 
 // DeviceGroupMandatoryFieldsUndefined indicates that device group mandatory field are undefined
 type DeviceGroupMandatoryFieldsUndefined struct{}
 
 func (e *DeviceGroupMandatoryFieldsUndefined) Error() string {
-	return "device group mandatory field are undefined"
+	return DeviceGroupMandatoryFieldsUndefinedMsg
 }
 
 // DeviceHasImageUndefined indicates that device record has image not defined
 type DeviceHasImageUndefined struct{}
 
 func (e *DeviceHasImageUndefined) Error() string {
-	return "device has image undefined"
+	return DeviceHasImageUndefinedMsg
 }
 
 // DeviceHasNoImageUpdate indicates that device record no image
 type DeviceHasNoImageUpdate struct{}
 
 func (e *DeviceHasNoImageUpdate) Error() string {
-	return "device has no image update"
+	return DeviceHasNoImageUpdateMsg
 }
 
 // DevicesHasMoreThanOneImageSet indicates that device record no image
 type DevicesHasMoreThanOneImageSet struct{}
 
 func (e *DevicesHasMoreThanOneImageSet) Error() string {
-	return "device has more than one image-set"
+	return DevicesHasMoreThanOneImageSetMsg
 }
 
 // ImageHasNoImageSet indicates that device record no image
 type ImageHasNoImageSet struct{}
 
 func (e *ImageHasNoImageSet) Error() string {
-	return "Image has no image-set"
+	return ImageHasNoImageSetMsg
 }
 
 // ErrUndefinedCommit indicate that the update transaction/image or some entity  has no commit defined.
@@ -264,42 +310,42 @@ var ErrUndefinedCommit = errors.New("entity has defined commit")
 type CommitNotFound struct{}
 
 func (e *CommitNotFound) Error() string {
-	return "not found"
+	return CommitNotFoundMsg
 }
 
 // CommitNotValid indicates commit matching the given id was not found
 type CommitNotValid struct{}
 
 func (e *CommitNotValid) Error() string {
-	return "not valid to update"
+	return CommitNotValidMsg
 }
 
 // OstreeNotFound was not found
 type OstreeNotFound struct{}
 
 func (e *OstreeNotFound) Error() string {
-	return "Ostree not found"
+	return OstreeNotFoundMsg
 }
 
 // EntitiesImageSetsMismatch indicates the CommitID does not belong to the same ImageSet as of Device's Image
 type EntitiesImageSetsMismatch struct{}
 
 func (e *EntitiesImageSetsMismatch) Error() string {
-	return "does not belong to the same image-set as devices images"
+	return EntitiesImageSetsMismatchMsg
 }
 
 // CommitImageNotFound indicates the Commit Image is not found
 type CommitImageNotFound struct{}
 
 func (e *CommitImageNotFound) Error() string {
-	return "commit image does not found"
+	return CommitImageNotFoundMsg
 }
 
 // SomeDevicesDoesNotExists indicates that device record no image
 type SomeDevicesDoesNotExists struct{}
 
 func (e *SomeDevicesDoesNotExists) Error() string {
-	return "image-set not found for all devices"
+	return SomeDevicesDoesNotExistsMsg
 }
 
 // ErrOrgIDMismatch returned when the context orgID is different from an entity OrgID
@@ -309,12 +355,12 @@ var ErrOrgIDMismatch = errors.New("context org_id and entity org_id mismatch")
 type KafkaAllBrokersDown struct{}
 
 func (e *KafkaAllBrokersDown) Error() string {
-	return "Cannot connect to any Kafka brokers"
+	return KafkaAllBrokersDownMsg
 }
 
 // DBError indicates a dbError during search
 type DBCommitError struct{}
 
 func (e *DBCommitError) Error() string {
-	return "Error searching for ImageSet of Device Images"
+	return DBCommitErrorMsg
 }

--- a/pkg/services/errors_test.go
+++ b/pkg/services/errors_test.go
@@ -1,0 +1,70 @@
+package services_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/redhatinsights/edge-api/pkg/services"
+)
+
+func TestDeviceNotFoundError(t *testing.T) {
+	testCases := []struct {
+		expectedErr error
+		expectedMsg	string
+	}{
+		{new(services.DeviceNotFoundError), services.DeviceNotFoundErrorMsg},
+		{new(services.UpdateNotFoundError), services.UpdateNotFoundErrorMsg},
+		{new(services.ImageNotFoundError), services.ImageNotFoundErrorMsg},
+		{new(services.ImageSetNotFoundError), services.ImageSetNotFoundErrorMsg},
+		{new(services.AccountOrOrgIDNotSet), services.AccountOrOrgIDNotSetMsg},
+		{new(services.AccountNotSet), services.AccountNotSetMsg},
+		{new(services.OrgIDNotSet), services.OrgIDNotSetMsg},
+		{new(services.IDMustBeInteger), services.IDMustBeIntegerMsg},
+		{new(services.ThirdPartyRepositoryNotFound), services.ThirdPartyRepositoryNotFoundMsg},
+		{new(services.ThirdPartyRepositoryAlreadyExists), services.ThirdPartyRepositoryAlreadyExistsMsg},
+		{new(services.ThirdPartyRepositoryNameIsEmpty), services.ThirdPartyRepositoryNameIsEmptyMsg},
+		{new(services.ThirdPartyRepositoryURLIsEmpty), services.ThirdPartyRepositoryURLIsEmptyMsg},
+		{new(services.ThirdPartyRepositoryInfoIsInvalid), services.ThirdPartyRepositoryInfoIsInvalidMsg},
+		{new(services.InvalidURLForCustomRepo), services.InvalidURLForCustomRepoMsg},
+		{new(services.ThirdPartyRepositoryImagesExists), services.ThirdPartyRepositoryImagesExistsMsg},
+		{new(services.ImageVersionAlreadyExists), services.ImageVersionAlreadyExistsMsg},
+		{new(services.ImageNameAlreadyExists), services.ImageNameAlreadyExistsMsg},
+		{new(services.PackageNameDoesNotExist), services.PackageNameDoesNotExistMsg},
+		{new(services.ImageNameUndefined), services.ImageNameUndefinedMsg},
+		{new(services.ImageSetUnDefined), services.ImageSetUnDefinedMsg},
+		{new(services.ImageUnDefined), services.ImageUnDefinedMsg},
+		{new(services.DeviceGroupNotFound), services.DeviceGroupNotFoundMsg},
+		{new(services.ImageSetAlreadyExists), services.ImageSetAlreadyExistsMsg},
+		{new(services.ImageNotInErrorState), services.ImageNotInErrorStateMsg},
+		{new(services.DeviceGroupOrgIDDevicesNotFound), services.DeviceGroupOrgIDDevicesNotFoundMsg},
+		{new(services.DeviceGroupDevicesNotFound), services.DeviceGroupDevicesNotFoundMsg},
+		{new(services.DeviceGroupAccountOrIDUndefined), services.DeviceGroupAccountOrIDUndefinedMsg},
+		{new(services.DeviceGroupDevicesNotSupplied), services.DeviceGroupDevicesNotSuppliedMsg},
+		{new(services.DeviceGroupDeviceNotSupplied), services.DeviceGroupDeviceNotSuppliedMsg},
+		{new(services.DeviceGroupAlreadyExists), services.DeviceGroupAlreadyExistsMsg},
+		{new(services.DeviceGroupAccountOrNameUndefined), services.DeviceGroupAccountOrNameUndefinedMsg},
+		{new(services.DeviceGroupMandatoryFieldsUndefined), services.DeviceGroupMandatoryFieldsUndefinedMsg},
+		{new(services.DeviceHasImageUndefined), services.DeviceHasImageUndefinedMsg},
+		{new(services.DeviceHasNoImageUpdate), services.DeviceHasNoImageUpdateMsg},
+		{new(services.DevicesHasMoreThanOneImageSet), services.DevicesHasMoreThanOneImageSetMsg},
+		{new(services.ImageHasNoImageSet), services.ImageHasNoImageSetMsg},
+		{new(services.CommitNotFound), services.CommitNotFoundMsg},
+		{new(services.CommitNotValid), services.CommitNotValidMsg},
+		{new(services.OstreeNotFound), services.OstreeNotFoundMsg},
+		{new(services.EntitiesImageSetsMismatch), services.EntitiesImageSetsMismatchMsg},
+		{new(services.CommitImageNotFound), services.CommitImageNotFoundMsg},
+		{new(services.SomeDevicesDoesNotExists), services.SomeDevicesDoesNotExistsMsg},
+		{new(services.KafkaAllBrokersDown), services.KafkaAllBrokersDownMsg},
+		{new(services.DBCommitError), services.DBCommitErrorMsg},
+	}
+
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing for %T", tc.expectedErr), func(t *testing.T) {
+			errMsg := tc.expectedErr.Error()
+			if errMsg != tc.expectedMsg {
+				t.Errorf("Got error message '%s', Expected '%s'.", errMsg, tc.expectedMsg)
+			}	
+		})
+	}
+}

--- a/pkg/services/errors_test.go
+++ b/pkg/services/errors_test.go
@@ -10,7 +10,7 @@ import (
 func TestDeviceNotFoundError(t *testing.T) {
 	testCases := []struct {
 		expectedErr error
-		expectedMsg	string
+		expectedMsg string
 	}{
 		{new(services.DeviceNotFoundError), services.DeviceNotFoundErrorMsg},
 		{new(services.UpdateNotFoundError), services.UpdateNotFoundErrorMsg},
@@ -58,13 +58,12 @@ func TestDeviceNotFoundError(t *testing.T) {
 		{new(services.DBCommitError), services.DBCommitErrorMsg},
 	}
 
-
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing for %T", tc.expectedErr), func(t *testing.T) {
 			errMsg := tc.expectedErr.Error()
 			if errMsg != tc.expectedMsg {
 				t.Errorf("Got error message '%s', Expected '%s'.", errMsg, tc.expectedMsg)
-			}	
+			}
 		})
 	}
 }


### PR DESCRIPTION
# Description

Adds unittests for `pkg/services/errors.go` and updates all strings used for each error type to be a constant which should make it easier to maintain and write future tests.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [x] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
