### PR TITLE
Increase test coverage on GetImageThirdPartyRepos

### DIFF
--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -175,6 +175,38 @@ var _ = Describe("Image Builder Client Test", func() {
 		Expect(err.Error()).To(Equal("error retrieving orgID  information, image orgID undefined"))
 	})
 
+	It("should retrieve and return third party repos from database and return valid list", func() {
+		pkgs := []models.Package{
+			{
+				Name: "vim",
+			},
+			{
+				Name: "ansible",
+			},
+		}
+		OrgId := faker.UUIDHyphenated()
+		thirdPartyRepo := models.ThirdPartyRepo{
+			Name:  faker.UUIDHyphenated(),
+			URL:   faker.URL(),
+			OrgID: OrgId,
+		}
+		db.DB.Create(&thirdPartyRepo)
+		img := &models.Image{Distribution: "rhel-8",
+			Packages: pkgs,
+			OrgID:    OrgId,
+			Commit: &models.Commit{
+				Arch: "x86_64",
+				Repo: &models.Repo{},
+			},
+			ThirdPartyRepositories: []models.ThirdPartyRepo{
+				thirdPartyRepo,
+			},
+		}
+		result, err := client.GetImageThirdPartyRepos(img)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result[0].BaseURL).To(Equal(thirdPartyRepo.URL))
+	})
+
 	It("should return error when custom repositories id are not valid/not found", func() {
 		pkgs := []models.Package{
 			{
@@ -186,7 +218,7 @@ var _ = Describe("Image Builder Client Test", func() {
 		}
 		img := &models.Image{Distribution: "rhel-8",
 			Packages: pkgs,
-			OrgID:    "Fake org_id",
+			OrgID:    "org_id",
 			Commit: &models.Commit{
 				Arch: "x86_64",
 				Repo: &models.Repo{},

--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -175,6 +175,39 @@ var _ = Describe("Image Builder Client Test", func() {
 		Expect(err.Error()).To(Equal("error retrieving orgID  information, image orgID undefined"))
 	})
 
+	It("should return error when custom repositories id are not valid/not found", func() {
+		pkgs := []models.Package{
+			{
+				Name: "vim",
+			},
+			{
+				Name: "ansible",
+			},
+		}
+		img := &models.Image{Distribution: "rhel-8",
+			Packages: pkgs,
+			OrgID:    "Fake org_id",
+			Commit: &models.Commit{
+				Arch: "x86_64",
+				Repo: &models.Repo{},
+			},
+			ThirdPartyRepositories: []models.ThirdPartyRepo{
+				{
+					Name: "repo test",
+					URL:  "https://repo.com",
+				},
+				{
+					Name: "repo test2",
+					URL:  "https://repo2.com",
+				},
+			},
+		}
+		result, err := client.GetImageThirdPartyRepos(img)
+		Expect(result).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("enter valid third party repository id"))
+	})
+
 	Context("compose image commit with ChangesRefs values", func() {
 		dist := "rhel-86"
 		repoURL := faker.URL()


### PR DESCRIPTION


# Description
This PR will add new test case to cover cases on GetImageThirdPartyRepos inside pkg/clients/imagebuilder/client.go
FIXES:  THEEDGE-3057

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
