### PR TITLE
remove validation of env to set gpg verify; Define always as false;

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -180,11 +180,10 @@ func CreateEdgeAPIConfig() (*EdgeConfig, error) {
 	}
 	options.SetDefault("FeatureFlagsService", os.Getenv("FEATURE_FLAGS_SERVICE"))
 
+	options.SetDefault("GpgVerify", "false")
 	if os.Getenv("SOURCES_ENV") == "prod" {
-		options.SetDefault("GpgVerify", "true")
 		options.SetDefault("FeatureFlagsEnvironment", "production")
 	} else {
-		options.SetDefault("GpgVerify", "false")
 		options.SetDefault("FeatureFlagsEnvironment", "development")
 	}
 

--- a/templates/template_playbook_dispatcher_ostree_rebase_payload_prod.test.yml
+++ b/templates/template_playbook_dispatcher_ostree_rebase_payload_prod.test.yml
@@ -9,7 +9,7 @@
     ostree_remote_name: "remote-name"
     ostree_changes_refs: "true"
     os_tree_ref: "rhel/9/x86_64/edge"
-    ostree_gpg_verify: "true"
+    ostree_gpg_verify: "false"
     ostree_gpg_keypath: "/etc/pki/rpm-gpg/"
     ostree_remote_template: |
       [remote "{{ ostree_remote_name }}"]


### PR DESCRIPTION
# Description
rollback validation on gpg verify and set default as true

FIXES: THEEDGE-3051 

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
