### PR TITLE
Use filepath.join for OS-agnostic path.

### DIFF
--- a/pkg/services/files/uploader_test.go
+++ b/pkg/services/files/uploader_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Uploader Test", func() {
 					uploadPath := faker.UUIDHyphenated() + "/" + faker.UUIDHyphenated()
 
 					sourceFileName := fmt.Sprintf("uploader-%d.target-file", time.Now().UnixNano())
-					sourceFilePath := os.TempDir() + string(os.PathSeparator) + sourceFileName
+					sourceFilePath := filepath.Join(os.TempDir(), sourceFileName)
 
 					// should not call S3Client PuObject
 					s3Client.EXPECT().PutObject(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)


### PR DESCRIPTION
# Description
I noticed that when running tests on my Mac, the following test was failing:

```
Uploader Test
/Users/omaciel/go/src/github.com/omaciel/edge-api/pkg/services/files/uploader_test.go:26
  S3Uploader
  /Users/omaciel/go/src/github.com/omaciel/edge-api/pkg/services/files/uploader_test.go:101
    S3Uploader
    /Users/omaciel/go/src/github.com/omaciel/edge-api/pkg/services/files/uploader_test.go:131
      UploadFile
      /Users/omaciel/go/src/github.com/omaciel/edge-api/pkg/services/files/uploader_test.go:157
        UploadFile should return error when sourcePath does not exists [It]
        /Users/omaciel/go/src/github.com/omaciel/edge-api/pkg/services/files/uploader_test.go:195

        Expected
            <string>: failed to open file "/var/folders/f8/d3hhm54d0lx8n395gr4_kq3w0000gn/T//uploader-1676754900455641000.target-file", open /var/folders/f8/d3hhm54d0lx8n395gr4_kq3w0000gn/T/uploader-1676754900455641000.target-file: no such file or directory
        to contain substring
            <string>: /var/folders/f8/d3hhm54d0lx8n395gr4_kq3w0000gn/T//uploader-1676754900455641000.target-file: no such file or directory

        /Users/omaciel/go/src/github.com/omaciel/edge-api/pkg/services/files/uploader_test.go:206
```

The issue seems to be related to how `os.Tempdir` works on Linux versus on a Mac, where the Mac version of golang returns an `/` at the end of the generated directory, but the Linux version doesn't. `filepath.Join()` should handle the separator in a more OS-agnostic way.

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
