### PR TITLE
fixes fixes-TestProcessHelper unused test arg.

### DIFF
--- a/pkg/services/repobuilder_test.go
+++ b/pkg/services/repobuilder_test.go
@@ -1692,7 +1692,7 @@ func (th *MockTestExecHelper) MockExecCommand(command string, args ...string) *e
 }
 
 // TestProcessHelper this will be executed in its own process instead of the real command
-func TestProcessHelper(t *testing.T) {
+func TestProcessHelper(_ *testing.T) {
 	if os.Getenv("TEST_PROCESS_HELPER") != "1" {
 		return
 	}


### PR DESCRIPTION
# Description
To make the linter version happy again, rename the arg to "_" as unused in the function, but needed as an argument will be passed.

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

