### PR TITLE
Removed "debug()" from DB calls.

### DIFF
--- a/cmd/kafka/main.go
+++ b/cmd/kafka/main.go
@@ -28,7 +28,7 @@ func getStaleBuilds(status string, age int) []models.Image {
 	// looks like we ran into a known pgx issue when using ? for parameters in certain prepared SQL statements
 	// 		using Sprintf to predefine the query and pass to Where
 	query := fmt.Sprintf("status = '%s' AND updated_at < NOW() - INTERVAL '%d hours'", status, age)
-	qresult := db.DB.Debug().Where(query).Find(&images)
+	qresult := db.DB.Where(query).Find(&images)
 	if qresult.Error != nil {
 		log.WithField("error", qresult.Error.Error()).Error("Stale builds query failed")
 		return nil
@@ -47,7 +47,7 @@ func getStaleBuilds(status string, age int) []models.Image {
 
 // set the status for a specific image
 func setImageStatus(id uint, status string) error {
-	tx := db.DB.Debug().Model(&models.Image{}).Where("ID = ?", id).Update("Status", status)
+	tx := db.DB.Model(&models.Image{}).Where("ID = ?", id).Update("Status", status)
 	if tx.Error != nil {
 		log.WithField("error", tx.Error.Error()).Error("Error updating image status")
 		return tx.Error
@@ -115,7 +115,7 @@ func main() {
 		// handle image builds in INTERRUPTED status
 		//	this is meant to handle builds that are interrupted when they are interrupted
 		// 	the stale interrupted build routine (above) should never actually find anything while this is running
-		qresult := db.DB.Debug().Where(&models.Image{Status: models.ImageStatusInterrupted}).Find(&images)
+		qresult := db.DB.Where(&models.Image{Status: models.ImageStatusInterrupted}).Find(&images)
 		if qresult.RowsAffected > 0 {
 			log.WithField("numImages", qresult.RowsAffected).Info("Found image(s) with interrupted status")
 		}

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -174,7 +174,6 @@ func main() {
 	for modelsIndex, modelsInterface := range modelsInterfaces {
 		log.Debugf("Migrating Model %d: %s", modelsIndex, modelsInterface.label)
 
-		// err := db.DB.Debug().AutoMigrate( modelsInterface.interfaceInstance )
 		err := db.DB.AutoMigrate(modelsInterface.interfaceInstance)
 		if err != nil {
 			log.Warningf("database automigrate failure %s", err)

--- a/pkg/routes/devicegroups_test.go
+++ b/pkg/routes/devicegroups_test.go
@@ -729,7 +729,7 @@ var _ = Describe("DeviceGroup routes", func() {
 
 		When("all is valid with same image Set ID", func() {
 			It("should update Devices from Group", func() {
-				res := db.DB.Debug().Omit("Devices.*").Create(&deviceGroup)
+				res := db.DB.Omit("Devices.*").Create(&deviceGroup)
 				Expect(res.Error).To(BeNil())
 				Expect(deviceGroup.ID).NotTo(Equal(0))
 				db.DB.Create(&commit)

--- a/pkg/routes/devices.go
+++ b/pkg/routes/devices.go
@@ -313,7 +313,7 @@ func GetDeviceDBInfo(w http.ResponseWriter, r *http.Request) {
 // GetDevicesView returns all data needed to display customers devices
 func GetDevicesView(w http.ResponseWriter, r *http.Request) {
 	contextServices := dependencies.ServicesFromContext(r.Context())
-	tx := devicesFilters(r, db.DB.Debug()).Where("image_id IS NOT NULL AND image_id != 0")
+	tx := devicesFilters(r, db.DB).Where("image_id IS NOT NULL AND image_id != 0")
 	pagination := common.GetPagination(r)
 
 	devicesCount, err := contextServices.DeviceService.GetDevicesCount(tx)

--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -693,7 +693,7 @@ func ResumeCreateImage(w http.ResponseWriter, r *http.Request) {
 
 		// re-grab the image from the database
 		var image *models.Image
-		db.DB.Debug().Preload("Commit.Repo").Joins("Commit").Joins("Installer").First(&image, tempImage.ID)
+		db.DB.Preload("Commit.Repo").Joins("Commit").Joins("Installer").First(&image, tempImage.ID)
 
 		resumeLog := edgeAPIServices.Log.WithField("originalRequestId", image.RequestID)
 		resumeLog.Info("Resuming image build")

--- a/pkg/routes/updates.go
+++ b/pkg/routes/updates.go
@@ -263,7 +263,7 @@ func AddUpdate(w http.ResponseWriter, r *http.Request) {
 			ctxServices.UpdateService.CreateUpdateAsync(update.ID)
 		}
 	}
-	if result := db.DB.Debug().Omit("Devices.*").Save(upd); result.Error != nil {
+	if result := db.DB.Omit("Devices.*").Save(upd); result.Error != nil {
 		ctxServices.Log.WithFields(log.Fields{
 			"error": result.Error.Error(),
 		}).Error("Error saving update")

--- a/pkg/routes/updates_test.go
+++ b/pkg/routes/updates_test.go
@@ -562,7 +562,7 @@ var _ = Describe("Update routes", func() {
 			{OrgID: orgID, Name: "3"},
 			{OrgID: orgID, Name: "4"},
 			{OrgID: orgID, Name: "5"}}
-		db.DB.Debug().Create(&commits)
+		db.DB.Create(&commits)
 
 		images := [5]models.Image{
 			{OrgID: orgID, CommitID: commits[0].ID, Status: models.ImageStatusSuccess, Version: 1, ImageSetID: &imageSet.ID},
@@ -571,7 +571,7 @@ var _ = Describe("Update routes", func() {
 			{OrgID: orgID, CommitID: commits[3].ID, Status: models.ImageStatusSuccess, Version: 4, ImageSetID: &imageSet.ID},
 			{OrgID: orgID, CommitID: commits[4].ID, Status: models.ImageStatusSuccess, Version: 5, ImageSetID: &imageSet.ID},
 		}
-		db.DB.Debug().Create(&images)
+		db.DB.Create(&images)
 
 		device := models.Device{
 			OrgID:   orgID,

--- a/pkg/services/commits_test.go
+++ b/pkg/services/commits_test.go
@@ -38,7 +38,7 @@ var _ = Describe("ValidateDevicesImageSetWithCommit", func() {
 			{OrgID: orgID, Name: "3"},
 			{OrgID: orgID, Name: "4"},
 			{OrgID: orgID, Name: "5"}}
-		db.DB.Debug().Create(&commits)
+		db.DB.Create(&commits)
 
 		images = []models.Image{
 			{OrgID: orgID, CommitID: commits[0].ID, Status: models.ImageStatusSuccess, Version: 1, ImageSetID: &imageSet.ID},
@@ -47,7 +47,7 @@ var _ = Describe("ValidateDevicesImageSetWithCommit", func() {
 			{OrgID: orgID, CommitID: commits[3].ID, Status: models.ImageStatusSuccess, Version: 4, ImageSetID: &imageSet.ID},
 			{OrgID: orgID, CommitID: commits[4].ID, Status: models.ImageStatusSuccess, Version: 5, ImageSetID: &imageSet.ID},
 		}
-		db.DB.Debug().Create(&images)
+		db.DB.Create(&images)
 
 		device = models.Device{
 			OrgID:   orgID,

--- a/pkg/services/devicegroups_test.go
+++ b/pkg/services/devicegroups_test.go
@@ -359,7 +359,7 @@ var _ = Describe("DeviceGroupsService basic functions", func() {
 				err = faker.FakeData(&fakeDeviceGroup)
 				Expect(err).To(BeNil())
 				fakeDeviceGroup.Devices = []models.Device{savedDeviceGroup.Devices[0]}
-				Expect(db.DB.Debug().Omit("Devices.*").Create(&fakeDeviceGroup).Error).To(BeNil())
+				Expect(db.DB.Omit("Devices.*").Create(&fakeDeviceGroup).Error).To(BeNil())
 
 				deletedDevices, delErr := deviceGroupsService.DeleteDeviceGroupDevices(orgID, deviceGroupID, fakeDeviceGroup.Devices)
 				Expect(delErr).NotTo(BeNil())
@@ -377,7 +377,7 @@ var _ = Describe("DeviceGroupsService basic functions", func() {
 				err = faker.FakeData(&fakeDeviceGroup)
 				Expect(err).To(BeNil())
 				fakeDeviceGroup.Devices = []models.Device{savedDeviceGroup.Devices[0], fakeDevice}
-				Expect(db.DB.Debug().Omit("Devices.*").Create(&fakeDeviceGroup).Error).To(BeNil())
+				Expect(db.DB.Omit("Devices.*").Create(&fakeDeviceGroup).Error).To(BeNil())
 
 				deletedDevices, delErr := deviceGroupsService.DeleteDeviceGroupDevices(orgID, deviceGroupID, fakeDeviceGroup.Devices)
 				Expect(delErr).NotTo(BeNil())

--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -232,7 +232,7 @@ func (s *DeviceService) GetUpdateAvailableForDevice(device inventory.Device, lat
 	}
 
 	var images []models.Image
-	query := db.DB.Debug().Limit(limit).Offset(offset).Where("Image_set_id = ? and Images.Status = ? and Images.Id > ?",
+	query := db.DB.Limit(limit).Offset(offset).Where("Image_set_id = ? and Images.Status = ? and Images.Id > ?",
 		currentImage.ImageSetID, models.ImageStatusSuccess, currentImage.ID,
 	).Joins("Commit").Order("Images.version desc")
 
@@ -953,7 +953,7 @@ func (s *DeviceService) platformInventoryCreateEventHelper(e PlatformInsightsCre
 	}
 
 	// We should not create a new device if UUID already exists
-	result := db.DB.Debug().Where(&models.Device{UUID: newDevice.UUID}).FirstOrCreate(&newDevice)
+	result := db.DB.Where(&models.Device{UUID: newDevice.UUID}).FirstOrCreate(&newDevice)
 
 	if result.Error != nil {
 		s.log.WithFields(log.Fields{
@@ -1075,7 +1075,7 @@ func (s *DeviceService) SyncDevicesWithInventory(orgID string) {
 					log.Fields{"host_id": device.UUID, "OrgID": device.OrgID},
 				).Debug("Deleting device")
 
-				if result := db.DB.Debug().Delete(&device); result.Error != nil {
+				if result := db.DB.Delete(&device); result.Error != nil {
 					s.log.WithFields(
 						log.Fields{"host_id": device.UUID, "OrgID": device.OrgID, "error": result.Error},
 					).Error("Error when deleting device in device sync")

--- a/pkg/services/devices_test.go
+++ b/pkg/services/devices_test.go
@@ -722,7 +722,7 @@ var _ = Describe("DfseviceService", func() {
 				Name:        event.Host.Name,
 				LastSeen:    event.Host.Updated,
 			}
-			result = db.DB.Debug().Clauses(clause.OnConflict{DoNothing: true}).Create(&newDevice)
+			result = db.DB.Clauses(clause.OnConflict{DoNothing: true}).Create(&newDevice)
 			err := deviceService.ProcessPlatformInventoryCreateEvent(message)
 			Expect(err).To(BeNil())
 			var savedDevice models.Device
@@ -924,7 +924,7 @@ var _ = Describe("DfseviceService", func() {
 				Type: models.DeviceGroupTypeDefault, OrgID: event.OrgID, Name: faker.UUIDHyphenated(),
 				Devices: []models.Device{device},
 			}
-			result = db.DB.Debug().Omit("Devices.*").Create(&deviceGroup)
+			result = db.DB.Omit("Devices.*").Create(&deviceGroup)
 			Expect(result.Error).To(BeNil())
 
 			// ensure device group created with device included
@@ -1572,7 +1572,7 @@ var _ = Describe("DfseviceService", func() {
 				ImageID: newImage.ID,
 			}
 
-			db.DB.Debug().Create(&device)
+			db.DB.Create(&device)
 
 			mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(newImage, nil)
 			mockImageService.EXPECT().GetRollbackImage(gomock.Eq(newImage)).Return(oldImage, nil)
@@ -1628,7 +1628,7 @@ var _ = Describe("DfseviceService", func() {
 				ImageID: image.ID,
 			}
 
-			db.DB.Debug().Create(&device)
+			db.DB.Create(&device)
 
 			mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(image, nil)
 			mockImageService.EXPECT().GetRollbackImage(gomock.Eq(image)).Return(image, nil)
@@ -1703,20 +1703,20 @@ var _ = Describe("DfseviceService", func() {
 		})
 		It("should return devices", func() {
 
-			db.DB.Debug().Create(&device)
+			db.DB.Create(&device)
 			count, err := deviceService.GetDevicesCountByImage(img.ID)
 			Expect(err).To(BeNil())
 			Expect(count).To(Equal(int64(3)))
 
 		})
 		It("should return 2", func() {
-			db.DB.Debug().Create(&device)
+			db.DB.Create(&device)
 			count, err := deviceService.GetDevicesCountByImage(img2.ID)
 			Expect(err).To(BeNil())
 			Expect(count).To(Equal(int64(2)))
 		})
 		It("should return 0", func() {
-			db.DB.Debug().Create(&device)
+			db.DB.Create(&device)
 			count, err := deviceService.GetDevicesCountByImage(img3.ID)
 			Expect(err).To(BeNil())
 			Expect(count).To(Equal(int64(0)))

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -646,7 +646,7 @@ func (s *ImageService) processImage(ctx context.Context, id uint) {
 			// we caught an interrupt. Mark the image as interrupted.
 			s.log.WithField("imageID", id).Debug("Select case SIGINT interrupt has been triggered")
 
-			tx := db.DB.Debug().Model(&models.Image{}).Where("ID = ?", id).Update("Status", models.ImageStatusInterrupted)
+			tx := db.DB.Model(&models.Image{}).Where("ID = ?", id).Update("Status", models.ImageStatusInterrupted)
 			s.log.WithField("imageID", id).Debug("Image updated with interrupted status")
 			if tx.Error != nil {
 				s.log.WithField("error", tx.Error.Error()).Error("Error updating image")
@@ -662,7 +662,7 @@ func (s *ImageService) processImage(ctx context.Context, id uint) {
 	}()
 
 	// business as usual from here to end of block
-	db.DB.Debug().Joins("Commit").Joins("Installer").First(&image, id)
+	db.DB.Joins("Commit").Joins("Installer").First(&image, id)
 
 	// Monitor the commit for completion
 	s.log.WithField("imageID", image.ID).Debug("Monitoring commit status for this image")
@@ -969,7 +969,7 @@ func (s *ImageService) UpdateImageStatus(image *models.Image) (*models.Image, er
 			// check that if error contain timeout and job stop responding and image's time creation is less than 3 hours
 			if strings.Contains(err.Error(), "running this job stopped responding") {
 				image.Status = models.ImageStatusInterrupted
-				tx := db.DB.Debug().Model(&models.Image{}).Where("ID = ?", image.ID).Update("Status", models.ImageStatusInterrupted)
+				tx := db.DB.Model(&models.Image{}).Where("ID = ?", image.ID).Update("Status", models.ImageStatusInterrupted)
 				if tx.Error != nil {
 					return image, err
 				}
@@ -1270,7 +1270,7 @@ func (s *ImageService) resumeProcessImage(ctx context.Context, image *models.Ima
 			// we caught an interrupt. Mark the image as interrupted.
 			s.log.WithField("imageID", id).Debug("Select case SIGINT interrupt has been triggered")
 
-			tx := db.DB.Debug().Model(&models.Image{}).Where("ID = ?", id).Update("Status", models.ImageStatusInterrupted)
+			tx := db.DB.Model(&models.Image{}).Where("ID = ?", id).Update("Status", models.ImageStatusInterrupted)
 			s.log.WithField("imageID", id).Debug("Image updated with interrupted status")
 			if tx.Error != nil {
 				s.log.WithField("error", tx.Error.Error()).Error("Error updating image")

--- a/pkg/services/images_test.go
+++ b/pkg/services/images_test.go
@@ -1721,14 +1721,14 @@ var _ = Describe("Image Service Test", func() {
 			})
 			Context("Get Devices count image", func() {
 				It("should return device count of image2", func() {
-					db.DB.Debug().Create(&devices)
+					db.DB.Create(&devices)
 					count, err := service.GetImageDevicesCount(image2.ID)
 					Expect(err).To(BeNil())
 					Expect(count).To(Equal(int64(2)))
 
 				})
 				It("should return 0 device of image1", func() {
-					db.DB.Debug().Create(&devices)
+					db.DB.Create(&devices)
 					count, err := service.GetImageDevicesCount(image1.ID)
 					Expect(err).To(BeNil())
 					Expect(count).To(Equal(int64(0)))
@@ -1736,7 +1736,7 @@ var _ = Describe("Image Service Test", func() {
 
 				It("GetUpdateInfo of image2 with 2 system and one installPackage", func() {
 					var imageDiff *models.ImageUpdateAvailable
-					db.DB.Debug().Create(&devices)
+					db.DB.Create(&devices)
 					totalPackage := len(image2.Commit.InstalledPackages)
 					imageDiff, err := service.GetUpdateInfo(*image2)
 					Expect(err).ToNot(HaveOccurred())

--- a/pkg/services/imagesets.go
+++ b/pkg/services/imagesets.go
@@ -162,7 +162,7 @@ func (s *ImageSetsService) GetImageSetsView(limit int, offset int, tx *gorm.DB) 
 	}
 
 	var imgs []models.Image
-	db.DB.Debug().Where("ID in ?", imageIDS).Find(&imgs)
+	db.DB.Where("ID in ?", imageIDS).Find(&imgs)
 	// build set of image status
 	imageSetToStatus := make(map[uint]string)
 	for _, image := range imgs {
@@ -280,7 +280,7 @@ func (s *ImageSetsService) preloadImageSetImageData(image *models.Image) error {
 			return res.Error
 		}
 	}
-	if err := db.DB.Debug().Model(image.Commit).Association("InstalledPackages").Find(&image.Commit.InstalledPackages); err != nil {
+	if err := db.DB.Model(image.Commit).Association("InstalledPackages").Find(&image.Commit.InstalledPackages); err != nil {
 		s.log.WithField("error", err.Error()).Error("error occurred when preloading image.Commit.InstalledPackages data")
 		return err
 	}

--- a/pkg/services/imagesets_test.go
+++ b/pkg/services/imagesets_test.go
@@ -92,7 +92,7 @@ var _ = Describe("ImageSets Service Test", func() {
 
 		It("should return image-set view with corresponding installer iso url and error status ", func() {
 
-			dbFilter := db.DB.Debug().Where("image_sets.name = ? ", imageSet1.Name)
+			dbFilter := db.DB.Where("image_sets.name = ? ", imageSet1.Name)
 
 			imageSetsView, err := service.GetImageSetsView(100, 0, dbFilter)
 			Expect(err).ToNot(HaveOccurred())
@@ -327,7 +327,7 @@ var _ = Describe("ImageSets Service Test", func() {
 			res1 = db.DB.First(&tempImage, image2.ID)
 			Expect(res1.Error.Error()).Should(Equal("record not found"))
 
-			dbFilter := db.DB.Debug().Where("image_sets.name = ? ", imageSet1.Name)
+			dbFilter := db.DB.Where("image_sets.name = ? ", imageSet1.Name)
 
 			imageSetsView, err := service.GetImageSetsView(100, 0, dbFilter)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -338,7 +338,7 @@ func (s *UpdateService) CreateUpdate(id uint) (*models.UpdateTransaction, error)
 			s.log.WithField("error", err.Error()).Error("Error saving update")
 			return nil, err
 		}
-		dRecord := db.DB.Debug().Omit("Devices, DispatchRecords.Device").Save(update)
+		dRecord := db.DB.Omit("Devices, DispatchRecords.Device").Save(update)
 		if dRecord.Error != nil {
 			s.log.WithField("error", dRecord.Error).Error("Error saving Dispach Record")
 			return nil, dRecord.Error
@@ -479,7 +479,7 @@ func (s *UpdateService) WriteTemplate(templateInfo TemplateRemoteInfo, orgID str
 // GetUpdateTransactionsForDevice returns all update transactions for a given device
 func (s *UpdateService) GetUpdateTransactionsForDevice(device *models.Device) (*[]models.UpdateTransaction, error) {
 	var updates []models.UpdateTransaction
-	result := db.DB.Debug().
+	result := db.DB.
 		Table("update_transactions").
 		Preload("DispatchRecords", func(db *gorm.DB) *gorm.DB {
 			return db.Where("dispatch_records.device_id = ?", device.ID)
@@ -553,7 +553,7 @@ func (s *UpdateService) ProcessPlaybookDispatcherRunEvent(message []byte) error 
 		s.log.Error("Playbook status is not on the json schema for this event")
 	}
 
-	result = db.DB.Debug().Omit("Device").Save(&dispatchRecord)
+	result = db.DB.Omit("Device").Save(&dispatchRecord)
 	if result.Error != nil {
 		return result.Error
 	}
@@ -596,7 +596,7 @@ func (s *UpdateService) SetUpdateStatus(update *models.UpdateTransaction) error 
 		update.Status = models.UpdateStatusSuccess
 	}
 	// If there isn't an error and it's not all success, some updates are still happening
-	result := db.DB.Debug().Model(&models.UpdateTransaction{}).Where("ID=?", update.ID).Update("Status", update.Status)
+	result := db.DB.Model(&models.UpdateTransaction{}).Where("ID=?", update.ID).Update("Status", update.Status)
 
 	return result.Error
 }
@@ -794,7 +794,7 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 					UUID:  device.ID,
 					OrgID: orgID,
 				}
-				if result := db.DB.Debug().Omit("Devices.*").Create(&updateDevice); result.Error != nil {
+				if result := db.DB.Omit("Devices.*").Create(&updateDevice); result.Error != nil {
 					return nil, result.Error
 				}
 			}
@@ -805,7 +805,7 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 				}).Info("Device is disconnected")
 				update.Status = models.UpdateStatusDeviceDisconnected
 				update.Devices = append(update.Devices, *updateDevice)
-				if result := db.DB.Debug().Omit("Devices.*").Create(&update); result.Error != nil {
+				if result := db.DB.Omit("Devices.*").Create(&update); result.Error != nil {
 					return nil, result.Error
 				}
 				continue
@@ -817,7 +817,7 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 			if updateDevice.OrgID == "" {
 				updateDevice.OrgID = orgID
 			}
-			result := db.DB.Debug().Omit("Devices.*").Save(&updateDevice)
+			result := db.DB.Omit("Devices.*").Save(&updateDevice)
 			if result.Error != nil {
 				return nil, result.Error
 			}

--- a/pkg/services/updates_test.go
+++ b/pkg/services/updates_test.go
@@ -80,9 +80,9 @@ var _ = Describe("UpdateService Basic functions", func() {
 					OrgID: org_id,
 				},
 			}
-			db.DB.Debug().Omit("Devices.*").Create(&updates[0])
-			db.DB.Debug().Omit("Devices.*").Create(&updates[1])
-			db.DB.Debug().Omit("Devices.*").Create(&updates[2])
+			db.DB.Omit("Devices.*").Create(&updates[0])
+			db.DB.Omit("Devices.*").Create(&updates[1])
+			db.DB.Omit("Devices.*").Create(&updates[2])
 
 			It("to return two updates for first device", func() {
 				actual, err := updateService.GetUpdateTransactionsForDevice(&device)
@@ -397,7 +397,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 
 					var updateTransaction models.UpdateTransaction
 
-					db.DB.Debug().Preload("DispatchRecords").Preload("DispatchRecords.Device").Preload("Devices").First(&updateTransaction, update.ID)
+					db.DB.Preload("DispatchRecords").Preload("DispatchRecords.Device").Preload("Devices").First(&updateTransaction, update.ID)
 
 					Expect(updateTransaction.ID).Should(Equal(update.ID))
 					Expect(updateTransaction.Status).Should(Equal(models.UpdateStatusError))


### PR DESCRIPTION
# Description

Once upon a time, sprinkling `debug()` everywhere we used our `DB` instance made sense, but it slows things down.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
