### PR TITLE
Handle lint for minimum replicas.

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -188,6 +188,8 @@ objects:
             cpu: 125m
             memory: 128Mi
     - name: ibvents
+      annotations:
+        ${LINT_ANNOTATION}: "minimum three replicas not required"
       minReplicas: 1
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}


### PR DESCRIPTION
# Description
DVO is no longer reported deployment_validation_operator_minimum_three_replicas failure for edge-api-ibvents. This failure is justified by [Jonathan Holloway](https://issues.redhat.com/secure/ViewProfile.jspa?name=jhollowa%40redhat.com) , and what's needed here is mute this alert using these docs: [doc1](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/dvo.md#disable-dvo-checks), [doc2](https://github.com/stackrox/kube-linter/blob/main/docs/configuring-kubelinter.md#ignoring-violations-for-specific-cases) , example: https://github.com/RedHatInsights/chrome-service-backend/blob/1d61c1f796b4792b2abcab66bbffd2065cea533c/deploy/clowdapp.yml#L84

FIXES: THEEDGE-3106

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
