### PR TITLE
content-sources: submit content-sources repositories to image builder.

### DIFF
--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -534,8 +534,25 @@ func (c *Client) GetImageThirdPartyRepos(image *models.Image) ([]Repository, err
 		return nil, errors.New("enter valid third party repository id")
 	}
 	for i := 0; i < len(thirdpartyrepos); i++ {
+		// init variables for current repository
+		var gpgKey *string
+		var enforceCheckGpg bool
+		// we have no checkGpg field in custom repo or in remote content-sources repositories or in image model
+		// assume that if repo has gpgKey, we should enforce CheckGPG
+		if thirdpartyrepos[i].GpgKey != "" {
+			gpgKey = &thirdpartyrepos[i].GpgKey
+			enforceCheckGpg = true
+		}
+
+		// to preserve compatibility, we want to pass checkGpg only in case of enforce checkGpg is true
+		var checkGpg *bool
+		if enforceCheckGpg {
+			checkGpg = &enforceCheckGpg
+		}
 		repos[i] = Repository{
-			BaseURL: thirdpartyrepos[i].URL,
+			BaseURL:  thirdpartyrepos[i].URL,
+			GPGKey:   gpgKey,
+			CheckGPG: checkGpg,
 		}
 	}
 

--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -537,14 +537,15 @@ func (c *Client) GetImageThirdPartyRepos(image *models.Image) ([]Repository, err
 		// init variables for current repository
 		var gpgKey *string
 		var enforceCheckGpg bool
-		// we have no checkGpg field in custom repo or in remote content-sources repositories or in image model
-		// assume that if repo has gpgKey, we should enforce CheckGPG
+		// there is no CheckGpg field in:
+		//		models.ThirdPartyRepo, repositories.Repository, models.Image
+		// assume that if repo has a GpgKey, we should set enforceCheckGPG to true
 		if thirdpartyrepos[i].GpgKey != "" {
 			gpgKey = &thirdpartyrepos[i].GpgKey
 			enforceCheckGpg = true
 		}
 
-		// to preserve compatibility, we want to pass checkGpg only in case of enforce checkGpg is true
+		// to preserve compatibility, we want to pass CheckGpg only in case of enforceCheckGpg is true
 		var checkGpg *bool
 		if enforceCheckGpg {
 			checkGpg = &enforceCheckGpg

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -287,7 +287,6 @@ func (s *ImageService) CreateImage(image *models.Image) error {
 	}
 
 	if feature.ContentSources.IsEnabled() {
-		// need to save the repos to database
 		err := s.SetImageContentSourcesRepositories(image)
 		if err != nil {
 			return err

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -51,6 +51,7 @@ type ImageServiceInterface interface {
 	SetErrorStatusOnImage(err error, i *models.Image)
 	CreateRepoForImage(context.Context, *models.Image) (*models.Repo, error)
 	CreateInstallerForImage(context.Context, *models.Image) (*models.Image, chan error, error)
+	SetImageContentSourcesRepositories(image *models.Image) error
 	GetImageByID(id string) (*models.Image, error)
 	GetImageByIDExtended(imageID uint, gormDB *gorm.DB) (*models.Image, error)
 	GetImageDevicesCount(imageId uint) (int64, error)
@@ -124,6 +125,105 @@ func GetImageReposFromDB(orgID string, repos []models.ThirdPartyRepo) (*[]models
 	return &imagesRepos, nil
 }
 
+// SetImageContentSourcesRepositories rebuild the image.ThirdPartyRepositories from content-sources repositories,
+// we get each repository from content-sources and check if it exists locally by its uuid,
+// if exists locally update its fields, if not create a new record,
+// add the existing/created record to image.ThirdPartyRepositories
+// the image is not saved, letting this responsibility to the caller function.
+func (s *ImageService) SetImageContentSourcesRepositories(image *models.Image) error {
+	if image == nil {
+		s.log.Error("image is not defined")
+		return new(ImageUnDefined)
+	}
+	if len(image.ThirdPartyRepositories) == 0 {
+		// do nothing and return early
+		return nil
+	}
+	if image.OrgID == "" {
+		s.log.WithField("image_name", image.Name).Error("image.OrgID is not defined")
+		return new(OrgIDNotSet)
+	}
+
+	// Get the Content-Sources Repositories by name
+	// create a map of content-sources repositories with their uuid as key
+	csRepos := make(map[string]*repositories.Repository, len(image.ThirdPartyRepositories))
+	// create a slice of repos uuids
+	csReposUUID := make([]string, 0, len(image.ThirdPartyRepositories))
+	for _, repo := range image.ThirdPartyRepositories {
+		csRepo, err := s.Repositories.GetRepositoryByName(repo.Name)
+		if err != nil {
+			s.log.WithFields(log.Fields{"repository_name": repo.Name, "error": err.Error()}).Error("error occurred while retrieving content-sources repository")
+			return err
+		}
+		csRepos[csRepo.UUID.String()] = csRepo
+		csReposUUID = append(csReposUUID, csRepo.UUID.String())
+	}
+
+	// Get the local existing custom repos that correspond to content-sources uuids
+	var existingEMRepos []models.ThirdPartyRepo
+	if err := db.Org(image.OrgID, "").Where("uuid", csReposUUID).Find(&existingEMRepos).Error; err != nil {
+		s.log.WithFields(log.Fields{"repos_uuid": csReposUUID, "error": err.Error()}).Error("error occurred while retrieving from local db")
+		return err
+	}
+	// Create a map of existing custom repos with uuid as key
+	existingEMReposUUID := make(map[string]*models.ThirdPartyRepo, len(image.ThirdPartyRepositories))
+	for _, emRepo := range existingEMRepos {
+		// create a local variable to prevent implicit memory aliasing in for loop
+		emRepo := emRepo
+		existingEMReposUUID[emRepo.UUID] = &emRepo
+	}
+
+	// build image third-party repos
+	imageCustomRepos := make([]models.ThirdPartyRepo, 0, len(image.ThirdPartyRepositories))
+	// use the same order as was given initially by using the slice csReposUUID, as the map csRepos may not guaranty the same order
+	for _, UUID := range csReposUUID {
+		csRepo := csRepos[UUID]
+		var emRepo models.ThirdPartyRepo
+		if existingEMRepo, ok := existingEMReposUUID[UUID]; ok {
+			// update local custom on any changes, to keep the used repos always updated
+			// make update only in case of changes
+			if existingEMRepo.Name != csRepo.Name ||
+				existingEMRepo.URL != csRepo.URL ||
+				existingEMRepo.GpgKey != csRepo.GpgKey ||
+				existingEMRepo.DistributionArch != csRepo.DistributionArch ||
+				existingEMRepo.PackageCount != csRepo.PackageCount {
+
+				existingEMRepo.Name = csRepo.Name
+				existingEMRepo.URL = csRepo.URL
+				existingEMRepo.GpgKey = csRepo.GpgKey
+				existingEMRepo.DistributionArch = csRepo.DistributionArch
+				existingEMRepo.PackageCount = csRepo.PackageCount
+
+				if err := db.DB.Save(existingEMRepo).Error; err != nil {
+					s.log.WithFields(log.Fields{"repo_uuid": UUID, "repo_id": existingEMRepo.ID, "error": err.Error()}).Error("error occurred while updating custom repository")
+					return err
+				}
+			}
+			emRepo = *existingEMRepo
+		} else {
+			// when custom repo with uuid does not exist, create a new one
+			emRepo = models.ThirdPartyRepo{
+				OrgID:               image.OrgID,
+				Name:                csRepo.Name,
+				URL:                 csRepo.URL,
+				UUID:                csRepo.UUID.String(),
+				DistributionArch:    csRepo.DistributionArch,
+				DistributionVersion: &csRepo.DistributionVersions,
+				GpgKey:              csRepo.GpgKey,
+				PackageCount:        csRepo.PackageCount,
+			}
+			if err := db.DB.Create(&emRepo).Error; err != nil {
+				s.log.WithFields(log.Fields{"repository_uuid": csRepo.UUID.String(), "error": err.Error()}).Error("error occurred while creating thirdparty repository")
+				return err
+			}
+		}
+		imageCustomRepos = append(imageCustomRepos, emRepo)
+	}
+
+	image.ThirdPartyRepositories = imageCustomRepos
+	return nil
+}
+
 func (s *ImageService) getImageSetForNewImage(orgID string, image *models.Image) (*models.ImageSet, error) {
 	// Check for ImageSet existence, if imageSet does not exist create one,
 	// if it exists and is not linked to any images reuse it,
@@ -185,11 +285,20 @@ func (s *ImageService) CreateImage(image *models.Image) error {
 			return er
 		}
 	}
-	imagesrepos, err := GetImageReposFromDB(image.OrgID, image.ThirdPartyRepositories)
-	if err != nil {
-		return err
+
+	if feature.ContentSources.IsEnabled() {
+		// need to save the repos to database
+		err := s.SetImageContentSourcesRepositories(image)
+		if err != nil {
+			return err
+		}
+	} else {
+		imagesrepos, err := GetImageReposFromDB(image.OrgID, image.ThirdPartyRepositories)
+		if err != nil {
+			return err
+		}
+		image.ThirdPartyRepositories = *imagesrepos
 	}
-	image.ThirdPartyRepositories = *imagesrepos
 
 	// TODO: REFACTOR... ImageSet should be created first and an image created from it
 	imageSet, err := s.getImageSetForNewImage(image.OrgID, image)
@@ -309,16 +418,25 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 			return er
 		}
 	}
-	imagesrepos, err := GetImageReposFromDB(previousImage.OrgID, image.ThirdPartyRepositories)
-	if err != nil {
-		return err
+
+	image.OrgID = previousImage.OrgID
+
+	if feature.ContentSources.IsEnabled() {
+		err := s.SetImageContentSourcesRepositories(image)
+		if err != nil {
+			return err
+		}
+	} else {
+		imagesrepos, err := GetImageReposFromDB(previousImage.OrgID, image.ThirdPartyRepositories)
+		if err != nil {
+			return err
+		}
+		image.ThirdPartyRepositories = *imagesrepos
 	}
-	image.ThirdPartyRepositories = *imagesrepos
 
 	// important: update the image imageSet for any previous image build status,
 	// otherwise image will be orphaned from its imageSet if previous build failed
 	image.ImageSetID = previousImage.ImageSetID
-	image.OrgID = previousImage.OrgID
 	if image.Name == "" {
 		// set the name to previous image name, as it must be obvious that it should be the same.
 		image.Name = previousImage.Name

--- a/pkg/services/mock_services/images.go
+++ b/pkg/services/mock_services/images.go
@@ -399,6 +399,20 @@ func (mr *MockImageServiceInterfaceMockRecorder) SetFinalImageStatus(i interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFinalImageStatus", reflect.TypeOf((*MockImageServiceInterface)(nil).SetFinalImageStatus), i)
 }
 
+// SetImageContentSourcesRepositories mocks base method.
+func (m *MockImageServiceInterface) SetImageContentSourcesRepositories(image *models.Image) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetImageContentSourcesRepositories", image)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetImageContentSourcesRepositories indicates an expected call of SetImageContentSourcesRepositories.
+func (mr *MockImageServiceInterfaceMockRecorder) SetImageContentSourcesRepositories(image interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetImageContentSourcesRepositories", reflect.TypeOf((*MockImageServiceInterface)(nil).SetImageContentSourcesRepositories), image)
+}
+
 // SetLog mocks base method.
 func (m *MockImageServiceInterface) SetLog(arg0 *logrus.Entry) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
# Description
- Validate image ThirdParties repos when Creating/Updating Image before imagebuilder Compose, some repos exists and need updates, some needs to be created locally .
- Update Image Builder request repositories with new repository fields, for now image builder support only GPGKey, CheckGPG

FIXES: THEEDGE-3083

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor


# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

