### PR TITLE
ignore deleted images in the image-sets route  query

### DIFF
--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -223,7 +223,7 @@ func ListAllImageSets(w http.ResponseWriter, r *http.Request) {
 			Preload("Images.Commit").
 			Preload("Images.Installer").
 			Preload("Images.Commit.Repo").
-			Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id`).
+			Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id AND Images.deleted_at is NULL`).
 			Find(&imageSet)
 	} else {
 		// this code is no longer run, but would be used if sorting by status is re-implemented.


### PR DESCRIPTION
# Description
if the image-set had an image that was deleted, it's status still applies to the image-set
this should resolve that 

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
