### PR TITLE
kafka-cfg: FIXES GetKafkaProducerConfigMap sasl config.

### DIFF
--- a/pkg/common/kafka/kafkaconfigmap.go
+++ b/pkg/common/kafka/kafkaconfigmap.go
@@ -31,9 +31,9 @@ func (k *KafkaConfigMapService) GetKafkaProducerConfigMap() kafka.ConfigMap {
 	cfg := config.Get()
 	kafkaConfigMap := kafka.ConfigMap{}
 
-	if cfg.KafkaBrokers != nil {
+	if len(cfg.KafkaBrokers) > 0 {
 		kafkaConfigMap.SetKey("bootstrap.servers", fmt.Sprintf("%s:%d", cfg.KafkaBrokers[0].Hostname, *cfg.KafkaBrokers[0].Port))
-		if cfg.KafkaBrokers[0].Sasl != nil {
+		if cfg.KafkaBrokers[0].Authtype != nil && *cfg.KafkaBrokers[0].Authtype == "sasl" && cfg.KafkaBrokers[0].Sasl != nil {
 			kafkaConfigMap.SetKey("sasl.mechanisms", *cfg.KafkaBrokers[0].Sasl.SaslMechanism)
 			kafkaConfigMap.SetKey("security.protocol", *cfg.KafkaBrokers[0].Sasl.SecurityProtocol)
 			kafkaConfigMap.SetKey("sasl.username", *cfg.KafkaBrokers[0].Sasl.Username)

--- a/pkg/common/kafka/kafkaconfigmap_test.go
+++ b/pkg/common/kafka/kafkaconfigmap_test.go
@@ -18,7 +18,7 @@ func TestGetKafkaProducerConfigMap(t *testing.T) {
 
 	conf := cfg.KafkaConfig
 
-	authType := clowder.BrokerConfigAuthtype("Auth")
+	authType := clowder.BrokerConfigAuthtype("sasl")
 	dummyString := "something"
 	mech := "PLAIN"
 	proto := "SASL_SSL"
@@ -82,7 +82,7 @@ func TestGetKafkaConsumerConfigMap(t *testing.T) {
 
 	conf := cfg.KafkaConfig
 
-	authType := clowder.BrokerConfigAuthtype("Auth")
+	authType := clowder.BrokerConfigAuthtype("sasl")
 	dummyString := "something"
 	mech := "PLAIN"
 	proto := "SASL_SSL"


### PR DESCRIPTION
# Description
This PR will allow to add sasl configuration only the auth type is sasl.
Note: the configuration auth type maybe "sasl" or "mtls"  https://github.com/RedHatInsights/clowder/blob/master/controllers/cloud.redhat.com/config/schema.json#L225 .


FIXES: THEEDGE-3000

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [X] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

