### PR TITLE
THEEDGE-3037 Fix wrong HTTP status when trying to update an image that is not the latest

### DIFF
--- a/pkg/common/seeder/seeder.go
+++ b/pkg/common/seeder/seeder.go
@@ -26,6 +26,7 @@ func Images() *Image {
 				Version: "2:6.0-1",
 			},
 		},
+		repoURL: faker.URL(),
 	}
 }
 
@@ -39,6 +40,7 @@ type Image struct {
 	ostreeHashCommit  string
 	version           int
 	installedPackages []models.InstalledPackage
+	repoURL           string
 }
 
 func (i *Image) WithImageSetID(imageSetID uint) *Image {
@@ -61,6 +63,11 @@ func (i *Image) WithVersion(version int) *Image {
 	return i
 }
 
+func (i *Image) WithRepoURL(repoURL string) *Image {
+	i.repoURL = repoURL
+	return i
+}
+
 func (i *Image) Create() (*models.Image, *models.ImageSet) {
 	var imageSet *models.ImageSet
 
@@ -76,15 +83,24 @@ func (i *Image) Create() (*models.Image, *models.ImageSet) {
 	}
 
 	image := &models.Image{
+		Name: imageSet.Name,
 		Commit: &models.Commit{
+			Arch:              "x86_64",
 			OSTreeCommit:      i.ostreeHashCommit,
 			InstalledPackages: i.installedPackages,
 			OrgID:             orgID,
+			Repo: &models.Repo{
+				URL:    i.repoURL,
+				Status: models.RepoStatusSuccess,
+			},
 		},
-		Version:    i.version,
-		Status:     models.ImageStatusSuccess,
-		ImageSetID: &imageSet.ID,
-		OrgID:      orgID,
+		Version:      i.version,
+		Status:       models.ImageStatusSuccess,
+		ImageSetID:   &imageSet.ID,
+		OrgID:        orgID,
+		Account:      common.DefaultAccount,
+		Distribution: "rhel-91",
+		OutputTypes:  []string{models.ImageTypeCommit},
 	}
 
 	db.DB.Create(image.Commit)

--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -285,7 +285,8 @@ func CreateImageUpdate(w http.ResponseWriter, r *http.Request) {
 		var apiError errors.APIError
 		switch err.(type) {
 		case *services.PackageNameDoesNotExist, *services.ThirdPartyRepositoryInfoIsInvalid, *services.ThirdPartyRepositoryNotFound,
-			*services.ImageNameAlreadyExists, *services.ImageSetAlreadyExists, *services.ImageNameChangeIsProhibited:
+			*services.ImageNameAlreadyExists, *services.ImageSetAlreadyExists, *services.ImageNameChangeIsProhibited,
+			*services.ImageOnlyLatestCanModify:
 			apiError = errors.NewBadRequest(err.Error())
 		default:
 			apiError = errors.NewInternalServerError()

--- a/pkg/services/errors.go
+++ b/pkg/services/errors.go
@@ -28,6 +28,7 @@ const ImageUnDefinedMsg = "image-set is undefined"
 const DeviceGroupNotFoundMsg = "device group was not found"
 const ImageSetAlreadyExistsMsg = "image set already exists"
 const ImageNotInErrorStateMsg = "image is not in error state"
+const ImageOnlyLatestCanModifyMsg = "only the latest updated image can be modified"
 const DeviceGroupOrgIDDevicesNotFoundMsg = "devices not found among the device group orgID"
 const DeviceGroupDevicesNotFoundMsg = "devices not found in device group"
 const DeviceGroupAccountOrIDUndefinedMsg = "account or deviceGroupID undefined"
@@ -70,6 +71,13 @@ type ImageNotFoundError struct{}
 
 func (e *ImageNotFoundError) Error() string {
 	return ImageNotFoundErrorMsg
+}
+
+// ImageOnlyLatestCanModify indicates only the latest image can be modified
+type ImageOnlyLatestCanModify struct{}
+
+func (e *ImageOnlyLatestCanModify) Error() string {
+	return ImageOnlyLatestCanModifyMsg
 }
 
 // ImageSetNotFoundError indicates the image-set was not found

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -288,7 +288,8 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 	}
 	err := s.CheckIfIsLatestVersion(previousImage)
 	if err != nil {
-		return errors.NewBadRequest("only the latest updated image can be modified")
+		s.log.WithField("error", err).Error("Error, not the latest image")
+		return new(ImageOnlyLatestCanModify)
 	}
 	packages := image.Packages
 	for _, p := range packages {


### PR DESCRIPTION
# Description
The edge-api was returning the wrong HTTP status when trying to update an image that is not the latest.
These changes fix the issue.

FIXES: [THEEDGE-3037](https://issues.redhat.com/browse/THEEDGE-3037)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
