### PR TITLE
fixed list-image-sets route count query

### DIFF
--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -208,7 +208,7 @@ func ListAllImageSets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	countResult := imageSetFilters(r, db.OrgDB(orgID, db.DB, "Image_Sets").Debug().Model(&models.ImageSet{})).
-		Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id AND Image_Sets.deleted_at is NULL`).Distinct("image_sets.id").Count(&count)
+		Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id AND Images.deleted_at is NULL`).Distinct("image_sets.id").Count(&count)
 
 	if countResult.Error != nil {
 		s.Log.WithField("error", countResult.Error.Error()).Error("Error counting results for image sets list")

--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -208,7 +208,7 @@ func ListAllImageSets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	countResult := imageSetFilters(r, db.OrgDB(orgID, db.DB, "Image_Sets").Debug().Model(&models.ImageSet{})).
-		Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id`).Distinct("image_sets.id").Count(&count)
+		Joins(`JOIN Images ON Image_Sets.id = Images.image_set_id AND Image_Sets.deleted_at is NULL`).Distinct("image_sets.id").Count(&count)
 
 	if countResult.Error != nil {
 		s.Log.WithField("error", countResult.Error.Error()).Error("Error counting results for image sets list")


### PR DESCRIPTION
# Description

the count query needs to be updated as well to ignore deleted image-sets 

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
