### PR TITLE
image-sets: Fixes image-sets linter problems and remove any linter skipping.

### DIFF
--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -1,5 +1,3 @@
-// FIXME: golangci-lint
-// nolint:gocritic,govet,revive
 package routes
 
 import (
@@ -12,12 +10,12 @@ import (
 
 	"github.com/redhatinsights/edge-api/pkg/db"
 	"github.com/redhatinsights/edge-api/pkg/dependencies"
+	"github.com/redhatinsights/edge-api/pkg/errors"
 	"github.com/redhatinsights/edge-api/pkg/models"
+	"github.com/redhatinsights/edge-api/pkg/routes/common"
 	"github.com/redhatinsights/edge-api/pkg/services"
 
 	"github.com/go-chi/chi"
-	"github.com/redhatinsights/edge-api/pkg/errors"
-	"github.com/redhatinsights/edge-api/pkg/routes/common"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
@@ -576,9 +574,8 @@ func GetImageSetViewByID(w http.ResponseWriter, r *http.Request) {
 		// log and response handled by getContextImageSet
 		return
 	}
-	imagesDBFilters := imageDetailFilters(r, db.DB)
-	pagination := common.GetPagination(r)
-	imageSetIDView, err := ctxServices.ImageSetService.GetImageSetViewByID(imageSet.ID, pagination.Limit, pagination.Offset, imagesDBFilters)
+
+	imageSetIDView, err := ctxServices.ImageSetService.GetImageSetViewByID(imageSet.ID)
 	if err != nil {
 		var apiError errors.APIError
 		switch err.(type) {

--- a/pkg/routes/imagesets_test.go
+++ b/pkg/routes/imagesets_test.go
@@ -1,5 +1,3 @@
-// FIXME: golangci-lint
-// nolint:govet,ineffassign,revive,staticcheck,typecheck
 package routes
 
 import (
@@ -13,21 +11,21 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/bxcodec/faker/v3"
-	"github.com/go-chi/chi"
-	"github.com/redhatinsights/edge-api/pkg/errors"
-	"github.com/redhatinsights/edge-api/pkg/services"
-	"github.com/redhatinsights/edge-api/pkg/services/mock_services"
-	log "github.com/sirupsen/logrus"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"github.com/redhatinsights/edge-api/pkg/db"
 	"github.com/redhatinsights/edge-api/pkg/dependencies"
-
-	"github.com/golang/mock/gomock"
+	"github.com/redhatinsights/edge-api/pkg/errors"
 	"github.com/redhatinsights/edge-api/pkg/models"
 	"github.com/redhatinsights/edge-api/pkg/routes/common"
+	"github.com/redhatinsights/edge-api/pkg/services"
+	"github.com/redhatinsights/edge-api/pkg/services/mock_services"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/go-chi/chi"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestListAllImageSets(t *testing.T) {
@@ -220,6 +218,8 @@ func TestGetImageSetsDevicesByID(t *testing.T) {
 	}
 
 	respBody, err := ioutil.ReadAll(rr.Body)
+	assert.NoError(t, err)
+
 	jsonBody := ImageSetDevices{}
 	err = json.Unmarshal(respBody, &jsonBody)
 	if err != nil {
@@ -627,6 +627,8 @@ var _ = Describe("ImageSets Route Test", func() {
 
 				var allImageSetsResponse AllImageSetsResponse
 				respBody, err := ioutil.ReadAll(rr.Body)
+				Expect(err).ToNot(HaveOccurred())
+
 				err = json.Unmarshal(respBody, &allImageSetsResponse)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(allImageSetsResponse.Data) > 0).To(BeTrue())
@@ -663,6 +665,8 @@ var _ = Describe("ImageSets Route Test", func() {
 				Expect(rr.Code).To(Equal(http.StatusOK))
 				var imageSetDetailsResponse ImageSetDetailsResponse
 				respBody, err := ioutil.ReadAll(rr.Body)
+				Expect(err).ToNot(HaveOccurred())
+
 				err = json.Unmarshal(respBody, &imageSetDetailsResponse)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(imageSetDetailsResponse.Count).To(Equal(2))
@@ -762,6 +766,8 @@ var _ = Describe("ImageSets Route Test", func() {
 
 			var imageSetsViewResponse ImageSetsViewResponse
 			respBody, err := ioutil.ReadAll(rr.Body)
+			Expect(err).ToNot(HaveOccurred())
+
 			err = json.Unmarshal(respBody, &imageSetsViewResponse)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(imageSetsViewResponse.Count).To(Equal(2))
@@ -811,6 +817,8 @@ var _ = Describe("ImageSets Route Test", func() {
 
 				var imageSetsViewResponse ImageSetsViewResponse
 				respBody, err := ioutil.ReadAll(rr.Body)
+				Expect(err).ToNot(HaveOccurred())
+
 				err = json.Unmarshal(respBody, &imageSetsViewResponse)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(imageSetsViewResponse.Count).To(Equal(1))
@@ -828,6 +836,8 @@ var _ = Describe("ImageSets Route Test", func() {
 
 				var imageSetsViewResponse ImageSetsViewResponse
 				respBody, err := ioutil.ReadAll(rr.Body)
+				Expect(err).ToNot(HaveOccurred())
+
 				err = json.Unmarshal(respBody, &imageSetsViewResponse)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(imageSetsViewResponse.Count).To(Equal(0))
@@ -844,6 +854,7 @@ var _ = Describe("ImageSets Route Test", func() {
 
 				var responseError []validationError
 				respBody, err := ioutil.ReadAll(rr.Body)
+				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
 				Expect(err).ToNot(HaveOccurred())
@@ -862,6 +873,7 @@ var _ = Describe("ImageSets Route Test", func() {
 
 				var responseError []validationError
 				respBody, err := ioutil.ReadAll(rr.Body)
+				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
 				Expect(err).ToNot(HaveOccurred())
@@ -879,6 +891,7 @@ var _ = Describe("ImageSets Route Test", func() {
 
 				var responseError []validationError
 				respBody, err := ioutil.ReadAll(rr.Body)
+				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
 				Expect(err).ToNot(HaveOccurred())
@@ -887,9 +900,9 @@ var _ = Describe("ImageSets Route Test", func() {
 				Expect(responseError[0].Key).To(Equal("sort_by"))
 			})
 			It("the image set view image version sort is responding as expected", func() {
-				sort_args := []string{"created_at", "updated_at", "-updated_at", "-name"}
-				for _, sort_arg := range sort_args {
-					req, err := http.NewRequest("GET", fmt.Sprintf("/image-sets/view?sort_by=%s", sort_arg), nil)
+				sortArgs := []string{"created_at", "updated_at", "-updated_at", "-name"}
+				for _, sortArg := range sortArgs {
+					req, err := http.NewRequest("GET", fmt.Sprintf("/image-sets/view?sort_by=%s", sortArg), nil)
 					Expect(err).ToNot(HaveOccurred())
 
 					rr := httptest.NewRecorder()
@@ -898,10 +911,12 @@ var _ = Describe("ImageSets Route Test", func() {
 
 					var imageSetsViewResponse ImageSetsViewResponse
 					respBody, err := ioutil.ReadAll(rr.Body)
+					Expect(err).ToNot(HaveOccurred())
+
 					err = json.Unmarshal(respBody, &imageSetsViewResponse)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(len(imageSetsViewResponse.Data) > 2).To(BeTrue())
-					switch sort_arg {
+					switch sortArg {
 					case "name":
 						for i := 0; i < len(imageSetsViewResponse.Data)-1; i++ {
 							Expect(imageSetsViewResponse.Data[i].Name <= imageSetsViewResponse.Data[i+1].Name).To(BeTrue())
@@ -929,7 +944,7 @@ var _ = Describe("ImageSets Route Test", func() {
 			It("The imageSetView end point is working as expected", func() {
 				req, err := http.NewRequest("GET", fmt.Sprintf("/image-sets/view/%d", imageSet1.ID), nil)
 				Expect(err).ToNot(HaveOccurred())
-				mockImageSetService.EXPECT().GetImageSetViewByID(imageSet1.ID, 30, 0, gomock.Any()).Return(&services.ImageSetIDView{}, nil)
+				mockImageSetService.EXPECT().GetImageSetViewByID(imageSet1.ID).Return(&services.ImageSetIDView{}, nil)
 
 				rr := httptest.NewRecorder()
 				router.ServeHTTP(rr, req)
@@ -954,7 +969,7 @@ var _ = Describe("ImageSets Route Test", func() {
 			It("The imageSetView end point return not found when image not found", func() {
 				req, err := http.NewRequest("GET", fmt.Sprintf("/image-sets/view/%d", imageSet1.ID), nil)
 				Expect(err).ToNot(HaveOccurred())
-				mockImageSetService.EXPECT().GetImageSetViewByID(imageSet1.ID, 30, 0, gomock.Any()).Return(nil, new(services.ImageNotFoundError))
+				mockImageSetService.EXPECT().GetImageSetViewByID(imageSet1.ID).Return(nil, new(services.ImageNotFoundError))
 
 				rr := httptest.NewRecorder()
 				router.ServeHTTP(rr, req)
@@ -1012,6 +1027,7 @@ var _ = Describe("ImageSets Route Test", func() {
 
 				var responseError []validationError
 				respBody, err := ioutil.ReadAll(rr.Body)
+				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
 				Expect(err).ToNot(HaveOccurred())
@@ -1029,6 +1045,7 @@ var _ = Describe("ImageSets Route Test", func() {
 
 				var responseError []validationError
 				respBody, err := ioutil.ReadAll(rr.Body)
+				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
 				Expect(err).ToNot(HaveOccurred())
@@ -1037,9 +1054,9 @@ var _ = Describe("ImageSets Route Test", func() {
 				Expect(responseError[0].Key).To(Equal("sort_by"))
 			})
 			It("the image set view image version sort is responding as expected", func() {
-				sort_args := []string{"created_at", "name", "version", "-version"}
-				for _, sort_arg := range sort_args {
-					req, err := http.NewRequest("GET", fmt.Sprintf("/image-sets/view/%d/versions?sort_by=%s", imageSet1.ID, sort_arg), nil)
+				sortArgs := []string{"created_at", "name", "version", "-version"}
+				for _, sortArg := range sortArgs {
+					req, err := http.NewRequest("GET", fmt.Sprintf("/image-sets/view/%d/versions?sort_by=%s", imageSet1.ID, sortArg), nil)
 					Expect(err).ToNot(HaveOccurred())
 
 					mockImageSetService.EXPECT().GetImagesViewData(imageSet1.ID, 30, 0, gomock.Any()).Return(&services.ImagesViewData{}, nil)
@@ -1059,6 +1076,7 @@ var _ = Describe("ImageSets Route Test", func() {
 
 				var responseError []validationError
 				respBody, err := ioutil.ReadAll(rr.Body)
+				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
 				Expect(err).ToNot(HaveOccurred())
@@ -1076,6 +1094,7 @@ var _ = Describe("ImageSets Route Test", func() {
 
 				var responseError []validationError
 				respBody, err := ioutil.ReadAll(rr.Body)
+				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
 				Expect(err).ToNot(HaveOccurred())
@@ -1093,6 +1112,7 @@ var _ = Describe("ImageSets Route Test", func() {
 
 				var responseError []validationError
 				respBody, err := ioutil.ReadAll(rr.Body)
+				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
 				Expect(err).ToNot(HaveOccurred())
@@ -1110,6 +1130,7 @@ var _ = Describe("ImageSets Route Test", func() {
 
 				var responseError []validationError
 				respBody, err := ioutil.ReadAll(rr.Body)
+				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/services/imagesets_test.go
+++ b/pkg/services/imagesets_test.go
@@ -1,5 +1,3 @@
-// FIXME: golangci-lint
-// nolint:revive,typecheck
 package services_test
 
 import (
@@ -182,8 +180,7 @@ var _ = Describe("ImageSets Service Test", func() {
 		db.DB.Create(&otherImage1)
 
 		It("GetImageSetViewByID returns ImageSet details as expected", func() {
-			imagesOrderByDB := db.DB.Order("images.created_at DESC")
-			imageSetIDView, err := service.GetImageSetViewByID(imageSet1.ID, 30, 0, imagesOrderByDB)
+			imageSetIDView, err := service.GetImageSetViewByID(imageSet1.ID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(imageSetIDView.ImageSet.ID).To(Equal(imageSet1.ID))
 			Expect(imageSetIDView.ImageBuildIsoURL).To(Equal(fmt.Sprintf("/api/edge/v1/storage/isos/%d", image2.Installer.ID)))
@@ -230,7 +227,7 @@ var _ = Describe("ImageSets Service Test", func() {
 			Expect(imageSetsView).ToNot(BeNil())
 			Expect(len(*imageSetsView) > 0).To(BeTrue())
 			for _, imageSetsViewItem := range *imageSetsView {
-				imageSetView, err := service.GetImageSetViewByID(imageSetsViewItem.ID, 100, 0, nil) // nolint:govet
+				imageSetView, err := service.GetImageSetViewByID(imageSetsViewItem.ID)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(imageSetView).ToNot(BeNil())
 				Expect(imageSetsViewItem.UpdatedAt).To(Equal(imageSetView.LastImageDetails.Image.UpdatedAt))

--- a/pkg/services/mock_services/imagesets.go
+++ b/pkg/services/mock_services/imagesets.go
@@ -7,126 +7,67 @@ package mock_services
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
 	models "github.com/redhatinsights/edge-api/pkg/models"
 	services "github.com/redhatinsights/edge-api/pkg/services"
+
 	gorm "gorm.io/gorm"
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockImageSetsServiceInterface is a mock of ImageSetsServiceInterface interface
+// MockImageSetsServiceInterface is a mock of ImageSetsServiceInterface interface.
 type MockImageSetsServiceInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockImageSetsServiceInterfaceMockRecorder
 }
 
-// MockImageSetsServiceInterfaceMockRecorder is the mock recorder for MockImageSetsServiceInterface
+// MockImageSetsServiceInterfaceMockRecorder is the mock recorder for MockImageSetsServiceInterface.
 type MockImageSetsServiceInterfaceMockRecorder struct {
 	mock *MockImageSetsServiceInterface
 }
 
-// NewMockImageSetsServiceInterface creates a new mock instance
+// NewMockImageSetsServiceInterface creates a new mock instance.
 func NewMockImageSetsServiceInterface(ctrl *gomock.Controller) *MockImageSetsServiceInterface {
 	mock := &MockImageSetsServiceInterface{ctrl: ctrl}
 	mock.recorder = &MockImageSetsServiceInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockImageSetsServiceInterface) EXPECT() *MockImageSetsServiceInterfaceMockRecorder {
 	return m.recorder
 }
 
-// GetImageSetsByID mocks base method
-func (m *MockImageSetsServiceInterface) GetImageSetsByID(imageSetID int) (*models.ImageSet, error) {
+// DeleteImageSet mocks base method.
+func (m *MockImageSetsServiceInterface) DeleteImageSet(imageSetID uint) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetImageSetsByID", imageSetID)
-	ret0, _ := ret[0].(*models.ImageSet)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "DeleteImageSet", imageSetID)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// GetImageSetsByID indicates an expected call of GetImageSetsByID
-func (mr *MockImageSetsServiceInterfaceMockRecorder) GetImageSetsByID(imageSetID interface{}) *gomock.Call {
+// DeleteImageSet indicates an expected call of DeleteImageSet.
+func (mr *MockImageSetsServiceInterfaceMockRecorder) DeleteImageSet(imageSetID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageSetsByID", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).GetImageSetsByID), imageSetID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteImageSet", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).DeleteImageSet), imageSetID)
 }
 
-// GetImageSetsViewCount mocks base method
-func (m *MockImageSetsServiceInterface) GetImageSetsViewCount(tx *gorm.DB) (int64, error) {
+// GetDeviceIdsByImageSetID mocks base method.
+func (m *MockImageSetsServiceInterface) GetDeviceIdsByImageSetID(imageSetID uint) (int, []string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetImageSetsViewCount", tx)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "GetDeviceIdsByImageSetID", imageSetID)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].([]string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
-// GetImageSetsViewCount indicates an expected call of GetImageSetsViewCount
-func (mr *MockImageSetsServiceInterfaceMockRecorder) GetImageSetsViewCount(tx interface{}) *gomock.Call {
+// GetDeviceIdsByImageSetID indicates an expected call of GetDeviceIdsByImageSetID.
+func (mr *MockImageSetsServiceInterfaceMockRecorder) GetDeviceIdsByImageSetID(imageSetID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageSetsViewCount", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).GetImageSetsViewCount), tx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceIdsByImageSetID", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).GetDeviceIdsByImageSetID), imageSetID)
 }
 
-// GetImageSetsView mocks base method
-func (m *MockImageSetsServiceInterface) GetImageSetsView(limit, offset int, tx *gorm.DB) (*[]models.ImageSetView, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetImageSetsView", limit, offset, tx)
-	ret0, _ := ret[0].(*[]models.ImageSetView)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetImageSetsView indicates an expected call of GetImageSetsView
-func (mr *MockImageSetsServiceInterfaceMockRecorder) GetImageSetsView(limit, offset, tx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageSetsView", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).GetImageSetsView), limit, offset, tx)
-}
-
-// GetImageSetViewByID mocks base method
-func (m *MockImageSetsServiceInterface) GetImageSetViewByID(imageSetID uint, imagesLimit, imagesOffSet int, imagesDBFilter *gorm.DB) (*services.ImageSetIDView, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetImageSetViewByID", imageSetID, imagesLimit, imagesOffSet, imagesDBFilter)
-	ret0, _ := ret[0].(*services.ImageSetIDView)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetImageSetViewByID indicates an expected call of GetImageSetViewByID
-func (mr *MockImageSetsServiceInterfaceMockRecorder) GetImageSetViewByID(imageSetID, imagesLimit, imagesOffSet, imagesDBFilter interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageSetViewByID", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).GetImageSetViewByID), imageSetID, imagesLimit, imagesOffSet, imagesDBFilter)
-}
-
-// GetImageSetsBuildIsoURL mocks base method
-func (m *MockImageSetsServiceInterface) GetImageSetsBuildIsoURL(orgID string, imageSetIDS []uint) (map[uint]uint, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetImageSetsBuildIsoURL", orgID, imageSetIDS)
-	ret0, _ := ret[0].(map[uint]uint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetImageSetsBuildIsoURL indicates an expected call of GetImageSetsBuildIsoURL
-func (mr *MockImageSetsServiceInterfaceMockRecorder) GetImageSetsBuildIsoURL(orgID, imageSetIDS interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageSetsBuildIsoURL", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).GetImageSetsBuildIsoURL), orgID, imageSetIDS)
-}
-
-// GetImagesViewData mocks base method
-func (m *MockImageSetsServiceInterface) GetImagesViewData(imageSetID uint, imagesLimit, imagesOffSet int, tx *gorm.DB) (*services.ImagesViewData, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetImagesViewData", imageSetID, imagesLimit, imagesOffSet, tx)
-	ret0, _ := ret[0].(*services.ImagesViewData)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetImagesViewData indicates an expected call of GetImagesViewData
-func (mr *MockImageSetsServiceInterfaceMockRecorder) GetImagesViewData(imageSetID, imagesLimit, imagesOffSet, tx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImagesViewData", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).GetImagesViewData), imageSetID, imagesLimit, imagesOffSet, tx)
-}
-
-// GetImageSetImageViewByID mocks base method
+// GetImageSetImageViewByID mocks base method.
 func (m *MockImageSetsServiceInterface) GetImageSetImageViewByID(imageSetID, imageID uint) (*services.ImageSetImageIDView, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetImageSetImageViewByID", imageSetID, imageID)
@@ -135,38 +76,98 @@ func (m *MockImageSetsServiceInterface) GetImageSetImageViewByID(imageSetID, ima
 	return ret0, ret1
 }
 
-// GetImageSetImageViewByID indicates an expected call of GetImageSetImageViewByID
+// GetImageSetImageViewByID indicates an expected call of GetImageSetImageViewByID.
 func (mr *MockImageSetsServiceInterfaceMockRecorder) GetImageSetImageViewByID(imageSetID, imageID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageSetImageViewByID", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).GetImageSetImageViewByID), imageSetID, imageID)
 }
 
-// GetDeviceIdsByImageSetID mocks base method
-func (m *MockImageSetsServiceInterface) GetDeviceIdsByImageSetID(imageSetId uint) (int, []string, error) {
+// GetImageSetViewByID mocks base method.
+func (m *MockImageSetsServiceInterface) GetImageSetViewByID(imageSetID uint) (*services.ImageSetIDView, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeviceIdsByImageSetID", imageSetId)
-	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].([]string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret := m.ctrl.Call(m, "GetImageSetViewByID", imageSetID)
+	ret0, _ := ret[0].(*services.ImageSetIDView)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// GetDeviceIdsByImageSetID indicates an expected call of GetDeviceIdsByImageSetID
-func (mr *MockImageSetsServiceInterfaceMockRecorder) GetDeviceIdsByImageSetID(imageSetId interface{}) *gomock.Call {
+// GetImageSetViewByID indicates an expected call of GetImageSetViewByID.
+func (mr *MockImageSetsServiceInterfaceMockRecorder) GetImageSetViewByID(imageSetID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceIdsByImageSetID", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).GetDeviceIdsByImageSetID), imageSetId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageSetViewByID", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).GetImageSetViewByID), imageSetID)
 }
 
-// DeleteImageSet mocks base method
-func (m *MockImageSetsServiceInterface) DeleteImageSet(imageSetID uint) error {
+// GetImageSetsBuildIsoURL mocks base method.
+func (m *MockImageSetsServiceInterface) GetImageSetsBuildIsoURL(orgID string, imageSetIDS []uint) (map[uint]uint, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteImageSet", imageSetID)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "GetImageSetsBuildIsoURL", orgID, imageSetIDS)
+	ret0, _ := ret[0].(map[uint]uint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// DeleteImageSet indicates an expected call of DeleteImageSet
-func (mr *MockImageSetsServiceInterfaceMockRecorder) DeleteImageSet(imageSetID interface{}) *gomock.Call {
+// GetImageSetsBuildIsoURL indicates an expected call of GetImageSetsBuildIsoURL.
+func (mr *MockImageSetsServiceInterfaceMockRecorder) GetImageSetsBuildIsoURL(orgID, imageSetIDS interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteImageSet", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).DeleteImageSet), imageSetID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageSetsBuildIsoURL", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).GetImageSetsBuildIsoURL), orgID, imageSetIDS)
+}
+
+// GetImageSetsByID mocks base method.
+func (m *MockImageSetsServiceInterface) GetImageSetsByID(imageSetID int) (*models.ImageSet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImageSetsByID", imageSetID)
+	ret0, _ := ret[0].(*models.ImageSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImageSetsByID indicates an expected call of GetImageSetsByID.
+func (mr *MockImageSetsServiceInterfaceMockRecorder) GetImageSetsByID(imageSetID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageSetsByID", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).GetImageSetsByID), imageSetID)
+}
+
+// GetImageSetsView mocks base method.
+func (m *MockImageSetsServiceInterface) GetImageSetsView(limit, offset int, tx *gorm.DB) (*[]models.ImageSetView, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImageSetsView", limit, offset, tx)
+	ret0, _ := ret[0].(*[]models.ImageSetView)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImageSetsView indicates an expected call of GetImageSetsView.
+func (mr *MockImageSetsServiceInterfaceMockRecorder) GetImageSetsView(limit, offset, tx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageSetsView", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).GetImageSetsView), limit, offset, tx)
+}
+
+// GetImageSetsViewCount mocks base method.
+func (m *MockImageSetsServiceInterface) GetImageSetsViewCount(tx *gorm.DB) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImageSetsViewCount", tx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImageSetsViewCount indicates an expected call of GetImageSetsViewCount.
+func (mr *MockImageSetsServiceInterfaceMockRecorder) GetImageSetsViewCount(tx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageSetsViewCount", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).GetImageSetsViewCount), tx)
+}
+
+// GetImagesViewData mocks base method.
+func (m *MockImageSetsServiceInterface) GetImagesViewData(imageSetID uint, imagesLimit, imagesOffSet int, tx *gorm.DB) (*services.ImagesViewData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImagesViewData", imageSetID, imagesLimit, imagesOffSet, tx)
+	ret0, _ := ret[0].(*services.ImagesViewData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImagesViewData indicates an expected call of GetImagesViewData.
+func (mr *MockImageSetsServiceInterfaceMockRecorder) GetImagesViewData(imageSetID, imagesLimit, imagesOffSet, tx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImagesViewData", reflect.TypeOf((*MockImageSetsServiceInterface)(nil).GetImagesViewData), imageSetID, imagesLimit, imagesOffSet, tx)
 }


### PR DESCRIPTION
Fixing code to satisfy linters, remove skipping from image-sets files 


 
## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
