### PR TITLE
workaround for missing inst.stage2 (BZ 2152192)

### DIFF
--- a/scripts/fleetkick.sh
+++ b/scripts/fleetkick.sh
@@ -70,12 +70,14 @@ edit_isolinux() {
     KICKFILE=$3
 
     [[ -e $CONFIG ]] && file $CONFIG || (echo "ERROR: no $CONFIG file" && exit 1)
+    # Add inst.stage2 if missing (see https://bugzilla.redhat.com/show_bug.cgi?id=2152192)
+    sed -i "/rescue/n;/inst.stage2/n;/LABEL=${VOLID}/ s/$/ inst.stage2=hd:LABEL=${VOLID}/g" $CONFIG
     # Remove an existing inst.ks instruction
     sed -i "/rescue/n;/LABEL=${VOLID}/ s/\<inst.ks[^ ]*//g" $CONFIG
     # Replace an existing inst.ks instruction
-    sed -i "/rescue/n;/LABEL=${VOLID}/ s/\<inst.ks[^ ]*/inst.ks=hd:LABEL=${VOLID}:\/${KICKFILE} None/g" $CONFIG
+    sed -i "/rescue/n;/LABEL=${VOLID}/ s/\<inst.ks[^ ]*/inst.ks=hd:LABEL=${VOLID}:\/${KICKFILE}/g" $CONFIG
     # Inject an inst.ks instruction
-    sed -i "/inst.ks=/n;/rescue/n;/LABEL=${VOLID}/ s/$/ inst.ks=hd:LABEL=${VOLID}:\/${KICKFILE} None/g" $CONFIG
+    sed -i "/inst.ks=/n;/rescue/n;/LABEL=${VOLID}/ s/$/ inst.ks=hd:LABEL=${VOLID}:\/${KICKFILE}/g" $CONFIG
     grep $VOLID $CONFIG
 }
 
@@ -86,12 +88,14 @@ edit_efiboot() {
     KICKFILE=$3
 
     [[ -e $CONFIG ]] && file $CONFIG || (echo "ERROR: no $CONFIG file" && exit 1)
+    # Add inst.stage2 if missing (see https://bugzilla.redhat.com/show_bug.cgi?id=2152192)
+    sed -i "/rescue/n;/inst.stage2/n;/LABEL=${VOLID}/ s/$/ inst.stage2=hd:LABEL=${VOLID}/g" $CONFIG
     # Remove an existing inst.ks instruction
     sed -i "/rescue/n;/LABEL=${VOLID}/ s/\<inst.ks[^ ]*//g" $CONFIG
     # Replace an existing inst.ks instruction
-    sed -i "/rescue/n;/LABEL=${VOLID}/ s/\<inst.ks[^ ]*/inst.ks=hd:LABEL=${VOLID}:\/${KICKFILE} None/g" $CONFIG
+    sed -i "/rescue/n;/LABEL=${VOLID}/ s/\<inst.ks[^ ]*/inst.ks=hd:LABEL=${VOLID}:\/${KICKFILE}/g" $CONFIG
     # Inject an inst.ks instruction
-    sed -i "/inst.ks=/n;/rescue/n;/LABEL=${VOLID}/ s/$/ inst.ks=hd:LABEL=${VOLID}:\/${KICKFILE} None/g" $CONFIG
+    sed -i "/inst.ks=/n;/rescue/n;/LABEL=${VOLID}/ s/$/ inst.ks=hd:LABEL=${VOLID}:\/${KICKFILE}/g" $CONFIG
     grep $VOLID $CONFIG
 }
 


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description

Workaround to add inst.stage2 entry to EFI/BOOT/grub.cfg and isolinux/isolinux.cfg for upcoming Image Builder change to include either inst.stage2 or inst.ks but not both.
See BZ [2152192](https://bugzilla.redhat.com/show_bug.cgi?id=2152192)

Also removed None keyword.

Fixes # (issue) https://bugzilla.redhat.com/show_bug.cgi?id=2152192

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
