### PR TITLE
changed openapi-spec-validator to 0.5.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -88,7 +88,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install openapi-spec-validator
-        run: pip install openapi-spec-validator=0.5.2
+        run: pip install openapi-spec-validator==0.5.2
 
       - name: Validate spec-file
         run: python3 -m openapi_spec_validator ${{ github.workspace }}/cmd/spec/openapi.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -88,7 +88,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install openapi-spec-validator
-        run: pip install openapi-spec-validator
+        run: pip install openapi-spec-validator=0.5.2
 
       - name: Validate spec-file
         run: python3 -m openapi_spec_validator ${{ github.workspace }}/cmd/spec/openapi.json


### PR DESCRIPTION
0.5.3 is currently broken, as a fix this PR enforces the install of version 0.5.2 which works fine

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

FIXES: <!-- THEEDGE-NNNN -->

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
