### PR TITLE
Fixed OpenAPI check by using an older version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -88,7 +88,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install openapi-spec-validator
-        run: pip install openapi-spec-validator
+        run: pip install openapi-spec-validator==0.5.2
 
       - name: Validate spec-file
         run: python3 -m openapi_spec_validator ${{ github.workspace }}/cmd/spec/openapi.json


### PR DESCRIPTION
# Description
The OpenAPI PR check is failing as shown below
![image](https://user-images.githubusercontent.com/6431695/216078594-f3995db2-376f-44ca-981a-54385ba2cf7e.png)

Fix by using an older version of `openapi-spec-validator`

FIXES: [THEEDGE-3029](https://issues.redhat.com/browse/THEEDGE-3029)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
