### PR TITLE
devices: fixes event_device_sync_test and add more coverage.

### DIFF
--- a/pkg/services/devices/event_device_sync.go
+++ b/pkg/services/devices/event_device_sync.go
@@ -24,19 +24,17 @@ func (ev EventDeviceSyncHandler) Consume(ctx context.Context) {
 
 	if ev.RedHatOrgID == "" || ev.Data.RequestID == "" {
 		eventlog.WithFields(log.Fields{
-			"message":   "Malformed device sync request, required data missing",
 			"requestId": ev.Data.RequestID,
 			"orgID":     ev.RedHatOrgID,
-		})
+		}).Error("Malformed device sync request, required data missing")
 		return
 	}
 
 	if ev.RedHatOrgID != ev.Data.Identity.Identity.OrgID {
 		eventlog.WithFields(log.Fields{
-			"message":    "Malformed device sync request, required data mis match",
 			"IdentityId": ev.Data.Identity.Identity.OrgID,
 			"orgID":      ev.RedHatOrgID,
-		})
+		}).Error("Malformed device sync request, required data mismatch")
 		return
 	}
 	// get the services from the context

--- a/pkg/services/devices/event_device_sync_test.go
+++ b/pkg/services/devices/event_device_sync_test.go
@@ -1,6 +1,7 @@
 package devices_test
 
 import (
+	"bytes"
 	"context"
 	"time"
 
@@ -20,17 +21,29 @@ import (
 var _ = Describe("Event Device sync Event Test", func() {
 	var ctx context.Context
 	var mockDeviceService *mock_services.MockDeviceServiceInterface
+	var ctrl *gomock.Controller
+	var logBuffer bytes.Buffer
+	var testLog *log.Entry
+
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
-		defer ctrl.Finish()
+		ctrl = gomock.NewController(GinkgoT())
 		mockDeviceService = mock_services.NewMockDeviceServiceInterface(ctrl)
+		testLog = log.NewEntry(log.StandardLogger())
+		// Set the output to use our new local logBuffer
+		logBuffer = bytes.Buffer{}
+		testLog.Logger.SetOutput(&logBuffer)
 
 		ctx = context.Background()
 		ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 			DeviceService: mockDeviceService,
 		})
-		ctx = utility.ContextWithLogger(ctx, log.NewEntry(log.StandardLogger()))
+		ctx = utility.ContextWithLogger(ctx, testLog)
 	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
 	Describe("consume device sync event", func() {
 		When("device sync is requested", func() {
 			Context("DB and inventory mismatch", func() {
@@ -47,6 +60,57 @@ var _ = Describe("Event Device sync Event Test", func() {
 					event.Data = *edgePayload
 					mockDeviceService.EXPECT().SyncDevicesWithInventory(event.RedHatOrgID).Return()
 					event.Consume(ctx)
+				})
+
+				It("SyncDevicesWithInventory should not be called when RequestID is empty", func() {
+					ident, err := common.GetIdentityFromContext(ctx)
+					Expect(err).To(BeNil())
+					edgePayload := &models.EdgeBasePayload{
+						Identity:       ident,
+						LastHandleTime: time.Now().Format(time.RFC3339),
+						RequestID:      "",
+					}
+					event := &eventReq.EventDeviceSyncHandler{}
+					event.RedHatOrgID = ident.Identity.OrgID
+					event.Data = *edgePayload
+					// SyncDevicesWithInventory should not be called
+					mockDeviceService.EXPECT().SyncDevicesWithInventory(event.RedHatOrgID).Times(0)
+					event.Consume(ctx)
+					Expect(logBuffer.String()).To(ContainSubstring("Malformed device sync request, required data missing"))
+				})
+
+				It("SyncDevicesWithInventory should not be called when OrgID is empty", func() {
+					ident, err := common.GetIdentityFromContext(ctx)
+					Expect(err).To(BeNil())
+					edgePayload := &models.EdgeBasePayload{
+						Identity:       ident,
+						LastHandleTime: time.Now().Format(time.RFC3339),
+						RequestID:      faker.UUIDHyphenated(),
+					}
+					event := &eventReq.EventDeviceSyncHandler{}
+					event.RedHatOrgID = ""
+					event.Data = *edgePayload
+					// SyncDevicesWithInventory should not be called
+					mockDeviceService.EXPECT().SyncDevicesWithInventory(gomock.Any()).Times(0)
+					event.Consume(ctx)
+					Expect(logBuffer.String()).To(ContainSubstring("Malformed device sync request, required data missing"))
+				})
+
+				It("SyncDevicesWithInventory should not be called when OrgID is different from identity one", func() {
+					ident, err := common.GetIdentityFromContext(ctx)
+					Expect(err).To(BeNil())
+					edgePayload := &models.EdgeBasePayload{
+						Identity:       ident,
+						LastHandleTime: time.Now().Format(time.RFC3339),
+						RequestID:      faker.UUIDHyphenated(),
+					}
+					event := &eventReq.EventDeviceSyncHandler{}
+					event.RedHatOrgID = faker.UUIDHyphenated()
+					event.Data = *edgePayload
+					// SyncDevicesWithInventory should not be called
+					mockDeviceService.EXPECT().SyncDevicesWithInventory(gomock.Any()).Times(0)
+					event.Consume(ctx)
+					Expect(logBuffer.String()).To(ContainSubstring("Malformed device sync request, required data mismatch"))
 				})
 			})
 		})


### PR DESCRIPTION
coverage added up to from 100% to file event_device_sync_test.go

The main problem resolved here with test gomock.Controller  stopped before even the test started, and  the mock calls was not recorded.  

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

![image](https://user-images.githubusercontent.com/131553/205329485-f7c3dcb5-e319-42c8-be97-93c274a30275.png)

