### PR TITLE
Added image-builder to clowdapp

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -378,7 +378,7 @@ parameters:
 - description: ImageBuilder service URL
   name: IMAGEBUILDER_URL
   required: false
-  value: "http://image-builder:8080"
+  value: "http://image-builder-service:8000"
 - description: Host Inventory service URL
   name: INVENTORYURL
   required: false

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -327,6 +327,7 @@ objects:
       - host-inventory
       - playbook-dispatcher
       - ingress
+      - image-builder
     featureFlags: true
 parameters:
 - description: Cpu limit of service

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -328,6 +328,7 @@ objects:
       - playbook-dispatcher
       - ingress
       - image-builder
+      - rhsm-api-proxy
     featureFlags: true
 parameters:
 - description: Cpu limit of service


### PR DESCRIPTION
# Description

Added image-builder as an optional dependency to clowdapp.
When deploying to ephemeral it will deploy image-builder and rhsm-api-proxy services to have the ability to build rhel images on ephemeral env.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
