### PR TITLE
kafka: FIXES images/updates SendNotifications.

### DIFF
--- a/pkg/common/kafka/utils.go
+++ b/pkg/common/kafka/utils.go
@@ -1,0 +1,34 @@
+package kafkacommon
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+)
+
+// DefaultDeliveryTimeout the default delivery timeout in ms
+const DefaultDeliveryTimeout = 10000
+
+var ErrUnknownProduceDeliveryEvent = errors.New("producer produce returned unknown delivery event message")
+var ErrProduceDeliveryTimeout = errors.New("producer produce message delivery timeout")
+
+// WaitProduceDeliveryEvent wait for a message to be delivered used with Producer Produce function
+// this allows to not block other deliveries when using a global producer instance (ProducerService.GetProducerInstance())
+func WaitProduceDeliveryEvent(deliveryChan chan kafka.Event, timeout int) error {
+	if timeout == 0 {
+		timeout = DefaultDeliveryTimeout
+	}
+	timeoutDuration, _ := time.ParseDuration(fmt.Sprintf("%dms", timeout))
+	select {
+	case event := <-deliveryChan:
+		message, ok := event.(*kafka.Message)
+		if !ok {
+			return ErrUnknownProduceDeliveryEvent
+		}
+		return message.TopicPartition.Error
+	case <-time.After(timeoutDuration):
+		return ErrProduceDeliveryTimeout
+	}
+}

--- a/pkg/common/kafka/utils_test.go
+++ b/pkg/common/kafka/utils_test.go
@@ -1,0 +1,86 @@
+package kafkacommon_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	kafkacommon "github.com/redhatinsights/edge-api/pkg/common/kafka"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/stretchr/testify/assert"
+)
+
+type TestEvent struct{ Output string }
+
+func (event *TestEvent) String() string {
+	return event.Output
+}
+
+func TestWaitProduceDeliveryEvent(t *testing.T) {
+	topic := "a_dummy_topic_name"
+	expectedTopicPartitionError := errors.New("an expected topicPartition error")
+
+	testCases := []struct {
+		Name          string
+		Event         kafka.Event
+		Timeout       int
+		ExpectedError error
+	}{
+		{
+			Name: "should return nil when no error occurred",
+			Event: &kafka.Message{
+				TopicPartition: kafka.TopicPartition{
+					Topic: &topic, Partition: kafka.PartitionAny,
+					Error: nil,
+				},
+			},
+			ExpectedError: nil,
+		},
+		{
+			Name: "should return the occurred error",
+			Event: &kafka.Message{
+				TopicPartition: kafka.TopicPartition{
+					Topic: &topic, Partition: kafka.PartitionAny,
+					Error: expectedTopicPartitionError,
+				},
+			},
+			ExpectedError: expectedTopicPartitionError,
+		},
+		{
+			Name:          "should return error when the event type is not kafka.Message",
+			Event:         &TestEvent{Output: "a dummy event output, this is not a kafka.Message type"},
+			ExpectedError: kafkacommon.ErrUnknownProduceDeliveryEvent,
+		},
+		{
+			Name: "should return timeout error when the producer produce message did not finish in time",
+			Event: &kafka.Message{
+				TopicPartition: kafka.TopicPartition{
+					Topic: &topic, Partition: kafka.PartitionAny,
+					Error: nil,
+				},
+			},
+			Timeout:       500,
+			ExpectedError: kafkacommon.ErrProduceDeliveryTimeout,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			deliveryChan := make(chan kafka.Event)
+			defer close(deliveryChan)
+			go func(channel chan kafka.Event, event kafka.Event, timeout int) {
+				if timeout > 0 {
+					timeoutDuration, _ := time.ParseDuration(fmt.Sprintf("%dms", timeout))
+					time.Sleep(timeoutDuration)
+					return
+				}
+				channel <- event
+			}(deliveryChan, testCase.Event, testCase.Timeout)
+
+			err := kafkacommon.WaitProduceDeliveryEvent(deliveryChan, testCase.Timeout)
+			assert.Equal(t, testCase.ExpectedError, err)
+		})
+	}
+}


### PR DESCRIPTION
# Description

1. Images SendNotification call Flush before closing the producer. (Using flush scenario was not working as was blocking all the application for that amount of time , and was replaced with WaitProduceDeliveryEvent that is working )
2. Update SendNotification use the project GetProducerInstance that is a global producer, use deliveryChannel to ensure, the message is delivered or not. see https://github.com/confluentinc/confluent-kafka-go/blob/80c58f81b6cc32d3ed046609bf660a41a061b23d/examples/producer_example/producer_example.go

FIXES-THEEDGE-3000

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

