### PR TITLE
Removed Jenkins Go hack.

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -2,7 +2,6 @@
 
 set -exv
 
-export GOROOT="/opt/go/1.17.7" # Force Jenkins to use Go 1.17.7 since we don't have 1.18 yet
 export PATH="${GOROOT}/bin:${PATH}"
 
 export PR_CHECK="false" # Only used when doing a PR check from Github.
@@ -54,7 +53,7 @@ done
 podman run --rm -i \
     -v $PWD:/usr/src:z \
     registry.access.redhat.com/ubi8/go-toolset:1.18.4-8 \
-    cd /usr/src && make coverage-no-fdo
+    /bin/bash -c 'cd /usr/src && make coverage-no-fdo'
 
 # Generate sonarqube reports
 make scan_project

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-export GOROOT="/opt/go/1.17.7" # Force Jenkins to use Go 1.17.7 since we don't have 1.18 yet
 export PATH="${GOROOT}/bin:${PATH}"
 
 export PR_CHECK="true" # Only used when doing a PR check from Github.
@@ -48,7 +47,7 @@ podman run --rm -i \
     --name $CONTAINER_NAME \
     -v $PWD:/usr/src:z \
     registry.access.redhat.com/ubi8/go-toolset:1.18.4-8 \
-    cd /usr/src && make coverage-no-fdo
+    /bin/bash -c 'cd /usr/src && make coverage-no-fdo'
 
 # Generate sonarqube reports
 make scan_project


### PR DESCRIPTION
# Description

I have removed a workaround that forced our `podman run` commands to use the underlying version of `Go` installed on the Jenkins slave, which as of today is `Go 1.17`. This PR should now ensure that we use `Go 1.18.4` which is the same version `Edge API` uses.  

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
