### PR TITLE
fixed path for GetImageSetsDevicesByID in the spec-file

### DIFF
--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -1148,7 +1148,7 @@ paths:
                 $ref: "#/components/schemas/v1.InternalServerError"
           description: There was an internal server error.
       summary: Deletes an image-set
-  /images/{ImageSetId}/devices:
+  /image-sets/{ImageSetId}/devices:
     get:
       operationId: GetImageSetsDevicesByID
       parameters:


### PR DESCRIPTION
# Description

the spec-file lists GetImageSetsDevicesByID under the images route while it should be under the image-sets route

Fixes # (issue)
https://issues.redhat.com/browse/THEEDGE-2916
## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
