### PR TITLE
Add clean target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ EXCLUDE_DIRS=-e /test/ -e /cmd/db -e /cmd/kafka \
 CONTAINERFILE_NAME=Dockerfile
 
 .PHONY:	all bonfire-config-local bonfire-config-github build-containers \
-               build-edge-api-container coverage coverage-html coverage-no-fdo \
+               build-edge-api-container clean coverage coverage-html coverage-no-fdo \
                create-ns deploy-app deploy-env fmt generate-docs help lint pre-commit \
                restart-app scale-down scale-up scan_project test test-clean-no-fdo \
                test-no-fdo vet vet-no-fdo
@@ -68,6 +68,9 @@ build-test-container:
 		--no-cache \
 		--tag "$(TEST_CONTAINER_TAG)" \
 		.
+
+clean:
+	golangci-lint cache clean
 
 coverage:
 	go test $(BUILD_TAGS) $$(go list $(BUILD_TAGS) ./... | grep -v $(EXCLUDE_DIRS)) $(TEST_OPTIONS) -coverprofile=coverage.txt -covermode=atomic
@@ -105,6 +108,7 @@ help:
 	@echo "build-containers          Builds all the container images"
 	@echo "build-edge-api-container  Builds the edge-api container"
 	@echo "build-test-container      Builds the test container"
+	@echo "clean                     Removes cached golangci files"
 	@echo "coverage                  Runs 'go test' coverage on the project"
 	@echo "coverage-html             Create HTML version of coverage report"
 	@echo "coverage-no-fdo           Runs 'go test' coverage on the project without FDO"


### PR DESCRIPTION
# Description

Add clean target that clears the golangci-lint cache

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
