### PR TITLE
Added coverage-output-no-fdo on lint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -100,6 +100,9 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout edge-api
 
+      - name: Run Go Test Coverage output without fdo
+        run: make coverage-output-no-fdo
+
       - name: Run Go Test Coverage without fdo
         run: make coverage-no-fdo
 

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,9 @@ build-test-container:
 coverage:
 	go test $(BUILD_TAGS) $$(go list $(BUILD_TAGS) ./... | grep -v $(EXCLUDE_DIRS)) $(TEST_OPTIONS) -coverprofile=coverage.txt -covermode=atomic
 
+coverage-output-no-fdo:
+	go test $$(go list ./... | grep -v $(EXCLUDE_DIRS)) $(TEST_OPTIONS) -coverprofile=coverage.txt -covermode=atomic
+
 coverage-html:
 	go tool cover -html=coverage.txt -o coverage.html
 


### PR DESCRIPTION
# Description
The step `coverage-no-fdo` is failing and it's not showing any logs, so adding `coverage-output-no-fdo` on lint action to show the logs.

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
