### PR TITLE
updates: FIXES ValidateUpdateSelection images.

### DIFF
--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -703,7 +703,7 @@ func (s *UpdateService) UpdateDevicesFromUpdateTransaction(update models.UpdateT
 // ValidateUpdateSelection validate the images for update
 func (s *UpdateService) ValidateUpdateSelection(orgID string, imageIds []uint) (bool, error) {
 	var count int64
-	if result := db.Org(orgID, "").Debug().Table("images").Where(`id IN ?`, imageIds).Group("image_set_id").Count(&count); result.Error != nil {
+	if result := db.Org(orgID, "").Table("images").Distinct("image_set_id").Where(`id IN ?`, imageIds).Count(&count); result.Error != nil {
 		return false, result.Error
 	}
 


### PR DESCRIPTION
The sql produced does reflect what was intended:

The produced in the broken one:  
SELECT count(*) FROM `images` WHERE (org_id = "00000000" ) AND id IN (53,54) GROUP BY `image_set_id`

 The produced now: 
 SELECT COUNT(DISTINCT(`image_set_id`)) FROM `images` WHERE (org_id = "00000000" ) AND id IN (48,49) 
 
 This has been discovered when gorm has changed/fixed many things https://github.com/RedHatInsights/edge-api/pull/1791

This is already covered by unittests.

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
