### PR TITLE
fixed list-image-sets when the latest image in the set is deleted

### DIFF
--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -218,6 +218,7 @@ func ListAllImageSets(w http.ResponseWriter, r *http.Request) {
 		sort.Slice(img.Images, func(i, j int) bool {
 			return img.Images[i].ID > img.Images[j].ID
 		})
+		imgSet.ImageSetData.Version = img.Images[0].Version
 		imageSetIsoURLSetten := false
 		for _, i := range img.Images {
 			if i.InstallerID != nil {

--- a/pkg/services/images_test.go
+++ b/pkg/services/images_test.go
@@ -1602,16 +1602,17 @@ var _ = Describe("Image Service Test", func() {
 					}
 					db.DB.Create(&image1)
 					db.DB.Create(&image2)
-					err := service.DeleteImage(&image1)
+					err := service.DeleteImage(&image2)
 					Expect(err).To(BeNil())
 					var tempImage models.Image
-					res := db.DB.First(&tempImage, image1)
+					res := db.DB.First(&tempImage, image2)
 					Expect(res.Error.Error()).Should(Equal("record not found"))
-					res = db.DB.First(&tempImage, image2)
+					res = db.DB.First(&tempImage, image1)
 					Expect(res.Error).To(BeNil())
 					var tempImageSet models.ImageSet
 					res = db.DB.First(&tempImageSet, imageSet)
 					Expect(res.Error).To(BeNil())
+					Expect(tempImageSet.Version).To(Equal(image1.Version))
 				})
 			})
 		})


### PR DESCRIPTION
# Description

when the latest image in the set is deleted, the list-all-image-sets endpoint will show an incorrect version.

this PR fixes this issue and also changes the unit-test so that it verifies that the image set is being updated to the correct version when the latest image in the set is deleted 

Fixes # (issue)
[THEEDGE-2943](https://issues.redhat.com/browse/THEEDGE-2943)
## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
