### PR TITLE
content-sources: Update GetRepositoryByUUID to handle http.StatusNotFound.

### DIFF
--- a/pkg/clients/repositories/client.go
+++ b/pkg/clients/repositories/client.go
@@ -192,6 +192,9 @@ func (c *Client) GetRepositoryByUUID(uuid string) (*Repository, error) {
 		c.log.WithFields(log.Fields{"statusCode": res.StatusCode, "error": err.Error()}).Error("content source repository response error")
 		return nil, err
 	}
+	if res.StatusCode == http.StatusNotFound {
+		return nil, ErrRepositoryNoFound
+	}
 	if res.StatusCode != http.StatusOK {
 		c.log.WithFields(log.Fields{"statusCode": res.StatusCode, "responseBody": string(body)}).Error("content source repository error response")
 		return nil, ErrRepositoryRequestResponse

--- a/pkg/clients/repositories/clients_test.go
+++ b/pkg/clients/repositories/clients_test.go
@@ -436,6 +436,13 @@ func TestGetRepositoryByUUID(t *testing.T) {
 			ExpectedError: nil,
 		},
 		{
+			Name:          "should return ErrRepositoryNoFound when http status is 404",
+			UUID:          repoUUID,
+			HTTPStatus:    http.StatusNotFound,
+			IOReadAll:     io.ReadAll,
+			ExpectedError: repositories.ErrRepositoryNoFound,
+		},
+		{
 			Name:          "should return error when http status is not 200",
 			UUID:          repoUUID,
 			HTTPStatus:    http.StatusBadRequest,


### PR DESCRIPTION
# Description
Update content-sources GetRepositoryByUUID to return err not found when content-sources return handle http.StatusNotFound.

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

