### PR TITLE
notifications: Fixes send Image Creation notification with imageSet pointer.

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -1590,7 +1590,12 @@ func (s *ImageService) SendImageNotification(i *models.Image) (ImageNotification
 
 		event.Metadata = emptyJSON.metaMap
 
-		event.Payload = fmt.Sprintf(`{"ImageId":"%v","ImageSetID":"%v"}`, i.ID, i.ImageSetID)
+		var imageSetID uint
+		if i.ImageSetID != nil {
+			imageSetID = *i.ImageSetID
+		}
+
+		event.Payload = fmt.Sprintf(`{"ImageId":"%v","ImageSetID":"%v"}`, i.ID, imageSetID)
 		events = append(events, event)
 
 		recipient.IgnoreUserPreferences = false


### PR DESCRIPTION
# Description
We are setting the imageSet payload with imageSet pointer address value. 
Fix by setting the payload with imageSet pointer Value.
Added a unit test for sending notification when creating image.


FIXES: THEEDGE-3149

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

