### PR TITLE
escape character on search

### DIFF
--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	log "github.com/sirupsen/logrus"
 
@@ -513,8 +514,9 @@ func (c *Client) SearchPackage(packageName string, arch string, dist string) (*S
 	if packageName == "" || arch == "" || dist == "" {
 		return nil, errors.New("mandatory fields should not be empty")
 	}
+
 	// build the correct URL using the package name
-	url := fmt.Sprintf("%s/api/image-builder/v1/packages?distribution=%s&architecture=%s&search=%s", cfg.ImageBuilderConfig.URL, dist, arch, packageName)
+	url := fmt.Sprintf("%s/api/image-builder/v1/packages?distribution=%s&architecture=%s&search=%s", cfg.ImageBuilderConfig.URL, dist, arch, url.QueryEscape(packageName))
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Image Builder Client Test", func() {
 		Expect(err).To(BeNil())
 		Expect(res.Meta.Count).To(Equal(0))
 	})
-	FIt("test validation of special character package name", func() {
+	It("test validation of special character package name", func() {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)

--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -89,10 +89,16 @@ var _ = Describe("Image Builder Client Test", func() {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprintln(w, `{"meta":{"count":1}}`)
+			pkgName := r.URL.Query().Get("search")
+			Expect(pkgName).To(ContainSubstring("gcc-c++"))
+			parampkgName := r.URL.RawQuery
+			Expect(parampkgName).To(ContainSubstring("search=gcc-c%2B%2B"))
+
 		}))
 		defer ts.Close()
 		config.Get().ImageBuilderConfig.URL = ts.URL
 		res, err := client.SearchPackage("gcc-c++", "x86_64", "rhel-85")
+
 		Expect(err).To(BeNil())
 		Expect(res.Meta.Count).To(Equal(1))
 	})

--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -84,6 +84,18 @@ var _ = Describe("Image Builder Client Test", func() {
 		Expect(err).To(BeNil())
 		Expect(res.Meta.Count).To(Equal(0))
 	})
+	FIt("test validation of special character package name", func() {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintln(w, `{"meta":{"count":1}}`)
+		}))
+		defer ts.Close()
+		config.Get().ImageBuilderConfig.URL = ts.URL
+		res, err := client.SearchPackage("gcc-c++", "x86_64", "rhel-85")
+		Expect(err).To(BeNil())
+		Expect(res.Meta.Count).To(Equal(1))
+	})
 	It("test validation of empty package name", func() {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
# Description

escape character to avoid error on package search

Fixes # (THEEDGE-2871)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
