### PR TITLE
prcheck: add replace to coverage podman command

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -47,7 +47,7 @@ source $CICD_ROOT/post_test_results.sh
 CONTAINER_NAME="edge-pr-check-$ghprbPullId"
 
 # Run coverage using same version of Go as the App
-podman run --user root --rm -i \
+podman run --user root --rm --replace -i \
     --name $CONTAINER_NAME \
     -v $PWD:/usr/src:z \
     registry.access.redhat.com/ubi8/go-toolset:1.18.4-8 \


### PR DESCRIPTION
# Description
Adding --replace to the code coverage podman command in PR check

FIXES: THEEDGE-3151

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
