### PR TITLE
Add ImageSetID to image creation event for notification link.

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -1582,7 +1582,7 @@ func (s *ImageService) SendImageNotification(i *models.Image) (ImageNotification
 
 		event.Metadata = emptyJSON.metaMap
 
-		event.Payload = fmt.Sprintf("{  \"ImageId\" : \"%v\"}", i.ID)
+		event.Payload = fmt.Sprintf("{  \"ImageId\" : \"%v\", \"ImageSetID\" : \"%v\"}", i.ID, i.ImageSetID)
 		events = append(events, event)
 
 		recipient.IgnoreUserPreferences = false


### PR DESCRIPTION
# Description

Add ImageSetID to image creation event for notification link.
Currently we only send the image id and we need both image id and imageset id for the link to the image.

Fixes # (issue)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
