### PR TITLE
clowder: disable DVO check for erroneous ibvents failure

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -425,3 +425,5 @@ parameters:
   name: TENANT_TRANSLATOR_PORT
   required: false
   value: '8892'
+- name: LINT_ANNOTATION
+  value: 'ignore-check.kube-linter.io/minimum-three-replicas'


### PR DESCRIPTION
Signed-off-by: Jonathan Holloway <jholloway@redhat.com>

# Description
Skip check for three replicas currently failing on ibvents (which only requires 1)

FIXES: THEEDGE-3017

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
