### PR TITLE
content-sources: prohibit any changes to repos when feature flag is enabled

### DIFF
--- a/pkg/errors/api.go
+++ b/pkg/errors/api.go
@@ -72,8 +72,14 @@ type FeatureNotAvailable struct {
 	apiError
 }
 
+// FeatureNotAvailableDefaultMessage the message used by default for FeatureNotAvailable API error
+const FeatureNotAvailableDefaultMessage = "Feature not available"
+
 // NewFeatureNotAvailable creates a new NewFeatureNotAvailable
 func NewFeatureNotAvailable(message string) APIError {
+	if message == "" {
+		message = FeatureNotAvailableDefaultMessage
+	}
 	err := new(FeatureNotAvailable)
 	err.Code = "FEATURE_NOT_AVAILABLE"
 	err.Title = message

--- a/pkg/routes/thirdpartyrepo.go
+++ b/pkg/routes/thirdpartyrepo.go
@@ -101,6 +101,10 @@ func getThirdPartyRepo(w http.ResponseWriter, r *http.Request) *models.ThirdPart
 // CreateThirdPartyRepo creates Third Party Repository
 func CreateThirdPartyRepo(w http.ResponseWriter, r *http.Request) {
 	ctxServices := dependencies.ServicesFromContext(r.Context())
+	if feature.ContentSources.IsEnabled() {
+		respondWithAPIError(w, ctxServices.Log, errors.NewFeatureNotAvailable(""))
+		return
+	}
 	thirdPartyRepo, err := createRequest(w, r)
 	if err != nil {
 		// error handled by createRequest already
@@ -388,12 +392,17 @@ func GetThirdPartyRepoByID(w http.ResponseWriter, r *http.Request) {
 
 // UpdateThirdPartyRepo updates the existing third party repository
 func UpdateThirdPartyRepo(w http.ResponseWriter, r *http.Request) {
+	ctxServices := dependencies.ServicesFromContext(r.Context())
+	if feature.ContentSources.IsEnabled() {
+		respondWithAPIError(w, ctxServices.Log, errors.NewFeatureNotAvailable(""))
+		return
+	}
 	oldtprepo := getThirdPartyRepo(w, r)
 	if oldtprepo == nil {
 		// error is handled by getThirdPartyRepo
 		return
 	}
-	ctxServices := dependencies.ServicesFromContext(r.Context())
+
 	tprepo, err := createRequest(w, r)
 	if err != nil {
 		// error handled by createRequest already
@@ -427,12 +436,17 @@ func UpdateThirdPartyRepo(w http.ResponseWriter, r *http.Request) {
 
 // DeleteThirdPartyRepoByID deletes the third party repository using ID
 func DeleteThirdPartyRepoByID(w http.ResponseWriter, r *http.Request) {
+	ctxServices := dependencies.ServicesFromContext(r.Context())
+	if feature.ContentSources.IsEnabled() {
+		respondWithAPIError(w, ctxServices.Log, errors.NewFeatureNotAvailable(""))
+		return
+	}
 	tprepo := getThirdPartyRepo(w, r)
 	if tprepo == nil {
 		// error response handled by getThirdPartyRepo
 		return
 	}
-	ctxServices := dependencies.ServicesFromContext(r.Context())
+
 	tprepo, err := ctxServices.ThirdPartyRepoService.DeleteThirdPartyRepoByID(fmt.Sprint(tprepo.ID))
 	if err != nil {
 		var responseErr errors.APIError


### PR DESCRIPTION
# Description
In the context of content-sources feature enabled, to avoid any confusion between local repos and content-sources one, block any modification to any local repo. for the API any repo must be modified only in content-sources. 

In other words for the external world in this context we are using content-sources and have no feature in our application to modify or manage content-sources repos, this implies to return feature not available error when trying todo so on API.

FIXES: THEEDGE-3227

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
