### PR TITLE
notifications: Fixes send Device Update notification.

### DIFF
--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"text/template"
 	"time"
@@ -629,7 +630,27 @@ func (s *UpdateService) SetUpdateStatus(update *models.UpdateTransaction) error 
 // SendDeviceNotification connects to platform.notifications.ingress on image topic
 func (s *UpdateService) SendDeviceNotification(i *models.UpdateTransaction) (ImageNotification, error) {
 	s.log.WithField("message", i).Info("SendImageNotification::Starts")
-	events := []EventNotification{{Metadata: make(map[string]string), Payload: fmt.Sprintf("{  \"UpdateID\" : \"%v\"}", i.ID)}}
+	// notification template of notifications-backend service need device name as ID
+	// join devices names of updateTransaction, in the current scenario updateTransaction may have only one device,
+	// because the initial updateTransaction will be split per device (eg for each device we are creating an updateTransaction)
+	// build a list of devices name to make sure we are always consistent, and we can send notifications event with multi-devices
+	deviceNames := make([]string, 0, len(i.Devices))
+	for _, device := range i.Devices {
+		deviceNames = append(deviceNames, device.Name)
+	}
+	notificationDeviceName := strings.Join(deviceNames, ", ")
+	// marshal data as device name may need escaping
+	type NotificationPayLoad struct {
+		ID string `json:"ID"`
+	}
+	notificationPayLoad := NotificationPayLoad{ID: notificationDeviceName}
+	payload, err := json.Marshal(notificationPayLoad)
+	if err != nil {
+		s.log.WithField("error", err.Error()).Error("error occurred while marshalling notification payload")
+		return ImageNotification{}, err
+	}
+
+	events := []EventNotification{{Metadata: make(map[string]string), Payload: string(payload)}}
 	users := []string{NotificationConfigUser}
 	recipients := []RecipientNotification{{IgnoreUserPreferences: false, OnlyAdmins: false, Users: users}}
 
@@ -640,7 +661,7 @@ func (s *UpdateService) SendDeviceNotification(i *models.UpdateTransaction) (Ima
 		EventType:   NotificationConfigEventTypeDevice,
 		Timestamp:   time.Now().Format(time.RFC3339),
 		OrgID:       i.OrgID,
-		Context:     fmt.Sprintf("{  \"CommitID\" : \"%v\"}", i.CommitID),
+		Context:     fmt.Sprintf(`{"CommitID":"%v","UpdateID":"%v"}`, i.CommitID, i.ID),
 		Events:      events,
 		Recipients:  recipients,
 	}
@@ -792,14 +813,6 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 
 		// Get the models.Commit from the Commit ID passed in via JSON
 		update.Commit = commit
-
-		notify, errNotify := s.SendDeviceNotification(&update)
-		if errNotify != nil {
-			s.log.WithField("message", errNotify.Error()).Error("Error to send device notification")
-			s.log.WithField("message", notify).Error("Notify Error")
-
-		}
-
 		update.DispatchRecords = []models.DispatchRecord{}
 
 		devices := update.Devices
@@ -943,6 +956,12 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 			updates = append(updates, update)
 		}
 		s.log.WithField("updateID", update.ID).Info("Update has been created")
+
+		notify, errNotify := s.SendDeviceNotification(&update)
+		if errNotify != nil {
+			s.log.WithField("message", errNotify.Error()).Error("Error to send device notification")
+			s.log.WithField("message", notify).Error("Notify Error")
+		}
 	}
 	return &updates, nil
 }


### PR DESCRIPTION
# Description

The email notification was sent with empty device name, see issue comment.
- Move send notification call to later stage when the update transaction model will have all the necessary data (already unittest covered).
- Fixes the notification payload to have update transaction device name, as it's expected by notifications-backend service https://github.com/RedHatInsights/notifications-backend/pull/1716 (added unittest for the changes).

FIXES: THEEDGE-3149

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

