### PR TITLE
image-sets-view: fixes image-sets-view count sql.

### DIFF
--- a/pkg/services/imagesets_test.go
+++ b/pkg/services/imagesets_test.go
@@ -67,6 +67,8 @@ var _ = Describe("ImageSets Service Test", func() {
 		// other image set
 		otherImageSet1 := models.ImageSet{OrgID: OrgID, Name: CommonName + "-" + faker.Name(), Version: 1}
 		db.DB.Create(&otherImageSet1)
+		otherImage0 := models.Image{OrgID: OrgID, Name: otherImageSet1.Name, ImageSetID: &otherImageSet1.ID, Version: 1, Status: models.ImageStatusBuilding}
+		db.DB.Create(&otherImage0)
 		otherImage1 := models.Image{OrgID: OrgID, Name: otherImageSet1.Name, ImageSetID: &otherImageSet1.ID, Version: 1, Status: models.ImageStatusSuccess}
 		otherImage1.Installer = &models.Installer{OrgID: OrgID, ImageBuildISOURL: faker.URL(), Status: models.ImageStatusSuccess}
 		db.DB.Create(&otherImage1)
@@ -88,6 +90,33 @@ var _ = Describe("ImageSets Service Test", func() {
 			count, err := service.GetImageSetsViewCount(dbFilter)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(count).To(Equal(int64(2)))
+		})
+
+		It("should return The right image view count  when filtering by status success", func() {
+
+			dbFilter := db.DB.Where("image_sets.name LIKE ? AND images.status =  ?", CommonName+"%", models.ImageStatusSuccess)
+
+			count, err := service.GetImageSetsViewCount(dbFilter)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(count).To(Equal(int64(1)))
+		})
+
+		It("should return The right image view count  when filtering by status error", func() {
+
+			dbFilter := db.DB.Where("image_sets.name LIKE ? AND images.status =  ?", CommonName+"%", models.ImageStatusError)
+
+			count, err := service.GetImageSetsViewCount(dbFilter)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(count).To(Equal(int64(1)))
+		})
+
+		It("should return The right image view count  when filtering by status building", func() {
+
+			dbFilter := db.DB.Where("image_sets.name LIKE ? AND images.status =  ?", CommonName+"%", models.ImageStatusBuilding)
+
+			count, err := service.GetImageSetsViewCount(dbFilter)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(count).To(Equal(int64(0)))
 		})
 
 		It("should return image-set view with corresponding installer iso url and error status ", func() {


### PR DESCRIPTION
align the count sql with the one for data.

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
