### PR TITLE
Remove deprecated option and travis comments from mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -57,12 +57,10 @@ pull_request_rules:
       - author~=^dependabot(|-preview)\[bot\]$
       - and: *common-merge-criteria
       - check-success=Lint
-      # - check-success=Travis CI - Pull Request
     actions:
       queue:
         name: edge-api
         method: merge
-        rebase_fallback: none
   #
   # If PR check fails, request resolution (prevent stalling the merge queue)
   - name: Request PR check re-run
@@ -76,7 +74,6 @@ pull_request_rules:
           - or:
               - -check-success=ci.int.devshift.net PR build
               - -check-success=Lint
-              # - -check-success=Travis CI - Pull Request
     actions:
       comment:
         message: "This pull request needs all pr-checks to run successfully. Could you fix it @{{author}}? 🙏"
@@ -90,7 +87,6 @@ pull_request_rules:
       - base=main
       - and: *common-merge-criteria
       - check-success=Lint
-      # - check-success=Travis CI - Pull Request
       - check-success=ci.int.devshift.net PR build
       - label!=work in progress
       - label!=do not merge
@@ -101,7 +97,6 @@ pull_request_rules:
       queue:
         name: edge-api
         method: merge
-        rebase_fallback: none
   #
   # Detect when PR conflicts and add label
   - name: warn on conflicts


### PR DESCRIPTION
# Description

1) Remove deprecated mergify option
2) Remove travis comments from mergify

Fixes # (issue)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

yamllint + dashboard verification of configuration