### PR TITLE
Add Glitchtip support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,7 @@ type EdgeConfig struct {
 	TenantTranslatorPort       string                    `json:"tenant_translator_port,omitempty"`
 	TenantTranslatorURL        string                    `json:"tenant_translator_url,omitempty"`
 	ImageBuilderOrgID          string                    `json:"image_builder_org_id,omitempty"`
+	GlitchtipDsn               string                    `json:"glitchtip_dsn,omitempty"`
 }
 
 type dbConfig struct {
@@ -241,6 +242,7 @@ func CreateEdgeAPIConfig() (*EdgeConfig, error) {
 		KafkaRequestRequiredAcks:   options.GetInt("KafkaRequestRequiredAcks"),
 		KafkaMessageSendMaxRetries: options.GetInt("KafkaMessageSendMaxRetries"),
 		KafkaRetryBackoffMs:        options.GetInt("KafkaRetryBackoffMs"),
+		GlitchtipDsn:               options.GetString("GlitchtipDsn"),
 	}
 	if edgeConfig.TenantTranslatorHost != "" && edgeConfig.TenantTranslatorPort != "" {
 		edgeConfig.TenantTranslatorURL = fmt.Sprintf("http://%s:%s", edgeConfig.TenantTranslatorHost, edgeConfig.TenantTranslatorPort)
@@ -412,6 +414,7 @@ func LogConfigAtStartup(cfg *EdgeConfig) {
 		"EdgeAPIServicePort":       cfg.EdgeAPIServicePort,
 		"EdgeCertAPIURL":           cfg.EdgeCertAPIBaseURL,
 		"ImageBuilderOrgID":        cfg.ImageBuilderOrgID,
+		"GlitchtipDsn":             cfg.GlitchtipDsn,
 	}
 
 	// loop through the key/value pairs

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -16,6 +16,12 @@ objects:
     name: image-builder-org-id
   stringData:
     key: ${IMAGE_BUILDER_ORG_ID}
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: glitchtip-dsn
+  stringData:
+    key: ${GLITCHTIP_DSN}
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:
@@ -87,6 +93,11 @@ objects:
             secretKeyRef:
               key: key
               name: image-builder-org-id
+        - name: GLITCHTIPDSN
+          valueFrom:
+            secretKeyRef:
+              key: key
+              name: glitchtip-dsn
         - name: EDGEAPIBASEURL
           value: ${EDGEAPIBASEURL}
         - name: EDGECERTAPIBASEURL

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/getsentry/sentry-go v0.18.0 // indirect
 	github.com/go-openapi/analysis v0.21.2 // indirect
 	github.com/go-openapi/errors v0.20.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/getkin/kin-openapi v0.114.0 h1:ar7QiJpDdlR+zSyPjrLf8mNnpoFP/lI90XcywMCFNe8=
 github.com/getkin/kin-openapi v0.114.0/go.mod h1:l5e9PaFUo9fyLJCPGQeXI2ML8c3P8BHOEV2VaAVf/pc=
+github.com/getsentry/sentry-go v0.18.0 h1:MtBW5H9QgdcJabtZcuJG80BMOwaBpkRDZkxRkNC1sN0=
+github.com/getsentry/sentry-go v0.18.0/go.mod h1:Kgon4Mby+FJ7ZWHFUAZgVaIa8sxHtnRJRLTXZr51aKQ=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -23,6 +23,11 @@ type Flag struct {
 	EnvVar string
 }
 
+// GLITCHTIP LOGGING FLAGS
+
+// GlitchtipLogging is the feature flag for reporting errors to GlitchTip
+var GlitchtipLogging = &Flag{Name: "edge-management.glitchtip_logging", EnvVar: "GLITCHTIP_LOGGING"}
+
 // KAFKA LOGGING FLAGS
 
 // KafkaLogging is the feature flag for logging kafka messages


### PR DESCRIPTION
# Description
This PR implements GlitchTip for error tracking:
- add new `GlitchtipDsn` configuration parameter, which is read as a Vault secret when deployed via Clowder
- add new dependency `github.com/getsentry/sentry-go`
- initialize the Sentry client in `main.go`, so that all exceptions caught by the client in `main()` will be sent to GlitchTip

Normal functionality is unaffected, and I've verified that a `panic()` added after https://github.com/RedHatInsights/edge-api/blob/cc3990138b72f90ca592cf893b8b72770be3ba4c/main.go#L179 is successfully reported to the edge-api-stage GlitchTip project for PR checks run against stage.

FIXES: THEEDGE-2974

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
