### PR TITLE
Hopefully sonarqube shows coverage for PRs.

### DIFF
--- a/sonarqube.sh
+++ b/sonarqube.sh
@@ -11,7 +11,7 @@ COMMIT_SHORT=$(git rev-parse --short=7 HEAD)
 # SonarQube parameters can be found below:
 #   https://sonarqube.corp.redhat.com/documentation/analysis/pull-request/
 if [[ "${PR_CHECK}" = "true" ]]; then
-    export PR_CHECK_OPTS="-Dsonar.pullrequest.branch=${GIT_BRANCH} -Dsonar.pullrequest.key=${ghprbPullId} -Dsonar.newCode.referenceBranch=main";
+    export PR_CHECK_OPTS="-Dsonar.pullrequest.branch=${GIT_BRANCH} -Dsonar.pullrequest.key=${ghprbPullId} -Dsonar.newCode.referenceBranch=master";
 fi
 
 podman run \


### PR DESCRIPTION
# Description

Eventhough SonarQube creates branches for every PR it scans, we're still not seeing code coverage at the PR level. Since SonarQube calls the main repository `master`, I am hoping that this small PR fixes the issue for us.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
