### PR TITLE
linter: Fixes ImageDetails lint unsed at images modules.

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -1090,6 +1090,7 @@ func (s *ImageService) calculateChecksum(isoPath string, image *models.Image) er
 }
 
 // ImageDetail return the structure to inform package info to images
+// nolint: unused // golangci-lint does not parse well this block, it says Image not used, but it's used
 type ImageDetail struct {
 	Image              *models.Image `json:"image"`
 	AdditionalPackages int           `json:"additional_packages"`


### PR DESCRIPTION
# Description
golangci-lint does not parse well this block, it says for example Image not used, but it's used later in the code.

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
