### PR TITLE
kafka: Fixes SecurityProtocol to update package update-app-common-go to latest 1.6.5.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.26.0
 	github.com/prometheus/client_golang v1.14.0
-	github.com/redhatinsights/app-common-go v1.6.4
+	github.com/redhatinsights/app-common-go v1.6.5
 	github.com/redhatinsights/platform-go-middlewares v0.20.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/viper v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -423,6 +423,8 @@ github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/redhatinsights/app-common-go v1.6.4 h1:L6xhROlGEXN4zvw51whl+ZxtMN1fcs3yj0Gz5A8AVXw=
 github.com/redhatinsights/app-common-go v1.6.4/go.mod h1:6gzRyg8ZyejwMCksukeAhh2ZXOB3uHSmBsbP06fG2PQ=
+github.com/redhatinsights/app-common-go v1.6.5 h1:7bLQds050wxk98qO/aGvECmd9oN3EvZyFxFWATzs5e8=
+github.com/redhatinsights/app-common-go v1.6.5/go.mod h1:6gzRyg8ZyejwMCksukeAhh2ZXOB3uHSmBsbP06fG2PQ=
 github.com/redhatinsights/platform-go-middlewares v0.20.0 h1:qwK9ArGYRlORsZ56PXXLJrGvzTsMe3bk2lR+WN5aIjM=
 github.com/redhatinsights/platform-go-middlewares v0.20.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a/go.mod h1:4r5QyqhjIWCcK8DO4KMclc5Iknq5qVBAlbYYzAbUScQ=

--- a/pkg/common/kafka/kafkaconfigmap.go
+++ b/pkg/common/kafka/kafkaconfigmap.go
@@ -33,12 +33,24 @@ func (k *KafkaConfigMapService) GetKafkaProducerConfigMap() kafka.ConfigMap {
 
 	if len(cfg.KafkaBrokers) > 0 {
 		kafkaConfigMap.SetKey("bootstrap.servers", fmt.Sprintf("%s:%d", cfg.KafkaBrokers[0].Hostname, *cfg.KafkaBrokers[0].Port))
+		var securityProtocol string
+		if cfg.KafkaBrokers[0].SecurityProtocol != nil {
+			securityProtocol = *cfg.KafkaBrokers[0].SecurityProtocol
+		}
 		if cfg.KafkaBrokers[0].Authtype != nil && *cfg.KafkaBrokers[0].Authtype == "sasl" && cfg.KafkaBrokers[0].Sasl != nil {
 			kafkaConfigMap.SetKey("sasl.mechanisms", *cfg.KafkaBrokers[0].Sasl.SaslMechanism)
-			kafkaConfigMap.SetKey("security.protocol", *cfg.KafkaBrokers[0].Sasl.SecurityProtocol)
 			kafkaConfigMap.SetKey("sasl.username", *cfg.KafkaBrokers[0].Sasl.Username)
 			kafkaConfigMap.SetKey("sasl.password", *cfg.KafkaBrokers[0].Sasl.Password)
+			if securityProtocol == "" && cfg.KafkaBrokers[0].Sasl.SecurityProtocol != nil && *cfg.KafkaBrokers[0].Sasl.SecurityProtocol != "" { // nolint: staticcheck
+				// seems we still in transition period and no security protocol was defined in parent
+				// set it from sasl config
+				securityProtocol = *cfg.KafkaBrokers[0].Sasl.SecurityProtocol // nolint: staticcheck
+			}
 		}
+		if securityProtocol != "" {
+			kafkaConfigMap.SetKey("security.protocol", securityProtocol)
+		}
+
 	}
 	return kafkaConfigMap
 }

--- a/pkg/common/kafka/kafkaconfigmap_test.go
+++ b/pkg/common/kafka/kafkaconfigmap_test.go
@@ -157,7 +157,8 @@ func TestGetKafkaProducerConfigMapSecurityProtocol(t *testing.T) {
 		config.Get().KafkaBrokers = conf
 	}(originalKafkaBrokerConf)
 
-	authType := clowder.BrokerConfigAuthtype("sasl")
+	authTypeSasl := clowder.BrokerConfigAuthtype("sasl")
+	authTypeMtls := clowder.BrokerConfigAuthtype("mtls")
 	dummyString := faker.UUIDHyphenated()
 	mech := "PLAIN"
 	SecurityProtocols := []string{faker.UUIDHyphenated(), faker.UUIDHyphenated()}
