### PR TITLE
kafka: Add producer message retries config values.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,49 +19,52 @@ import (
 
 // EdgeConfig represents the runtime configuration
 type EdgeConfig struct {
-	Hostname                 string                    `json:"hostname,omitempty"`
-	Auth                     bool                      `json:"auth,omitempty"`
-	WebPort                  int                       `json:"web_port,omitempty"`
-	MetricsPort              int                       `json:"metrics_port,omitempty"`
-	MetricsBaseURL           string                    `json:"metrics_api_base_url,omitempty"`
-	Logging                  *loggingConfig            `json:"logging,omitempty"`
-	LogLevel                 string                    `json:"log_level,omitempty"`
-	Debug                    bool                      `json:"debug,omitempty"`
-	Database                 *dbConfig                 `json:"database,omitempty"`
-	BucketName               string                    `json:"bucket_name,omitempty"`
-	BucketRegion             string                    `json:"bucket_region,omitempty"`
-	AccessKey                string                    `json:"-"`
-	SecretKey                string                    `json:"-"`
-	RepoTempPath             string                    `json:"repo_temp_path,omitempty"`
-	OpenAPIFilePath          string                    `json:"openapi_file_path,omitempty"`
-	ImageBuilderConfig       *imageBuilderConfig       `json:"image_builder,omitempty"`
-	InventoryConfig          *inventoryConfig          `json:"inventory,omitempty"`
-	PlaybookDispatcherConfig *playbookDispatcherConfig `json:"playbook_dispatcher,omitempty"`
-	TemplatesPath            string                    `json:"templates_path,omitempty"`
-	EdgeAPIBaseURL           string                    `json:"edge_api_base_url,omitempty"`
-	EdgeCertAPIBaseURL       string                    `json:"edge_cert_api_base_url,omitempty"`
-	EdgeAPIServiceHost       string                    `json:"edge_api_service_host,omitempty"`
-	EdgeAPIServicePort       int                       `json:"edge_api_service_port,omitempty"`
-	UploadWorkers            int                       `json:"upload_workers,omitempty"`
-	KafkaConfig              *clowder.KafkaConfig      `json:"kafka,omitempty"`
-	KafkaBrokers             []clowder.BrokerConfig    `json:"kafka_brokers,omitempty"`
-	KafkaBroker              *clowder.BrokerConfig     `json:"kafka_broker,omitempty"`
-	KafkaBrokerCaCertPath    string                    `json:"kafka_broker_ca_cert_path,omitempty"`
-	KafkaTopics              map[string]string         `json:"kafka_topics,omitempty"`
-	FDO                      *fdoConfig                `json:"fdo,omitempty"`
-	Local                    bool                      `json:"local,omitempty"`
-	Dev                      bool                      `json:"dev,omitempty"`
-	UnleashURL               string                    `json:"unleash_url,omitempty"`
-	UnleashSecretName        string                    `json:"unleash_secret_name,omitempty"`
-	FeatureFlagsEnvironment  string                    `json:"featureflags_environment,omitempty"`
-	FeatureFlagsURL          string                    `json:"featureflags_url,omitempty"`
-	FeatureFlagsAPIToken     string                    `json:"featureflags_api_token,omitempty"`
-	FeatureFlagsService      string                    `json:"featureflags_service,omitempty"`
-	FeatureFlagsBearerToken  string                    `json:"featureflags_bearer_token,omitempty"`
-	TenantTranslatorHost     string                    `json:"tenant_translator_host,omitempty"`
-	TenantTranslatorPort     string                    `json:"tenant_translator_port,omitempty"`
-	TenantTranslatorURL      string                    `json:"tenant_translator_url,omitempty"`
-	ImageBuilderOrgID        string                    `json:"image_builder_org_id,omitempty"`
+	Hostname                   string                    `json:"hostname,omitempty"`
+	Auth                       bool                      `json:"auth,omitempty"`
+	WebPort                    int                       `json:"web_port,omitempty"`
+	MetricsPort                int                       `json:"metrics_port,omitempty"`
+	MetricsBaseURL             string                    `json:"metrics_api_base_url,omitempty"`
+	Logging                    *loggingConfig            `json:"logging,omitempty"`
+	LogLevel                   string                    `json:"log_level,omitempty"`
+	Debug                      bool                      `json:"debug,omitempty"`
+	Database                   *dbConfig                 `json:"database,omitempty"`
+	BucketName                 string                    `json:"bucket_name,omitempty"`
+	BucketRegion               string                    `json:"bucket_region,omitempty"`
+	AccessKey                  string                    `json:"-"`
+	SecretKey                  string                    `json:"-"`
+	RepoTempPath               string                    `json:"repo_temp_path,omitempty"`
+	OpenAPIFilePath            string                    `json:"openapi_file_path,omitempty"`
+	ImageBuilderConfig         *imageBuilderConfig       `json:"image_builder,omitempty"`
+	InventoryConfig            *inventoryConfig          `json:"inventory,omitempty"`
+	PlaybookDispatcherConfig   *playbookDispatcherConfig `json:"playbook_dispatcher,omitempty"`
+	TemplatesPath              string                    `json:"templates_path,omitempty"`
+	EdgeAPIBaseURL             string                    `json:"edge_api_base_url,omitempty"`
+	EdgeCertAPIBaseURL         string                    `json:"edge_cert_api_base_url,omitempty"`
+	EdgeAPIServiceHost         string                    `json:"edge_api_service_host,omitempty"`
+	EdgeAPIServicePort         int                       `json:"edge_api_service_port,omitempty"`
+	UploadWorkers              int                       `json:"upload_workers,omitempty"`
+	KafkaConfig                *clowder.KafkaConfig      `json:"kafka,omitempty"`
+	KafkaBrokers               []clowder.BrokerConfig    `json:"kafka_brokers,omitempty"`
+	KafkaBroker                *clowder.BrokerConfig     `json:"kafka_broker,omitempty"`
+	KafkaBrokerCaCertPath      string                    `json:"kafka_broker_ca_cert_path,omitempty"`
+	KafkaRequestRequiredAcks   int                       `json:"kafka_request_required_acks,omitempty"`
+	KafkaMessageSendMaxRetries int                       `json:"kafka_message_send_max_retries,omitempty"`
+	KafkaRetryBackoffMs        int                       `json:"kafka_retry_backoff_ms,omitempty"`
+	KafkaTopics                map[string]string         `json:"kafka_topics,omitempty"`
+	FDO                        *fdoConfig                `json:"fdo,omitempty"`
+	Local                      bool                      `json:"local,omitempty"`
+	Dev                        bool                      `json:"dev,omitempty"`
+	UnleashURL                 string                    `json:"unleash_url,omitempty"`
+	UnleashSecretName          string                    `json:"unleash_secret_name,omitempty"`
+	FeatureFlagsEnvironment    string                    `json:"featureflags_environment,omitempty"`
+	FeatureFlagsURL            string                    `json:"featureflags_url,omitempty"`
+	FeatureFlagsAPIToken       string                    `json:"featureflags_api_token,omitempty"`
+	FeatureFlagsService        string                    `json:"featureflags_service,omitempty"`
+	FeatureFlagsBearerToken    string                    `json:"featureflags_bearer_token,omitempty"`
+	TenantTranslatorHost       string                    `json:"tenant_translator_host,omitempty"`
+	TenantTranslatorPort       string                    `json:"tenant_translator_port,omitempty"`
+	TenantTranslatorURL        string                    `json:"tenant_translator_url,omitempty"`
+	ImageBuilderOrgID          string                    `json:"image_builder_org_id,omitempty"`
 }
 
 type dbConfig struct {
@@ -140,6 +143,9 @@ func CreateEdgeAPIConfig() (*EdgeConfig, error) {
 	options.SetDefault("Local", false)
 	options.SetDefault("Dev", false)
 	options.SetDefault("EDGEMGMT_CONFIGPATH", "/tmp/edgemgmt_config.json")
+	options.SetDefault("KafkaRequestRequiredAcks", -1)
+	options.SetDefault("KafkaMessageSendMaxRetries", 15)
+	options.SetDefault("KafkaRetryBackoffMs", 100)
 	options.AutomaticEnv()
 
 	if options.GetBool("Debug") {
@@ -220,18 +226,21 @@ func CreateEdgeAPIConfig() (*EdgeConfig, error) {
 			APIVersion:          options.GetString("FDOApiVersion"),
 			AuthorizationBearer: options.GetString("FDOAuthorizationBearer"),
 		},
-		Local:                   options.GetBool("Local"),
-		Dev:                     options.GetBool("Dev"),
-		UnleashURL:              options.GetString("FeatureFlagsUrl"),
-		UnleashSecretName:       options.GetString("FeatureFlagsBearerToken"),
-		FeatureFlagsEnvironment: options.GetString("FeatureFlagsEnvironment"),
-		FeatureFlagsURL:         options.GetString("FeatureFlagsUrl"),
-		FeatureFlagsAPIToken:    options.GetString("FeatureFlagsAPIToken"),
-		FeatureFlagsBearerToken: options.GetString("FeatureFlagsBearerToken"),
-		FeatureFlagsService:     options.GetString("FeatureFlagsService"),
-		TenantTranslatorHost:    options.GetString("TenantTranslatorHost"),
-		TenantTranslatorPort:    options.GetString("TenantTranslatorPort"),
-		ImageBuilderOrgID:       options.GetString("ImageBuilderOrgID"),
+		Local:                      options.GetBool("Local"),
+		Dev:                        options.GetBool("Dev"),
+		UnleashURL:                 options.GetString("FeatureFlagsUrl"),
+		UnleashSecretName:          options.GetString("FeatureFlagsBearerToken"),
+		FeatureFlagsEnvironment:    options.GetString("FeatureFlagsEnvironment"),
+		FeatureFlagsURL:            options.GetString("FeatureFlagsUrl"),
+		FeatureFlagsAPIToken:       options.GetString("FeatureFlagsAPIToken"),
+		FeatureFlagsBearerToken:    options.GetString("FeatureFlagsBearerToken"),
+		FeatureFlagsService:        options.GetString("FeatureFlagsService"),
+		TenantTranslatorHost:       options.GetString("TenantTranslatorHost"),
+		TenantTranslatorPort:       options.GetString("TenantTranslatorPort"),
+		ImageBuilderOrgID:          options.GetString("ImageBuilderOrgID"),
+		KafkaRequestRequiredAcks:   options.GetInt("KafkaRequestRequiredAcks"),
+		KafkaMessageSendMaxRetries: options.GetInt("KafkaMessageSendMaxRetries"),
+		KafkaRetryBackoffMs:        options.GetInt("KafkaRetryBackoffMs"),
 	}
 	if edgeConfig.TenantTranslatorHost != "" && edgeConfig.TenantTranslatorPort != "" {
 		edgeConfig.TenantTranslatorURL = fmt.Sprintf("http://%s:%s", edgeConfig.TenantTranslatorHost, edgeConfig.TenantTranslatorPort)

--- a/pkg/common/kafka/kafkaconfigmap.go
+++ b/pkg/common/kafka/kafkaconfigmap.go
@@ -26,8 +26,8 @@ func NewKafkaConfigMapService() KafkaConfigMapServiceInterface {
 	return &KafkaConfigMapService{}
 }
 
-// GetKafkaProducerConfigMap returns the correct kafka auth based on the environment and given config
-func (k *KafkaConfigMapService) GetKafkaProducerConfigMap() kafka.ConfigMap {
+// getKafkaCommonConfigMap returns the kafka configMap common to producer and consumer
+func (k *KafkaConfigMapService) getKafkaCommonConfigMap() kafka.ConfigMap {
 	cfg := config.Get()
 	kafkaConfigMap := kafka.ConfigMap{}
 
@@ -65,10 +65,22 @@ func (k *KafkaConfigMapService) GetKafkaProducerConfigMap() kafka.ConfigMap {
 	return kafkaConfigMap
 }
 
+// GetKafkaProducerConfigMap returns the correct kafka auth based on the environment and given config
+func (k *KafkaConfigMapService) GetKafkaProducerConfigMap() kafka.ConfigMap {
+	cfg := config.Get()
+	kafkaConfigMap := k.getKafkaCommonConfigMap()
+
+	kafkaConfigMap.SetKey("request.required.acks", cfg.KafkaRequestRequiredAcks)
+	kafkaConfigMap.SetKey("message.send.max.retries", cfg.KafkaMessageSendMaxRetries)
+	kafkaConfigMap.SetKey("retry.backoff.ms", cfg.KafkaRetryBackoffMs)
+
+	return kafkaConfigMap
+}
+
 // GetKafkaConsumerConfigMap returns the correct kafka auth based on the environment and given config
 func (k *KafkaConfigMapService) GetKafkaConsumerConfigMap(consumerGroup string) kafka.ConfigMap {
 	cfg := config.Get()
-	kafkaConfigMap := k.GetKafkaProducerConfigMap()
+	kafkaConfigMap := k.getKafkaCommonConfigMap()
 	kafkaConfigMap.SetKey("group.id", consumerGroup)
 
 	if cfg.KafkaBrokers != nil {

--- a/pkg/common/kafka/kafkaconfigmap_test.go
+++ b/pkg/common/kafka/kafkaconfigmap_test.go
@@ -39,11 +39,14 @@ func TestGetKafkaProducerConfigMap(t *testing.T) {
 		},
 	}
 	kafkaConfigMap := kafka.ConfigMap{
-		"bootstrap.servers": "192.168.1.7:80",
-		"sasl.mechanisms":   "PLAIN",
-		"security.protocol": "SASL_SSL",
-		"sasl.username":     "something",
-		"sasl.password":     "something",
+		"bootstrap.servers":        "192.168.1.7:80",
+		"sasl.mechanisms":          "PLAIN",
+		"security.protocol":        "SASL_SSL",
+		"sasl.username":            "something",
+		"sasl.password":            "something",
+		"request.required.acks":    -1,
+		"message.send.max.retries": 15,
+		"retry.backoff.ms":         100,
 	}
 	cfg.KafkaBroker = &brokerConfig
 


### PR DESCRIPTION
# Description
Add producer configMap keys:
* request.required.acks
* message.send.max.retries
* retry.backoff.ms This is also used in some sibling projects https://github.com/RedHatInsights/playbook-dispatcher/blob/master/internal/common/kafka/kafka.go#L24
More info about the keys: https://camel.apache.org/components/3.20.x/kafka-component.html

added to configuration only this values:
```go 

	KafkaRequestRequiredAcks   int                       `json:"kafka_request_required_acks,omitempty"`
	KafkaMessageSendMaxRetries int                       `json:"kafka_message_send_max_retries,omitempty"`
	KafkaRetryBackoffMs        int                       `json:"kafka_retry_backoff_ms,omitempty"`

```
FIXES: THEEDGE-3000

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
