### PR TITLE
THEEDGE-3019 Fixes missing data when a device update finishes

### DIFF
--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -540,8 +540,8 @@ func (s *UpdateService) ProcessPlaybookDispatcherRunEvent(message []byte) error 
 	case PlaybookStatusSuccess:
 		// TODO: We might wanna check if it's really success by checking the running hash on the device here
 		dispatchRecord.Status = models.DispatchRecordStatusComplete
-		dispatchRecord.Device.AvailableHash = os.DevNull
 		dispatchRecord.Device.CurrentHash = dispatchRecord.Device.AvailableHash
+		dispatchRecord.Device.AvailableHash = os.DevNull
 	case PlaybookStatusRunning:
 		dispatchRecord.Status = models.DispatchRecordStatusRunning
 	case PlaybookStatusTimeout:
@@ -557,6 +557,12 @@ func (s *UpdateService) ProcessPlaybookDispatcherRunEvent(message []byte) error 
 	}
 
 	result = db.DB.Omit("Device").Save(&dispatchRecord)
+	if result.Error != nil {
+		return result.Error
+	}
+
+	// since it's using Omit, the device is not being saved, then it's required to explicit save the device
+	result = db.DB.Save(&dispatchRecord.Device)
 	if result.Error != nil {
 		return result.Error
 	}


### PR DESCRIPTION
# Description
**AvailableHash** and **CurrentHash** are not being saved when the device update finishes.

FIXES: [THEEDGE-3019](https://issues.redhat.com/browse/THEEDGE-3019)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
