### PR TITLE
repo builder: add more logging when pull-local and static-delta cmd fails

### DIFF
--- a/pkg/services/repobuilder.go
+++ b/pkg/services/repobuilder.go
@@ -416,19 +416,22 @@ func (rb *RepoBuilder) RepoPullLocalStaticDeltas(u *models.Commit, o *models.Com
 
 	// pull the local repo at the exact rev (which was HEAD of o.OSTreeRef)
 	cmd := BuildCommand("/usr/bin/ostree", "pull-local", "--repo", uprepo, oldrepo, oldRevParse)
-	err = cmd.Run()
-	if err != nil {
+	if output, err := cmd.CombinedOutput(); err != nil {
+		rb.log.WithFields(
+			log.Fields{"error": err.Error(), "OSTreeCommit": oldRevParse, "output": output},
+		).Error("error occurred while running pull-local command")
 		return err
 	}
 
 	// generate static delta
 	cmd = BuildCommand("/usr/bin/ostree", "static-delta", "generate", "--repo", uprepo, "--from", oldRevParse, "--to", updateRevParse)
-	err = cmd.Run()
-	if err != nil {
+	if output, err := cmd.CombinedOutput(); err != nil {
+		rb.log.WithFields(
+			log.Fields{"error": err.Error(), "OSTreeCommit": oldRevParse, "output": output},
+		).Error("error occurred while running static-delta command")
 		return err
 	}
 	return nil
-
 }
 
 // RepoRevParse Handle the RevParse separate since we need the stdout parsed


### PR DESCRIPTION
# Description
The feature using OldCommits is disabled now, but we are trying to make the code working, errors are raising, and we need to know the nature. As manually I have no access to repos tar files as they have private ACL and cannot be even shared.

FIXES: THEEDGE-3009

## Type of change

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

