### PR TITLE
update: Fixes update repo status on repo building failure.

### DIFF
--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -387,6 +387,7 @@ func (s *UpdateService) BuildUpdateRepo(orgID string, updateID uint) (*models.Up
 	// 	if an interrupt, set update status to error
 	go s.SetUpdateErrorStatusWhenInterrupted(intctx, *update, sigint, intcancel)
 
+	updateRepoID := update.RepoID
 	update, err := s.RepoBuilder.BuildUpdateRepo(updateID)
 	if err != nil {
 		s.log.WithField("error", err.Error()).Error("Error building update repo")
@@ -394,6 +395,13 @@ func (s *UpdateService) BuildUpdateRepo(orgID string, updateID uint) (*models.Up
 		if result := db.DB.Model(&models.UpdateTransaction{}).Where("ID=?", updateID).Update("Status", models.UpdateStatusError); result.Error != nil {
 			s.log.WithField("error", err.Error()).Error("failed to save building error status")
 			return nil, result.Error
+		}
+		// set repo status to error
+		if updateRepoID != nil {
+			if err := db.DB.Model(&models.Repo{}).Where("ID", updateRepoID).Update("Status", models.RepoStatusError).Error; err != nil {
+				s.log.WithField("error", err.Error()).Error("failed to save update repository error status")
+				return nil, err
+			}
 		}
 		return nil, err
 	}


### PR DESCRIPTION
# Description
- Set status to RepoStatusError when BuildUpdateRepo fails.
- Update negative unittest.

FIXES: THEEDGE-3136

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

