### PR TITLE
images: FIXES change image name when updating.

### DIFF
--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -284,7 +284,8 @@ func CreateImageUpdate(w http.ResponseWriter, r *http.Request) {
 		ctxServices.Log.WithField("error", err.Error()).Error("Failed creating an update to an image")
 		var apiError errors.APIError
 		switch err.(type) {
-		case *services.PackageNameDoesNotExist, *services.ThirdPartyRepositoryInfoIsInvalid, *services.ThirdPartyRepositoryNotFound, *services.ImageNameAlreadyExists, *services.ImageSetAlreadyExists:
+		case *services.PackageNameDoesNotExist, *services.ThirdPartyRepositoryInfoIsInvalid, *services.ThirdPartyRepositoryNotFound,
+			*services.ImageNameAlreadyExists, *services.ImageSetAlreadyExists, *services.ImageNameChangeIsProhibited:
 			apiError = errors.NewBadRequest(err.Error())
 		default:
 			apiError = errors.NewInternalServerError()
@@ -344,6 +345,15 @@ func initImageCreateRequest(w http.ResponseWriter, r *http.Request) (*models.Ima
 	if err := readRequestJSONBody(w, r, ctxServices.Log, &image); err != nil {
 		return nil, err
 	}
+
+	if image.Name == "" {
+		// look if a previous image exists, to handle image name properly.
+		if previousImage, ok := r.Context().Value(imageKey).(*models.Image); ok && previousImage != nil {
+			// when updating from a previousImage and we do not supply an image name set it by default to previousImage.Name
+			image.Name = previousImage.Name
+		}
+	}
+
 	if err := image.ValidateRequest(); err != nil {
 		ctxServices.Log.WithField("error", err.Error()).Info("Error validating image")
 		respondWithAPIError(w, ctxServices.Log, errors.NewBadRequest(err.Error()))

--- a/pkg/services/errors.go
+++ b/pkg/services/errors.go
@@ -41,6 +41,7 @@ const DeviceHasNoImageUpdateMsg = "device has no image update"
 const DevicesHasMoreThanOneImageSetMsg = "device has more than one image-set"
 const ImageHasNoImageSetMsg = "Image has no image-set"
 const ImageCommitNotFoundMsg = "Image commit not found"
+const ImageNameChangeIsProhibitedMsg = "image name change is prohibited in the current context"
 const CommitNotFoundMsg = "Commit was not found"
 const CommitNotValidMsg = "is not valid for update"
 const OstreeNotFoundMsg = "Ostree not found"
@@ -216,6 +217,14 @@ type ImageNotInErrorState struct{}
 
 func (e *ImageNotInErrorState) Error() string {
 	return ImageNotInErrorStateMsg
+}
+
+// ImageNameChangeIsProhibited indicates that the image name was about to change, but this is not allowed
+// mainly this happens when updating an image
+type ImageNameChangeIsProhibited struct{}
+
+func (e *ImageNameChangeIsProhibited) Error() string {
+	return ImageNameChangeIsProhibitedMsg
 }
 
 // ImageSetInUse indicates unable to delete an image set

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -307,6 +307,13 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 	// otherwise image will be orphaned from its imageSet if previous build failed
 	image.ImageSetID = previousImage.ImageSetID
 	image.OrgID = previousImage.OrgID
+	if image.Name == "" {
+		// set the name to previous image name, as it must be obvious that it should be the same.
+		image.Name = previousImage.Name
+	} else if image.Name != previousImage.Name {
+		// as we are updating image version, do not allow image to change its name, as the name may be used as image ref.
+		return new(ImageNameChangeIsProhibited)
+	}
 
 	var currentImageSet models.ImageSet
 	result := db.DB.Where("Id = ?", previousImage.ImageSetID).First(&currentImageSet)


### PR DESCRIPTION
# Description
The current implementation is allowing to change the image name when updating an image via API, this should not be allowed as image names are refs. 

This PR fixes this behavior by:
1. if the update image name is empty, set it to previous image name. 
2. if the update image name is not empty and different from the previous image name return error.

FIXES: THEEDGE-2128

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor


# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