@@ -171,7 +172,7 @@ func TestGetKafkaProducerConfigMapSecurityProtocol(t *testing.T) {
 		{
 			Name: "should get security protocol from broker config",
 			BrokerConfig: clowder.BrokerConfig{
-				Authtype:         &authType,
+				Authtype:         &authTypeSasl,
 				Cacert:           &dummyString,
 				Hostname:         "192.168.1.7",
 				Port:             &port,
@@ -187,7 +188,7 @@ func TestGetKafkaProducerConfigMapSecurityProtocol(t *testing.T) {
 		{
 			Name: "should get security protocol from broker sasl config",
 			BrokerConfig: clowder.BrokerConfig{
-				Authtype: &authType,
+				Authtype: &authTypeSasl,
 				Cacert:   &dummyString,
 				Hostname: "192.168.1.7",
 				Port:     &port,
@@ -203,7 +204,7 @@ func TestGetKafkaProducerConfigMapSecurityProtocol(t *testing.T) {
 		{
 			Name: "should not get security protocol if no defined in broker or sasl config",
 			BrokerConfig: clowder.BrokerConfig{
-				Authtype: &authType,
+				Authtype: &authTypeSasl,
 				Cacert:   &dummyString,
 				Hostname: "192.168.1.7",
 				Port:     &port,
@@ -214,6 +215,38 @@ func TestGetKafkaProducerConfigMapSecurityProtocol(t *testing.T) {
 				},
 			},
 			ExpectedSecurityProtocol: "",
+		},
+		{
+			Name: "should not get security protocol when defined in sasl config and auth type mtls",
+			BrokerConfig: clowder.BrokerConfig{
+				Authtype: &authTypeMtls,
+				Cacert:   &dummyString,
+				Hostname: "192.168.1.7",
+				Port:     &port,
+				Sasl: &clowder.KafkaSASLConfig{
+					SaslMechanism:    &mech,
+					Username:         &dummyString,
+					Password:         &dummyString,
+					SecurityProtocol: &SecurityProtocols[1], // nolint: staticcheck
+				},
+			},
+			ExpectedSecurityProtocol: "",
+		},
+		{
+			Name: "should get security protocol when defined in broker config and auth type mtls",
+			BrokerConfig: clowder.BrokerConfig{
+				Authtype:         &authTypeMtls,
+				Cacert:           &dummyString,
+				Hostname:         "192.168.1.7",
+				Port:             &port,
+				SecurityProtocol: &SecurityProtocols[0],
+				Sasl: &clowder.KafkaSASLConfig{
+					SaslMechanism: &mech,
+					Username:      &dummyString,
+					Password:      &dummyString,
+				},
+			},
+			ExpectedSecurityProtocol: SecurityProtocols[0],
 		},
 	}
 

--- a/pkg/common/kafka/kafkaconfigmap_test.go
+++ b/pkg/common/kafka/kafkaconfigmap_test.go
@@ -24,15 +24,15 @@ func TestGetKafkaProducerConfigMap(t *testing.T) {
 	proto := "SASL_SSL"
 	port := 80
 	brokerConfig := clowder.BrokerConfig{
-		Authtype: &authType,
-		Cacert:   &dummyString,
-		Hostname: "192.168.1.7",
-		Port:     &port,
+		Authtype:         &authType,
+		Cacert:           &dummyString,
+		Hostname:         "192.168.1.7",
+		Port:             &port,
+		SecurityProtocol: &proto,
 		Sasl: &clowder.KafkaSASLConfig{
-			SaslMechanism:    &mech,
-			SecurityProtocol: &proto,
-			Username:         &dummyString,
-			Password:         &dummyString,
+			SaslMechanism: &mech,
+			Username:      &dummyString,
+			Password:      &dummyString,
 		},
 	}
 	kafkaConfigMap := kafka.ConfigMap{
@@ -88,15 +88,15 @@ func TestGetKafkaConsumerConfigMap(t *testing.T) {
 	proto := "SASL_SSL"
 	port := 80
 	brokerConfig := clowder.BrokerConfig{
-		Authtype: &authType,
-		Cacert:   &dummyString,
-		Hostname: "192.168.1.7",
-		Port:     &port,
+		Authtype:         &authType,
+		Cacert:           &dummyString,
+		Hostname:         "192.168.1.7",
+		Port:             &port,
+		SecurityProtocol: &proto,
 		Sasl: &clowder.KafkaSASLConfig{
-			SaslMechanism:    &mech,
-			SecurityProtocol: &proto,
-			Username:         &dummyString,
-			Password:         &dummyString,
+			SaslMechanism: &mech,
+			Username:      &dummyString,
+			Password:      &dummyString,
 		},
 	}
 	kafkaConfigMap := kafka.ConfigMap{

--- a/pkg/common/kafka/kafkaconfigmap_test.go
+++ b/pkg/common/kafka/kafkaconfigmap_test.go
@@ -9,6 +9,8 @@ import (
 	v1 "github.com/redhatinsights/app-common-go/pkg/api/v1"
 	"github.com/redhatinsights/edge-api/config"
 	kafkacommon "github.com/redhatinsights/edge-api/pkg/common/kafka"
+
+	"github.com/bxcodec/faker/v3"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -143,6 +145,87 @@ func TestGetKafkaConsumerConfigMap(t *testing.T) {
 			consumerGroupID := "imagesisobuild"
 			configMap := service.GetKafkaConsumerConfigMap(consumerGroupID)
 			assert.Equal(t, configMap, test.ExpectedRequest)
+		})
+	}
+}
+
+func TestGetKafkaProducerConfigMapSecurityProtocol(t *testing.T) {
+	var service kafkacommon.KafkaConfigMapServiceInterface
+	cfg := config.Get()
+	originalKafkaBrokerConf := cfg.KafkaBrokers
+	defer func(conf []clowder.BrokerConfig) {
+		config.Get().KafkaBrokers = conf
+	}(originalKafkaBrokerConf)
+
+	authType := clowder.BrokerConfigAuthtype("sasl")
+	dummyString := faker.UUIDHyphenated()
+	mech := "PLAIN"
+	SecurityProtocols := []string{faker.UUIDHyphenated(), faker.UUIDHyphenated()}
+	port := 80
+
+	testCases := []struct {
+		Name                     string
+		BrokerConfig             clowder.BrokerConfig
+		ExpectedSecurityProtocol string
+	}{
+		{
+			Name: "should get security protocol from broker config",
+			BrokerConfig: clowder.BrokerConfig{
+				Authtype:         &authType,
+				Cacert:           &dummyString,
+				Hostname:         "192.168.1.7",
+				Port:             &port,
+				SecurityProtocol: &SecurityProtocols[0],
+				Sasl: &clowder.KafkaSASLConfig{
+					SaslMechanism: &mech,
+					Username:      &dummyString,
+					Password:      &dummyString,
+				},
+			},
+			ExpectedSecurityProtocol: SecurityProtocols[0],
+		},
+		{
+			Name: "should get security protocol from broker sasl config",
+			BrokerConfig: clowder.BrokerConfig{
+				Authtype: &authType,
+				Cacert:   &dummyString,
+				Hostname: "192.168.1.7",
+				Port:     &port,
+				Sasl: &clowder.KafkaSASLConfig{
+					SaslMechanism:    &mech,
+					Username:         &dummyString,
+					Password:         &dummyString,
+					SecurityProtocol: &SecurityProtocols[1], // nolint: staticcheck
+				},
+			},
+			ExpectedSecurityProtocol: SecurityProtocols[1],
+		},
+		{
+			Name: "should not get security protocol if no defined in broker or sasl config",
+			BrokerConfig: clowder.BrokerConfig{
+				Authtype: &authType,
+				Cacert:   &dummyString,
+				Hostname: "192.168.1.7",
+				Port:     &port,
+				Sasl: &clowder.KafkaSASLConfig{
+					SaslMechanism: &mech,
+					Username:      &dummyString,
+					Password:      &dummyString,
+				},
+			},
+			ExpectedSecurityProtocol: "",
+		},
+	}
+
+	service = kafkacommon.NewKafkaConfigMapService()
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			config.Get().KafkaBrokers = []clowder.BrokerConfig{testCase.BrokerConfig}
+
+			configMap := service.GetKafkaProducerConfigMap()
+			securityProtocol, err := configMap.Get("security.protocol", "")
+			assert.NoError(t, err, "cannot get security protocol from configMap, occur when as type mismatch")
+			assert.Equal(t, securityProtocol, testCase.ExpectedSecurityProtocol)
 		})
 	}
 }


### PR DESCRIPTION

# Description
update-app-common-go  have deprecated SecurityProtocol on sasl struct and add it to broker struct. https://github.com/RedHatInsights/app-common-go/commit/195d14d0d2eb6ca7490f087517ae04092f54fe7c

This is related to this PR failure https://github.com/RedHatInsights/edge-api/pull/1864

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor
- [X] Dependency Update

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
