### PR TITLE
Revert "validate env based on clowder config"

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -173,20 +173,18 @@ func CreateEdgeAPIConfig() (*EdgeConfig, error) {
 			}
 			options.SetDefault("FeatureFlagsBearerToken", clientAccessToken)
 		}
-		if cfg.Metadata != nil && *cfg.Metadata.Name == "prod" {
-			options.SetDefault("GpgVerify", "true")
-		}
 	} else {
 		options.SetDefault("FeatureFlagsUrl", os.Getenv("UNLEASH_URL"))
 		options.SetDefault("FeatureFlagsAPIToken", os.Getenv("UNLEASH_TOKEN"))
 		options.SetDefault("FeatureFlagsBearerToken", options.GetString("UNLEASH_TOKEN"))
-		options.SetDefault("GpgVerify", "false")
 	}
 	options.SetDefault("FeatureFlagsService", os.Getenv("FEATURE_FLAGS_SERVICE"))
 
 	if os.Getenv("SOURCES_ENV") == "prod" {
+		options.SetDefault("GpgVerify", "true")
 		options.SetDefault("FeatureFlagsEnvironment", "production")
 	} else {
+		options.SetDefault("GpgVerify", "false")
 		options.SetDefault("FeatureFlagsEnvironment", "development")
 	}
 

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -352,20 +352,16 @@ func (s *UpdateService) CreateUpdate(id uint) (*models.UpdateTransaction, error)
 }
 
 func NewTemplateRemoteInfo(update *models.UpdateTransaction) TemplateRemoteInfo {
-	gpgVerify := "false"
-	if feature.EnableGPGVerify.IsEnabled() {
-		gpgVerify = "true"
-	}
+
 	return TemplateRemoteInfo{
 		RemoteURL:           update.Repo.URL,
 		RemoteName:          "rhel-edge",
 		ContentURL:          update.Repo.URL,
 		UpdateTransactionID: update.ID,
-		GpgVerify:           gpgVerify,
+		GpgVerify:           config.Get().GpgVerify,
 		OSTreeRef:           update.Commit.OSTreeRef,
 		RemoteOstreeUpdate:  fmt.Sprint(update.ChangesRefs),
 	}
-
 }
 func (s *UpdateService) BuildUpdateRepo(orgID string, updateID uint) (*models.UpdateTransaction, error) {
 	var update *models.UpdateTransaction

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -81,9 +81,6 @@ var StorageImagesRepos = &Flag{Name: "edge-management.storage_images_repos", Env
 // UpdateRepoRequested is the feature flag to use for services.UpdateService.CreateUpdate(id) EDA Code
 var UpdateRepoRequested = &Flag{Name: "edge-management.update_repo_requested", EnvVar: "FEATURE_UPDATE_REPO_REQUESTED"}
 
-// EnableGPGVerify is the feature flag to use for enable gpg verification
-var EnableGPGVerify = &Flag{Name: "edge-management.gpg_verify", EnvVar: "ENABLE_GPG_VERIFY"}
-
 // ContentSources is a feature flag to use for code related to Parity and custom repositories
 var ContentSources = &Flag{Name: "edge-management.content_sources", EnvVar: "FEATURE_CONTENT_SOURCES"}
 


### PR DESCRIPTION
Reverts RedHatInsights/edge-api#1917
During our last meeting we decided to address the sign in first.
reverting to avoid any problem during the process