### PR TITLE
update-repo: FIXES BuildUpdateRepo with OldCommits.

### DIFF
--- a/pkg/services/repobuilder_test.go
+++ b/pkg/services/repobuilder_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/redhatinsights/edge-api/pkg/services"
 	"github.com/redhatinsights/edge-api/pkg/services/mock_files"
 	"github.com/redhatinsights/edge-api/pkg/services/mock_services"
+	feature "github.com/redhatinsights/edge-api/unleash/features"
 
 	"github.com/bxcodec/faker/v3"
 	"github.com/golang/mock/gomock"
@@ -501,11 +502,9 @@ var _ = Describe("RepoBuilder Service Test", func() {
 					ExternalURL:      false,
 					ImageBuildTarURL: faker.URL(),
 				},
-				// TODO add OldCommit as this need to be investigated (not in the context of the current task)
-				// as seems the OldCommits code in function BuildUpdateRepo cannot be reached in the current implementation
-				//	OldCommits: []models.Commit{
-				// 		{OrgID: orgID, OSTreeCommit: faker.UUIDHyphenated()},
-				//	},
+				// gomega does not support the scenarios with mocking the exec.command,
+				// scenarios with OldCommits will be tested using go testing in TestBuildUpdateRepoWithOldCommits functions
+				OldCommits: []models.Commit{},
 			}
 			err = db.DB.Create(update).Error
 			Expect(err).ToNot(HaveOccurred())
@@ -628,6 +627,582 @@ var _ = Describe("RepoBuilder Service Test", func() {
 		})
 	})
 })
