### PR TITLE
notifications: Fixes send Image Creation notification too early.

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -186,12 +186,6 @@ func (s *ImageService) CreateImage(image *models.Image) error {
 		return err
 	}
 	image.ThirdPartyRepositories = *imagesrepos
-	// Send Image creation to notification
-	notify, errNotify := s.SendImageNotification(image)
-	if errNotify != nil {
-		s.log.WithField("message", errNotify.Error()).Error("Error sending notification")
-		s.log.WithField("message", notify).Error("Notify Error")
-	}
 
 	// TODO: REFACTOR... ImageSet should be created first and an image created from it
 	imageSet, err := s.getImageSetForNewImage(image.OrgID, image)
@@ -231,6 +225,13 @@ func (s *ImageService) CreateImage(image *models.Image) error {
 
 	if result := db.DB.Create(&image); result.Error != nil {
 		return result.Error
+	}
+
+	// Send Image creation to notification
+	notify, errNotify := s.SendImageNotification(image)
+	if errNotify != nil {
+		s.log.WithField("message", errNotify.Error()).Error("Error sending notification")
+		s.log.WithField("message", notify).Error("Notify Error")
 	}
 
 	return nil


### PR DESCRIPTION
# Description


We are sending the notification too early, when the image.ID and image.ImageSetID are not defined yet. Move the notification code to the part where image.ID and image.ImageSetID are defined.

FIXES: THEEDGE-3149

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

