### PR TITLE
image-sets: remove the deprecated ioutil.ReadAll.

### DIFF
--- a/pkg/routes/imagesets_test.go
+++ b/pkg/routes/imagesets_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -43,7 +43,7 @@ func TestListAllImageSets(t *testing.T) {
 			status, http.StatusOK)
 
 	}
-	respBody, err := ioutil.ReadAll(rr.Body)
+	respBody, err := io.ReadAll(rr.Body)
 	if err != nil {
 		t.Errorf("failed reading response body: %s", err.Error())
 	}
@@ -217,7 +217,7 @@ func TestGetImageSetsDevicesByID(t *testing.T) {
 			status, http.StatusOK)
 	}
 
-	respBody, err := ioutil.ReadAll(rr.Body)
+	respBody, err := io.ReadAll(rr.Body)
 	assert.NoError(t, err)
 
 	jsonBody := ImageSetDevices{}
@@ -539,7 +539,7 @@ var _ = Describe("ImageSets Route Test", func() {
 				handler := http.HandlerFunc(ListAllImageSets)
 				handler.ServeHTTP(w, req)
 				Expect(w.Code).To(Equal(http.StatusOK), fmt.Sprintf("expected status %d, but got %d", w.Code, http.StatusOK))
-				respBody, err := ioutil.ReadAll(w.Body)
+				respBody, err := io.ReadAll(w.Body)
 				Expect(err).To(BeNil())
 				Expect(string(respBody)).To(ContainSubstring(name))
 				Expect(string(respBody)).ToNot(ContainSubstring("image-set-2"))
@@ -555,7 +555,7 @@ var _ = Describe("ImageSets Route Test", func() {
 				handler := http.HandlerFunc(ListAllImageSets)
 				handler.ServeHTTP(w, req)
 				Expect(w.Code).To(Equal(http.StatusOK), fmt.Sprintf("expected status %d, but got %d", w.Code, http.StatusOK))
-				respBody, err := ioutil.ReadAll(w.Body)
+				respBody, err := io.ReadAll(w.Body)
 				Expect(err).To(BeNil())
 				Expect(string(respBody)).To(ContainSubstring("image-set-2"))
 				Expect(string(respBody)).ToNot(ContainSubstring("image-set-1"))
@@ -626,7 +626,7 @@ var _ = Describe("ImageSets Route Test", func() {
 				Expect(rr.Code).To(Equal(http.StatusOK))
 
 				var allImageSetsResponse AllImageSetsResponse
-				respBody, err := ioutil.ReadAll(rr.Body)
+				respBody, err := io.ReadAll(rr.Body)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &allImageSetsResponse)
@@ -664,7 +664,7 @@ var _ = Describe("ImageSets Route Test", func() {
 				router.ServeHTTP(rr, req)
 				Expect(rr.Code).To(Equal(http.StatusOK))
 				var imageSetDetailsResponse ImageSetDetailsResponse
-				respBody, err := ioutil.ReadAll(rr.Body)
+				respBody, err := io.ReadAll(rr.Body)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &imageSetDetailsResponse)
@@ -765,7 +765,7 @@ var _ = Describe("ImageSets Route Test", func() {
 			Expect(rr.Code).To(Equal(http.StatusOK))
 
 			var imageSetsViewResponse ImageSetsViewResponse
-			respBody, err := ioutil.ReadAll(rr.Body)
+			respBody, err := io.ReadAll(rr.Body)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = json.Unmarshal(respBody, &imageSetsViewResponse)
@@ -816,7 +816,7 @@ var _ = Describe("ImageSets Route Test", func() {
 				Expect(rr.Code).To(Equal(http.StatusOK))
 
 				var imageSetsViewResponse ImageSetsViewResponse
-				respBody, err := ioutil.ReadAll(rr.Body)
+				respBody, err := io.ReadAll(rr.Body)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &imageSetsViewResponse)
@@ -835,7 +835,7 @@ var _ = Describe("ImageSets Route Test", func() {
 				Expect(rr.Code).To(Equal(http.StatusOK))
 
 				var imageSetsViewResponse ImageSetsViewResponse
-				respBody, err := ioutil.ReadAll(rr.Body)
+				respBody, err := io.ReadAll(rr.Body)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &imageSetsViewResponse)
@@ -853,7 +853,7 @@ var _ = Describe("ImageSets Route Test", func() {
 				Expect(rr.Code).To(Equal(http.StatusBadRequest))
 
 				var responseError []validationError
-				respBody, err := ioutil.ReadAll(rr.Body)
+				respBody, err := io.ReadAll(rr.Body)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
@@ -872,7 +872,7 @@ var _ = Describe("ImageSets Route Test", func() {
 				Expect(rr.Code).To(Equal(http.StatusBadRequest))
 
 				var responseError []validationError
-				respBody, err := ioutil.ReadAll(rr.Body)
+				respBody, err := io.ReadAll(rr.Body)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
@@ -890,7 +890,7 @@ var _ = Describe("ImageSets Route Test", func() {
 				Expect(rr.Code).To(Equal(http.StatusBadRequest))
 
 				var responseError []validationError
-				respBody, err := ioutil.ReadAll(rr.Body)
+				respBody, err := io.ReadAll(rr.Body)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
@@ -910,7 +910,7 @@ var _ = Describe("ImageSets Route Test", func() {
 					Expect(rr.Code).To(Equal(http.StatusOK))
 
 					var imageSetsViewResponse ImageSetsViewResponse
-					respBody, err := ioutil.ReadAll(rr.Body)
+					respBody, err := io.ReadAll(rr.Body)
 					Expect(err).ToNot(HaveOccurred())
 
 					err = json.Unmarshal(respBody, &imageSetsViewResponse)
@@ -1026,7 +1026,7 @@ var _ = Describe("ImageSets Route Test", func() {
 				Expect(rr.Code).To(Equal(http.StatusBadRequest))
 
 				var responseError []validationError
-				respBody, err := ioutil.ReadAll(rr.Body)
+				respBody, err := io.ReadAll(rr.Body)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
@@ -1044,7 +1044,7 @@ var _ = Describe("ImageSets Route Test", func() {
 				Expect(rr.Code).To(Equal(http.StatusBadRequest))
 
 				var responseError []validationError
-				respBody, err := ioutil.ReadAll(rr.Body)
+				respBody, err := io.ReadAll(rr.Body)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
@@ -1075,7 +1075,7 @@ var _ = Describe("ImageSets Route Test", func() {
 				Expect(rr.Code).To(Equal(http.StatusBadRequest))
 
 				var responseError []validationError
-				respBody, err := ioutil.ReadAll(rr.Body)
+				respBody, err := io.ReadAll(rr.Body)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
@@ -1093,7 +1093,7 @@ var _ = Describe("ImageSets Route Test", func() {
 				Expect(rr.Code).To(Equal(http.StatusBadRequest))
 
 				var responseError []validationError
-				respBody, err := ioutil.ReadAll(rr.Body)
+				respBody, err := io.ReadAll(rr.Body)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
@@ -1111,7 +1111,7 @@ var _ = Describe("ImageSets Route Test", func() {
 				Expect(rr.Code).To(Equal(http.StatusBadRequest))
 
 				var responseError []validationError
-				respBody, err := ioutil.ReadAll(rr.Body)
+				respBody, err := io.ReadAll(rr.Body)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)
@@ -1129,7 +1129,7 @@ var _ = Describe("ImageSets Route Test", func() {
 				Expect(rr.Code).To(Equal(http.StatusBadRequest))
 
 				var responseError []validationError
-				respBody, err := ioutil.ReadAll(rr.Body)
+				respBody, err := io.ReadAll(rr.Body)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(respBody, &responseError)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