+
+func TestBuildUpdateRepoWithOldCommits(t *testing.T) {
+	g := NewGomegaWithT(t)
+	currentDir, err := os.Getwd()
+	g.Expect(err).ToNot(HaveOccurred())
+	// enable oldCommits feature flag by setting the corresponding env variable
+	err = os.Setenv(feature.BuildUpdateRepoWithOldCommits.EnvVar, "True")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	defer func(dirPath string) {
+		// restore the standard command builder
+		services.BuildCommand = exec.Command
+		// restore the current dir path
+		err = os.Chdir(dirPath)
+		g.Expect(err).ToNot(HaveOccurred())
+		// unset oldCommits feature flag
+		err := os.Unsetenv(feature.BuildUpdateRepoWithOldCommits.EnvVar)
+		g.Expect(err).ToNot(HaveOccurred())
+	}(currentDir)
+
+	initialRepoTempPath := config.Get().RepoTempPath
+	repoTempPath := filepath.Join(os.TempDir(), fmt.Sprintf("repo_temp_test_%d", time.Now().Unix()))
+	err = os.MkdirAll(repoTempPath, 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	ctrl := gomock.NewController(t)
+
+	defer func(mockController *gomock.Controller, createdRepoTempPath string, configRepoTempPath string) {
+		mockController.Finish()
+		config.Get().RepoTempPath = configRepoTempPath
+		_ = os.RemoveAll(createdRepoTempPath)
+	}(ctrl, repoTempPath, initialRepoTempPath)
+
+	// set repo temp path to test predefined location
+	config.Get().RepoTempPath = repoTempPath
+
+	updateTempDirPath := filepath.Join(repoTempPath, "upd")
+	err = os.MkdirAll(updateTempDirPath, 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	mockFilesService := mock_services.NewMockFilesService(ctrl)
+	mockUploader := mock_files.NewMockUploader(ctrl)
+	mockExtractor := mock_files.NewMockExtractor(ctrl)
+	mockDownloader := mock_services.NewMockDownloader(ctrl)
+	ctx := context.Background()
+	logger := log.NewEntry(log.StandardLogger())
+	repoBuilder := services.RepoBuilder{
+		Service:      services.NewService(ctx, logger),
+		FilesService: mockFilesService,
+		Log:          logger,
+	}
+	orgID := faker.UUIDHyphenated()
+	update := &models.UpdateTransaction{
+		OrgID: orgID,
+		Repo:  &models.Repo{},
+		Commit: &models.Commit{
+			OrgID:            orgID,
+			OSTreeCommit:     faker.UUIDHyphenated(),
+			ExternalURL:      false,
+			ImageBuildTarURL: faker.URL(),
+			OSTreeRef:        config.OstreeRefRHEL9,
+		},
+		OldCommits: []models.Commit{
+			{
+				OrgID:            orgID,
+				OSTreeCommit:     faker.UUIDHyphenated(),
+				ImageBuildTarURL: faker.URL(),
+				ExternalURL:      false,
+				OSTreeRef:        config.OstreeRefRHEL9,
+			},
+		},
+	}
+	err = db.DB.Create(update).Error
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateWorkPath := filepath.Join(updateTempDirPath, strconv.FormatUint(uint64(update.ID), 10))
+	updateRepoPath := filepath.Join(updateWorkPath, "repo")
+	err = os.MkdirAll(updateRepoPath, 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateRepoTarFilePath := filepath.Join(updateWorkPath, "repo.tar")
+	_, err = os.Create(updateRepoTarFilePath)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateOldCommitWorkPath := filepath.Join(updateWorkPath, "staging", update.OldCommits[0].OSTreeCommit)
+	err = os.MkdirAll(updateOldCommitWorkPath, 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateOldCommitTarFilePath := filepath.Join(updateOldCommitWorkPath, "repo.tar")
+	_, err = os.Create(updateOldCommitTarFilePath)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateOldCommitRepoPath := filepath.Join(updateOldCommitWorkPath, "repo")
+	expectedRepoURL := faker.URL()
+
+	// GetDownloader should be called two time , one time with the update target commit and one time with old commit
+	mockFilesService.EXPECT().GetDownloader().Return(mockDownloader).Times(2)
+	mockDownloader.EXPECT().DownloadToPath(update.Commit.ImageBuildTarURL, updateRepoTarFilePath).Return(nil)
+	mockDownloader.EXPECT().DownloadToPath(update.OldCommits[0].ImageBuildTarURL, updateOldCommitTarFilePath).Return(nil)
+
+	// GetExtractor should be called two time , one time with the update target commit and one time with old commit
+	mockFilesService.EXPECT().GetExtractor().Return(mockExtractor).Times(2)
+	mockExtractor.EXPECT().Extract(gomock.AssignableToTypeOf(&os.File{}), updateWorkPath).Return(nil)
+	mockExtractor.EXPECT().Extract(gomock.AssignableToTypeOf(&os.File{}), updateOldCommitWorkPath).Return(nil)
+
+	mockFilesService.EXPECT().GetUploader().Return(mockUploader)
+	mockUploader.EXPECT().UploadRepo(updateRepoPath, strconv.FormatUint(uint64(update.ID), 10), "private").Return(expectedRepoURL, nil)
+
+	oldCommitRevision := update.OldCommits[0].OSTreeCommit
+	updateCommitRevision := update.Commit.OSTreeCommit
+
+	expectedExecCalls := []struct {
+		name                string
+		TestHelper          MockTestExecHelper
+		ExpectedOutput      string
+		ExpectedExistStatus int
+		ExpectedCommand     string
+		ExpectExecuted      bool
+	}{
+		{
+			name:                "run ostree command rev-parse for update commit successfully",
+			TestHelper:          NewMockTestExecHelper(t, updateCommitRevision, 0),
+			ExpectedOutput:      updateCommitRevision,
+			ExpectedExistStatus: 0,
+			ExpectedCommand:     fmt.Sprintf("ostree rev-parse --repo %s %s", updateRepoPath, update.Commit.OSTreeRef),
+		},
+		{
+			name:                "run ostree command rev-parse for old commit successfully",
+			TestHelper:          NewMockTestExecHelper(t, oldCommitRevision, 0),
+			ExpectedOutput:      oldCommitRevision,
+			ExpectedExistStatus: 0,
+			ExpectedCommand:     fmt.Sprintf("ostree rev-parse --repo %s %s", updateOldCommitRepoPath, update.OldCommits[0].OSTreeRef),
+		},
+		{
+			name:                "run ostree command pull-local successfully",
+			TestHelper:          NewMockTestExecHelper(t, "pull-local", 0),
+			ExpectedOutput:      "pull-local",
+			ExpectedExistStatus: 0,
+			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree --repo %s pull-local %s %s", updateRepoPath, updateOldCommitRepoPath, oldCommitRevision),
+		},
+		{
+			name:                "run ostree command static-delta successfully",
+			TestHelper:          NewMockTestExecHelper(t, "static-delta", 0),
+			ExpectedOutput:      "static-delta",
+			ExpectedExistStatus: 0,
+			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree --repo %s static-delta generate --from %s --to %s", updateRepoPath, oldCommitRevision, updateCommitRevision),
+		},
+	}
+	// chain TestExecHelper, so that each mock can initiate the next exec command helper
+	for ind := range expectedExecCalls {
+		if ind < (len(expectedExecCalls) - 1) {
+			expectedExecCalls[ind].TestHelper.Next = &expectedExecCalls[ind+1].TestHelper
+		}
+	}
+	// set the first exec command helper mock
+	services.BuildCommand = expectedExecCalls[0].TestHelper.MockExecCommand
+
+	updateTransaction, err := repoBuilder.BuildUpdateRepo(update.ID)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(updateTransaction).ToNot(BeNil())
+	g.Expect(updateTransaction.Repo.URL).To(Equal(expectedRepoURL))
+	g.Expect(updateTransaction.Repo.Status).To(Equal(models.RepoStatusSuccess))
+
+	// ensure all the commands was generated and run as expected
+	for _, testCase := range expectedExecCalls {
+		t.Run(testCase.name, func(t *testing.T) {
+			g.Expect(testCase.TestHelper.Executed).To(BeTrue())
+			g.Expect(testCase.TestHelper.ExistStatus).To(Equal(testCase.ExpectedExistStatus))
+			g.Expect(testCase.TestHelper.Output).To(Equal(testCase.ExpectedOutput))
+			if testCase.ExpectedCommand != "" {
+				g.Expect(testCase.TestHelper.Command).To(Equal(testCase.ExpectedCommand))
+			}
+		})
+	}
+}
+
+func TestBuildUpdateRepoWithOldCommitsStaticDeltaError(t *testing.T) {
+	// should return error when old commit ostree static-delta fails
+	g := NewGomegaWithT(t)
+	currentDir, err := os.Getwd()
+	g.Expect(err).ToNot(HaveOccurred())
+	// enable oldCommits feature flag by setting the corresponding env variable
+	err = os.Setenv(feature.BuildUpdateRepoWithOldCommits.EnvVar, "True")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	defer func(dirPath string) {
+		// restore the standard command builder
+		services.BuildCommand = exec.Command
+		// restore the current dir path
+		err = os.Chdir(dirPath)
+		g.Expect(err).ToNot(HaveOccurred())
+		// unset oldCommits feature flag
+		err := os.Unsetenv(feature.BuildUpdateRepoWithOldCommits.EnvVar)
+		g.Expect(err).ToNot(HaveOccurred())
+	}(currentDir)
+
+	initialRepoTempPath := config.Get().RepoTempPath
+	repoTempPath := filepath.Join(os.TempDir(), fmt.Sprintf("repo_temp_test_%d", time.Now().Unix()))
+	err = os.MkdirAll(repoTempPath, 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	ctrl := gomock.NewController(t)
+
+	defer func(mockController *gomock.Controller, createdRepoTempPath string, configRepoTempPath string) {
+		mockController.Finish()
+		config.Get().RepoTempPath = configRepoTempPath
+		_ = os.RemoveAll(createdRepoTempPath)
+	}(ctrl, repoTempPath, initialRepoTempPath)
+
+	// set repo temp path to test predefined location
+	config.Get().RepoTempPath = repoTempPath
+
+	updateTempDirPath := filepath.Join(repoTempPath, "upd")
+	err = os.MkdirAll(updateTempDirPath, 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	mockFilesService := mock_services.NewMockFilesService(ctrl)
+	mockUploader := mock_files.NewMockUploader(ctrl)
+	mockExtractor := mock_files.NewMockExtractor(ctrl)
+	mockDownloader := mock_services.NewMockDownloader(ctrl)
+	ctx := context.Background()
+	logger := log.NewEntry(log.StandardLogger())
+	repoBuilder := services.RepoBuilder{
+		Service:      services.NewService(ctx, logger),
+		FilesService: mockFilesService,
+		Log:          logger,
+	}
+	orgID := faker.UUIDHyphenated()
+	update := &models.UpdateTransaction{
+		OrgID: orgID,
+		Repo:  &models.Repo{},
+		Commit: &models.Commit{
+			OrgID:            orgID,
+			OSTreeCommit:     faker.UUIDHyphenated(),
+			ExternalURL:      false,
+			ImageBuildTarURL: faker.URL(),
+			OSTreeRef:        config.OstreeRefRHEL9,
+		},
+		OldCommits: []models.Commit{
+			{
+				OrgID:            orgID,
+				OSTreeCommit:     faker.UUIDHyphenated(),
+				ImageBuildTarURL: faker.URL(),
+				ExternalURL:      false,
+				OSTreeRef:        config.OstreeRefRHEL9,
+			},
+		},
+	}
+	err = db.DB.Create(update).Error
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateWorkPath := filepath.Join(updateTempDirPath, strconv.FormatUint(uint64(update.ID), 10))
+	updateRepoPath := filepath.Join(updateWorkPath, "repo")
+	err = os.MkdirAll(updateRepoPath, 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateRepoTarFilePath := filepath.Join(updateWorkPath, "repo.tar")
+	_, err = os.Create(updateRepoTarFilePath)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateOldCommitWorkPath := filepath.Join(updateWorkPath, "staging", update.OldCommits[0].OSTreeCommit)
+	err = os.MkdirAll(updateOldCommitWorkPath, 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateOldCommitTarFilePath := filepath.Join(updateOldCommitWorkPath, "repo.tar")
+	_, err = os.Create(updateOldCommitTarFilePath)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateOldCommitRepoPath := filepath.Join(updateOldCommitWorkPath, "repo")
+	expectedRepoURL := faker.URL()
+
+	// GetDownloader should be called two time , one time with the update target commit and one time with old commit
+	mockFilesService.EXPECT().GetDownloader().Return(mockDownloader).Times(2)
+	mockDownloader.EXPECT().DownloadToPath(update.Commit.ImageBuildTarURL, updateRepoTarFilePath).Return(nil)
+	mockDownloader.EXPECT().DownloadToPath(update.OldCommits[0].ImageBuildTarURL, updateOldCommitTarFilePath).Return(nil)
+
+	// GetExtractor should be called two time , one time with the update target commit and one time with old commit
+	mockFilesService.EXPECT().GetExtractor().Return(mockExtractor).Times(2)
+	mockExtractor.EXPECT().Extract(gomock.AssignableToTypeOf(&os.File{}), updateWorkPath).Return(nil)
+	mockExtractor.EXPECT().Extract(gomock.AssignableToTypeOf(&os.File{}), updateOldCommitWorkPath).Return(nil)
+
+	// we do not expect the repo to be uploaded
+	mockFilesService.EXPECT().GetUploader().Return(mockUploader).Times(0)
+	mockUploader.EXPECT().UploadRepo(updateRepoPath, strconv.FormatUint(uint64(update.ID), 10), "private").Return(expectedRepoURL, nil).Times(0)
+
+	oldCommitRevision := update.OldCommits[0].OSTreeCommit
+	updateCommitRevision := update.Commit.OSTreeCommit
+
+	expectedExecCalls := []struct {
+		name                string
+		TestHelper          MockTestExecHelper
+		ExpectedOutput      string
+		ExpectedExistStatus int
+		ExpectedCommand     string
+		ExpectExecuted      bool
+	}{
+		{
+			name:                "run ostree command rev-parse for update commit successfully",
+			TestHelper:          NewMockTestExecHelper(t, updateCommitRevision, 0),
+			ExpectedOutput:      updateCommitRevision,
+			ExpectedExistStatus: 0,
+			ExpectedCommand:     fmt.Sprintf("ostree rev-parse --repo %s %s", updateRepoPath, update.Commit.OSTreeRef),
+		},
+		{
+			name:                "run ostree command rev-parse for old commit successfully",
+			TestHelper:          NewMockTestExecHelper(t, oldCommitRevision, 0),
+			ExpectedOutput:      oldCommitRevision,
+			ExpectedExistStatus: 0,
+			ExpectedCommand:     fmt.Sprintf("ostree rev-parse --repo %s %s", updateOldCommitRepoPath, update.OldCommits[0].OSTreeRef),
+		},
+		{
+			name:                "run ostree command pull-local successfully",
+			TestHelper:          NewMockTestExecHelper(t, "pull-local", 0),
+			ExpectedOutput:      "pull-local",
+			ExpectedExistStatus: 0,
+			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree --repo %s pull-local %s %s", updateRepoPath, updateOldCommitRepoPath, oldCommitRevision),
+		},
+		{
+			name:                "run ostree command static-delta successfully",
+			TestHelper:          NewMockTestExecHelper(t, "static-delta", 1),
+			ExpectedOutput:      "static-delta",
+			ExpectedExistStatus: 1,
+			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree --repo %s static-delta generate --from %s --to %s", updateRepoPath, oldCommitRevision, updateCommitRevision),
+		},
+	}
+	// chain TestExecHelper, so that each mock can initiate the next exec command helper
+	for ind := range expectedExecCalls {
+		if ind < (len(expectedExecCalls) - 1) {
+			expectedExecCalls[ind].TestHelper.Next = &expectedExecCalls[ind+1].TestHelper
+		}
+	}
+	// set the first exec command helper mock
+	services.BuildCommand = expectedExecCalls[0].TestHelper.MockExecCommand
+
+	_, err = repoBuilder.BuildUpdateRepo(update.ID)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(Equal(fmt.Sprintf("exit status %d", expectedExecCalls[3].ExpectedExistStatus)))
+
+	// ensure all the commands was generated and run as expected
+	for _, testCase := range expectedExecCalls {
+		t.Run(testCase.name, func(t *testing.T) {
+			g.Expect(testCase.TestHelper.Executed).To(BeTrue())
+			g.Expect(testCase.TestHelper.ExistStatus).To(Equal(testCase.ExpectedExistStatus))
+			g.Expect(testCase.TestHelper.Output).To(Equal(testCase.ExpectedOutput))
+			if testCase.ExpectedCommand != "" {
+				g.Expect(testCase.TestHelper.Command).To(Equal(testCase.ExpectedCommand))
+			}
+		})
+	}
+}
+
+func TestBuildUpdateRepoWithOldCommitsExtractVersionRepoError(t *testing.T) {
+	// should return error when old commit ExtractVersionRepo fails
+	g := NewGomegaWithT(t)
+	currentDir, err := os.Getwd()
+	g.Expect(err).ToNot(HaveOccurred())
+	// enable oldCommits feature flag by setting the corresponding env variable
+	err = os.Setenv(feature.BuildUpdateRepoWithOldCommits.EnvVar, "True")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	defer func(dirPath string) {
+		// restore the current dir path
+		err = os.Chdir(dirPath)
+		g.Expect(err).ToNot(HaveOccurred())
+		// unset oldCommits feature flag
+		err := os.Unsetenv(feature.BuildUpdateRepoWithOldCommits.EnvVar)
+		g.Expect(err).ToNot(HaveOccurred())
+	}(currentDir)
+
+	initialRepoTempPath := config.Get().RepoTempPath
+	repoTempPath := filepath.Join(os.TempDir(), fmt.Sprintf("repo_temp_test_%d", time.Now().Unix()))
+	err = os.MkdirAll(repoTempPath, 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	ctrl := gomock.NewController(t)
+
+	defer func(mockController *gomock.Controller, createdRepoTempPath string, configRepoTempPath string) {
+		mockController.Finish()
+		config.Get().RepoTempPath = configRepoTempPath
+		_ = os.RemoveAll(createdRepoTempPath)
+	}(ctrl, repoTempPath, initialRepoTempPath)
+
+	// set repo temp path to test predefined location
+	config.Get().RepoTempPath = repoTempPath
+
+	updateTempDirPath := filepath.Join(repoTempPath, "upd")
+	err = os.MkdirAll(updateTempDirPath, 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	mockFilesService := mock_services.NewMockFilesService(ctrl)
+	mockUploader := mock_files.NewMockUploader(ctrl)
+	mockExtractor := mock_files.NewMockExtractor(ctrl)
+	mockDownloader := mock_services.NewMockDownloader(ctrl)
+	ctx := context.Background()
+	logger := log.NewEntry(log.StandardLogger())
+	repoBuilder := services.RepoBuilder{
+		Service:      services.NewService(ctx, logger),
+		FilesService: mockFilesService,
+		Log:          logger,
+	}
+	orgID := faker.UUIDHyphenated()
+	update := &models.UpdateTransaction{
+		OrgID: orgID,
+		Repo:  &models.Repo{},
+		Commit: &models.Commit{
+			OrgID:            orgID,
+			OSTreeCommit:     faker.UUIDHyphenated(),
+			ExternalURL:      false,
+			ImageBuildTarURL: faker.URL(),
+			OSTreeRef:        config.OstreeRefRHEL9,
+		},
+		OldCommits: []models.Commit{
+			{
+				OrgID:            orgID,
+				OSTreeCommit:     faker.UUIDHyphenated(),
+				ImageBuildTarURL: faker.URL(),
+				ExternalURL:      false,
+				OSTreeRef:        config.OstreeRefRHEL9,
+			},
+		},
+	}
+	err = db.DB.Create(update).Error
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateWorkPath := filepath.Join(updateTempDirPath, strconv.FormatUint(uint64(update.ID), 10))
+	updateRepoPath := filepath.Join(updateWorkPath, "repo")
+	err = os.MkdirAll(updateRepoPath, 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateRepoTarFilePath := filepath.Join(updateWorkPath, "repo.tar")
+	_, err = os.Create(updateRepoTarFilePath)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateOldCommitWorkPath := filepath.Join(updateWorkPath, "staging", update.OldCommits[0].OSTreeCommit)
+	err = os.MkdirAll(updateOldCommitWorkPath, 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateOldCommitTarFilePath := filepath.Join(updateOldCommitWorkPath, "repo.tar")
+	_, err = os.Create(updateOldCommitTarFilePath)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	expectedOldCommitRepoExtractError := errors.New("OldCommit ExtractVersionRepo error occurred")
+
+	// GetDownloader should be called two time , one time with the update target commit and one time with old commit
+	mockFilesService.EXPECT().GetDownloader().Return(mockDownloader).Times(2)
+	mockDownloader.EXPECT().DownloadToPath(update.Commit.ImageBuildTarURL, updateRepoTarFilePath).Return(nil)
+	mockDownloader.EXPECT().DownloadToPath(update.OldCommits[0].ImageBuildTarURL, updateOldCommitTarFilePath).Return(nil)
+
+	// GetExtractor should be called two time , one time with the update target commit and one time with old commit
+	mockFilesService.EXPECT().GetExtractor().Return(mockExtractor).Times(2)
+	mockExtractor.EXPECT().Extract(gomock.AssignableToTypeOf(&os.File{}), updateWorkPath).Return(nil)
+	mockExtractor.EXPECT().Extract(gomock.AssignableToTypeOf(&os.File{}), updateOldCommitWorkPath).Return(expectedOldCommitRepoExtractError)
+
+	// we do not expect the repo to be uploaded
+	mockFilesService.EXPECT().GetUploader().Return(mockUploader).Times(0)
+	mockUploader.EXPECT().UploadRepo(updateRepoPath, strconv.FormatUint(uint64(update.ID), 10), "private").Times(0)
+
+	// we do not expect any command to be run
+
+	_, err = repoBuilder.BuildUpdateRepo(update.ID)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(Equal(expectedOldCommitRepoExtractError))
+}
+
+func TestBuildUpdateRepoWithOldCommitsDownloadVersionRepoError(t *testing.T) {
+	// should return error when ExtractVersionRepo fails
+	g := NewGomegaWithT(t)
+	currentDir, err := os.Getwd()
+	g.Expect(err).ToNot(HaveOccurred())
+	// enable oldCommits feature flag by setting the corresponding env variable
+	err = os.Setenv(feature.BuildUpdateRepoWithOldCommits.EnvVar, "True")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	defer func(dirPath string) {
+		// restore the current dir path
+		err = os.Chdir(dirPath)
+		g.Expect(err).ToNot(HaveOccurred())
+		// unset oldCommits feature flag
+		err := os.Unsetenv(feature.BuildUpdateRepoWithOldCommits.EnvVar)
+		g.Expect(err).ToNot(HaveOccurred())
+	}(currentDir)
+
+	initialRepoTempPath := config.Get().RepoTempPath
+	repoTempPath := filepath.Join(os.TempDir(), fmt.Sprintf("repo_temp_test_%d", time.Now().Unix()))
+	err = os.MkdirAll(repoTempPath, 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	ctrl := gomock.NewController(t)
+
+	defer func(mockController *gomock.Controller, createdRepoTempPath string, configRepoTempPath string) {
+		mockController.Finish()
+		config.Get().RepoTempPath = configRepoTempPath
+		_ = os.RemoveAll(createdRepoTempPath)
+	}(ctrl, repoTempPath, initialRepoTempPath)
+
+	// set repo temp path to test predefined location
+	config.Get().RepoTempPath = repoTempPath
+
+	updateTempDirPath := filepath.Join(repoTempPath, "upd")
+	err = os.MkdirAll(updateTempDirPath, 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	mockFilesService := mock_services.NewMockFilesService(ctrl)
+	mockUploader := mock_files.NewMockUploader(ctrl)
+	mockExtractor := mock_files.NewMockExtractor(ctrl)
+	mockDownloader := mock_services.NewMockDownloader(ctrl)
+	ctx := context.Background()
+	logger := log.NewEntry(log.StandardLogger())
+	repoBuilder := services.RepoBuilder{
+		Service:      services.NewService(ctx, logger),
+		FilesService: mockFilesService,
+		Log:          logger,
+	}
+	orgID := faker.UUIDHyphenated()
+	update := &models.UpdateTransaction{
+		OrgID: orgID,
+		Repo:  &models.Repo{},
+		Commit: &models.Commit{
+			OrgID:            orgID,
+			OSTreeCommit:     faker.UUIDHyphenated(),
+			ExternalURL:      false,
+			ImageBuildTarURL: faker.URL(),
+			OSTreeRef:        config.OstreeRefRHEL9,
+		},
+		OldCommits: []models.Commit{
+			{
+				OrgID:            orgID,
+				OSTreeCommit:     faker.UUIDHyphenated(),
+				ImageBuildTarURL: faker.URL(),
+				ExternalURL:      false,
+				OSTreeRef:        config.OstreeRefRHEL9,
+			},
+		},
+	}
+	err = db.DB.Create(update).Error
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateWorkPath := filepath.Join(updateTempDirPath, strconv.FormatUint(uint64(update.ID), 10))
+	updateRepoPath := filepath.Join(updateWorkPath, "repo")
+	err = os.MkdirAll(updateRepoPath, 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateRepoTarFilePath := filepath.Join(updateWorkPath, "repo.tar")
+	_, err = os.Create(updateRepoTarFilePath)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateOldCommitWorkPath := filepath.Join(updateWorkPath, "staging", update.OldCommits[0].OSTreeCommit)
+	err = os.MkdirAll(updateOldCommitWorkPath, 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updateOldCommitTarFilePath := filepath.Join(updateOldCommitWorkPath, "repo.tar")
+	_, err = os.Create(updateOldCommitTarFilePath)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	expectedOldCommitRepoDownloadError := errors.New("OldCommit DownloadVersionRepo error occurred")
+
+	// GetDownloader should be called two time , one time with the update target commit and one time with old commit
+	mockFilesService.EXPECT().GetDownloader().Return(mockDownloader).Times(2)
+	mockDownloader.EXPECT().DownloadToPath(update.Commit.ImageBuildTarURL, updateRepoTarFilePath).Return(nil)
+	mockDownloader.EXPECT().DownloadToPath(update.OldCommits[0].ImageBuildTarURL, updateOldCommitTarFilePath).Return(expectedOldCommitRepoDownloadError)
+
+	// GetExtractor should be called one time with the update target commit, and should not be called with old commit
+	mockFilesService.EXPECT().GetExtractor().Return(mockExtractor).Times(1)
+	mockExtractor.EXPECT().Extract(gomock.AssignableToTypeOf(&os.File{}), updateWorkPath).Return(nil)
+	mockExtractor.EXPECT().Extract(gomock.AssignableToTypeOf(&os.File{}), updateOldCommitWorkPath).Times(0)
+
+	// we do not expect the repo to be uploaded
+	mockFilesService.EXPECT().GetUploader().Return(mockUploader).Times(0)
+	mockUploader.EXPECT().UploadRepo(updateRepoPath, strconv.FormatUint(uint64(update.ID), 10), "private").Times(0)
+
+	// we do not expect any exec.Command to be run
+
+	_, err = repoBuilder.BuildUpdateRepo(update.ID)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring(expectedOldCommitRepoDownloadError.Error()))
+}
 
 func TestRepoRevParse(t *testing.T) {
 	g := NewGomegaWithT(t)

--- a/pkg/services/repobuilder_test.go
+++ b/pkg/services/repobuilder_test.go
@@ -796,9 +796,7 @@ func TestBuildUpdateRepoWithOldCommits(t *testing.T) {
 			g.Expect(testCase.TestHelper.Executed).To(BeTrue())
 			g.Expect(testCase.TestHelper.ExistStatus).To(Equal(testCase.ExpectedExistStatus))
 			g.Expect(testCase.TestHelper.Output).To(Equal(testCase.ExpectedOutput))
-			if testCase.ExpectedCommand != "" {
-				g.Expect(testCase.TestHelper.Command).To(Equal(testCase.ExpectedCommand))
-			}
+			g.Expect(testCase.TestHelper.Command).To(Equal(testCase.ExpectedCommand))
 		})
 	}
 }
@@ -971,9 +969,7 @@ func TestBuildUpdateRepoWithOldCommitsStaticDeltaError(t *testing.T) {
 			g.Expect(testCase.TestHelper.Executed).To(BeTrue())
 			g.Expect(testCase.TestHelper.ExistStatus).To(Equal(testCase.ExpectedExistStatus))
 			g.Expect(testCase.TestHelper.Output).To(Equal(testCase.ExpectedOutput))
-			if testCase.ExpectedCommand != "" {
-				g.Expect(testCase.TestHelper.Command).To(Equal(testCase.ExpectedCommand))
-			}
+			g.Expect(testCase.TestHelper.Command).To(Equal(testCase.ExpectedCommand))
 		})
 	}
 }

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -892,6 +892,7 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 					result := db.DB.Create(&repo)
 					if result.Error != nil {
 						s.log.WithField("error", result.Error.Error()).Debug("Result error")
+						return nil, result.Error
 					}
 					s.log.WithFields(log.Fields{
 						"repoURL": repo.URL,

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -54,6 +54,9 @@ var ImageCompletionEventsEDA = &Flag{Name: "edge-management.completion_events", 
 // ImageCreateISOEDA is the feature flag for routes.CreateCommit() EDA code
 var ImageCreateISOEDA = &Flag{Name: "edge-management.image_create_iso", EnvVar: "FEATURE_IMAGECREATE_ISO"}
 
+// BuildUpdateRepoWithOldCommits is the feature flag for services.BuildUpdateRepo() to enable oldCommits feature
+var BuildUpdateRepoWithOldCommits = &Flag{Name: "edge-management.build_update_repo_with_old_commits", EnvVar: "FEATURE_BUILD_UPDATE_REPO_WITH_OLD_COMMITS"}
+
 // DEVICE FEATURE FLAGS
 
 // DeviceSync is the feature flag for routes.CreateImageUpdate() EDA code


### PR DESCRIPTION
# Description
The current implementation is not taking account of OldCommits when building device update repo. 

This PR fixes this behavior by:
1. Adding a feature flag of this feature so that it can be tested in different environment without breaking the current functionality. The feature flags has been added to stage and prod environments.
2. Include the Preload("OldCommit") in the query.
3. Fixes to paths problems in OldCommits code section.
4. Write unit-tests to test the expected behavior.

Fixed when minor problem in services/updates.go, where we do not return after a repo creation failure, as that repo is used later in the code and may cause a panic to occur.  

Note: We chosen to consider OldCommits functionality as new feature because the code has never been tested to work. This is a bug fix, because the code is already done, but needed some fixes and testing.

FIXES: THEEDGE-3009

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

