### PR TITLE
removing OneOf from /updates in path.yml

### DIFF
--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -359,11 +359,9 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - type: array
-                    items:
-                      $ref: "#/components/schemas/v1.UpdateTransaction"
-                  - $ref: "#/components/schemas/v1.APIResponse"
+                type: array
+                items:
+                  $ref: '#/components/schemas/v1.UpdateTransaction'
           description: OK
         "400":
           content:


### PR DESCRIPTION
# Description
<!--
-->
Removing `oneOf` from `/updates`. it was causing the following errors in the iqe tests:
```
ERROR iqe_edge/tests/rest/test_device_groups.py::test_device_groups_image_info - AttributeError: module 'iqe_edge_api.models' has no attribute 'OneOfarrayv1APIResponse'
ERROR iqe_edge/tests/rest/test_device_groups.py::test_get_device_group_details_by_id_sanity - AttributeError: module 'iqe_edge_api.models' has no attribute 'OneOfarrayv1APIResponse'
ERROR iqe_edge/tests/rest/test_device_groups.py::test_add_device_to_device_group_sanity - AttributeError: module 'iqe_edge_api.models' has no attribute 'OneOfarrayv1APIResponse'
```

FIXES: <!-- THEEDGE-NNNN -->

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
