### PR TITLE
repobuilder: Fixes RepoPullLocalStaticDeltas repo cmd option.

### DIFF
--- a/pkg/services/repobuilder.go
+++ b/pkg/services/repobuilder.go
@@ -415,14 +415,14 @@ func (rb *RepoBuilder) RepoPullLocalStaticDeltas(u *models.Commit, o *models.Com
 	}
 
 	// pull the local repo at the exact rev (which was HEAD of o.OSTreeRef)
-	cmd := BuildCommand("/usr/bin/ostree", "--repo", uprepo, "pull-local", oldrepo, oldRevParse)
+	cmd := BuildCommand("/usr/bin/ostree", "pull-local", "--repo", uprepo, oldrepo, oldRevParse)
 	err = cmd.Run()
 	if err != nil {
 		return err
 	}
 
 	// generate static delta
-	cmd = BuildCommand("/usr/bin/ostree", "--repo", uprepo, "static-delta", "generate", "--from", oldRevParse, "--to", updateRevParse)
+	cmd = BuildCommand("/usr/bin/ostree", "static-delta", "generate", "--repo", uprepo, "--from", oldRevParse, "--to", updateRevParse)
 	err = cmd.Run()
 	if err != nil {
 		return err

--- a/pkg/services/repobuilder_test.go
+++ b/pkg/services/repobuilder_test.go
@@ -765,14 +765,14 @@ func TestBuildUpdateRepoWithOldCommits(t *testing.T) {
 			TestHelper:          NewMockTestExecHelper(t, "pull-local", 0),
 			ExpectedOutput:      "pull-local",
 			ExpectedExistStatus: 0,
-			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree --repo %s pull-local %s %s", updateRepoPath, updateOldCommitRepoPath, oldCommitRevision),
+			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree pull-local --repo %s %s %s", updateRepoPath, updateOldCommitRepoPath, oldCommitRevision),
 		},
 		{
 			name:                "run ostree command static-delta successfully",
 			TestHelper:          NewMockTestExecHelper(t, "static-delta", 0),
 			ExpectedOutput:      "static-delta",
 			ExpectedExistStatus: 0,
-			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree --repo %s static-delta generate --from %s --to %s", updateRepoPath, oldCommitRevision, updateCommitRevision),
+			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree static-delta generate --repo %s --from %s --to %s", updateRepoPath, oldCommitRevision, updateCommitRevision),
 		},
 	}
 	// chain TestExecHelper, so that each mock can initiate the next exec command helper
@@ -940,14 +940,14 @@ func TestBuildUpdateRepoWithOldCommitsStaticDeltaError(t *testing.T) {
 			TestHelper:          NewMockTestExecHelper(t, "pull-local", 0),
 			ExpectedOutput:      "pull-local",
 			ExpectedExistStatus: 0,
-			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree --repo %s pull-local %s %s", updateRepoPath, updateOldCommitRepoPath, oldCommitRevision),
+			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree pull-local --repo %s %s %s", updateRepoPath, updateOldCommitRepoPath, oldCommitRevision),
 		},
 		{
 			name:                "run ostree command static-delta successfully",
 			TestHelper:          NewMockTestExecHelper(t, "static-delta", 1),
 			ExpectedOutput:      "static-delta",
 			ExpectedExistStatus: 1,
-			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree --repo %s static-delta generate --from %s --to %s", updateRepoPath, oldCommitRevision, updateCommitRevision),
+			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree static-delta generate --repo %s --from %s --to %s", updateRepoPath, oldCommitRevision, updateCommitRevision),
 		},
 	}
 	// chain TestExecHelper, so that each mock can initiate the next exec command helper
@@ -1303,14 +1303,14 @@ func TestRepoPullLocalStaticDeltas(t *testing.T) {
 			TestHelper:          NewMockTestExecHelper(t, "pull-local", 0),
 			ExpectedOutput:      "pull-local",
 			ExpectedExistStatus: 0,
-			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree --repo %s pull-local %s %s", updateRepoPath, oldRepoPath, oldCommitRevision),
+			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree pull-local --repo %s %s %s", updateRepoPath, oldRepoPath, oldCommitRevision),
 		},
 		{
 			name:                "should run ostree command static-delta successfully",
 			TestHelper:          NewMockTestExecHelper(t, "static-delta", 0),
 			ExpectedOutput:      "static-delta",
 			ExpectedExistStatus: 0,
-			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree --repo %s static-delta generate --from %s --to %s", updateRepoPath, oldCommitRevision, updateCommitRevision),
+			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree static-delta generate --repo %s --from %s --to %s", updateRepoPath, oldCommitRevision, updateCommitRevision),
 		},
 	}
 	// chain TestHelper, so that each mock can initiate the next exec command helper
@@ -1527,7 +1527,7 @@ func TestRepoPullLocalStaticDeltasFailsWhenPullLocalFail(t *testing.T) {
 			TestHelper:          NewMockTestExecHelper(t, "pull-local", 2),
 			ExpectedOutput:      "pull-local",
 			ExpectedExistStatus: 2,
-			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree --repo %s pull-local %s %s", updateRepoPath, oldRepoPath, oldCommitRevision),
+			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree pull-local --repo %s %s %s", updateRepoPath, oldRepoPath, oldCommitRevision),
 		},
 	}
 	// chain TestHelper, so that each mock can initiate the next exec command helper
@@ -1613,14 +1613,14 @@ func TestRepoPullLocalStaticDeltasFailsWhenStaticDeltaFails(t *testing.T) {
 			TestHelper:          NewMockTestExecHelper(t, "pull-local", 0),
 			ExpectedOutput:      "pull-local",
 			ExpectedExistStatus: 0,
-			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree --repo %s pull-local %s %s", updateRepoPath, oldRepoPath, oldCommitRevision),
+			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree pull-local --repo %s %s %s", updateRepoPath, oldRepoPath, oldCommitRevision),
 		},
 		{
 			name:                "should run ostree command static-delta successfully",
 			TestHelper:          NewMockTestExecHelper(t, "static-delta", 3),
 			ExpectedOutput:      "static-delta",
 			ExpectedExistStatus: 3,
-			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree --repo %s static-delta generate --from %s --to %s", updateRepoPath, oldCommitRevision, updateCommitRevision),
+			ExpectedCommand:     fmt.Sprintf("/usr/bin/ostree static-delta generate --repo %s --from %s --to %s", updateRepoPath, oldCommitRevision, updateCommitRevision),
 		},
 	}
 	// chain TestHelper, so that each mock can initiate the next exec command helper


### PR DESCRIPTION
# Description
The ostree command line option --repo should be positioned after the ostree commands for example: ostree pull-local --repo ./newrepo/repo 95ecf6d86961c1fe2f004096542be7aaecfd667a34314d83dce7f42a8e53266e and
ostree static-delta generate --repo repo --from 3d3c35ce2937ec39292a067ead285d2112325a82e5b97ea4bbbecd3b79a7cb81 --to 95ecf6d86961c1fe2f004096542be7aaecfd667a34314d83dce7f42a8e53266e

FIXES: THEEDGE-3009

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [X] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
