### PR TITLE
content-sources: add client CreateRepository.

### DIFF
--- a/pkg/clients/repositories/client.go
+++ b/pkg/clients/repositories/client.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -70,6 +71,7 @@ type ClientInterface interface {
 	GetRepositoryByURL(url string) (*Repository, error)
 	GetRepositoryByUUID(uuid string) (*Repository, error)
 	ListRepositories(requestParams ListRepositoriesParams, filters ListRepositoriesFilters) (*ListRepositoriesResponse, error)
+	CreateRepository(repository Repository) (*Repository, error)
 }
 
 // Client is the implementation of an ClientInterface
@@ -97,6 +99,9 @@ var APIRepositoriesPath = "repositories"
 
 // IOReadAll The io body reader
 var IOReadAll = io.ReadAll
+
+// NewJSONEncoder  create a new json encoder
+var NewJSONEncoder = json.NewEncoder
 
 var ErrRepositoryRequestResponse = errors.New("repository request error response")
 var ErrParsingRawURL = errors.New("error occurred while parsing raw url")
@@ -276,4 +281,61 @@ func (c *Client) ListRepositories(requestParams ListRepositoriesParams, filters 
 		return nil, err
 	}
 	return &response, nil
+}
+
+func (c *Client) CreateRepository(repository Repository) (*Repository, error) {
+	baseURL, err := c.GetBaseURL()
+	if err != nil {
+		return nil, err
+	}
+
+	repositoriesRawURL := baseURL.String() + fmt.Sprintf("/%s/%s/", APIVersion, APIRepositoriesPath)
+	repositoriesURL, err := baseURL.Parse(repositoriesRawURL)
+	if err != nil {
+		c.log.WithFields(log.Fields{"url": repositoriesRawURL, "error": err.Error()}).Error("failed to parse repository url")
+		return nil, ErrParsingRawURL
+	}
+
+	payloadBuffer := new(bytes.Buffer)
+	if err := NewJSONEncoder(payloadBuffer).Encode(&repository); err != nil {
+		c.log.WithField("error", err.Error()).Error("content source error occurred while encoding repository")
+		return nil, err
+	}
+
+	requestURL := repositoriesURL.String()
+	c.log.WithField("url", requestURL).Info("content source create repository request started")
+
+	req, _ := http.NewRequest("POST", requestURL, payloadBuffer)
+	req.Header.Add("Content-Type", "application/json")
+	headers := clients.GetOutgoingHeaders(c.ctx)
+	for key, value := range headers {
+		req.Header.Add(key, value)
+	}
+
+	client := clients.ConfigureClientWithTLS(&http.Client{})
+	res, err := client.Do(req)
+	if err != nil {
+		c.log.WithField("error", err.Error()).Error("content source create repository request error")
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	body, err := IOReadAll(res.Body)
+	if err != nil {
+		c.log.WithFields(log.Fields{"statusCode": res.StatusCode, "error": err.Error()}).Error("content source create repository response error")
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusCreated {
+		c.log.WithFields(log.Fields{"statusCode": res.StatusCode, "responseBody": string(body)}).Error("content source create repository response error")
+		return nil, ErrRepositoryRequestResponse
+	}
+
+	var responseRepository Repository
+	err = json.Unmarshal(body, &responseRepository)
+	if err != nil {
+		c.log.WithFields(log.Fields{"responseBody": string(body), "error": err.Error()}).Error("error occurred when unmarshalling response body to repository")
+		return nil, err
+	}
+	return &responseRepository, nil
 }

--- a/pkg/clients/repositories/clients_test.go
+++ b/pkg/clients/repositories/clients_test.go
@@ -545,3 +545,166 @@ func TestGetRepositoryByUUID(t *testing.T) {
 		})
 	}
 }
+
+// ErrFaultyWriter the error returned by FaultWriter's Write function
+var ErrFaultyWriter = errors.New("faulty writer expected write error")
+
+// FaultyWriter a struct that implement a Writer that return always error when writing
+type FaultyWriter struct{}
+
+func (f *FaultyWriter) Write(_ []byte) (n int, err error) {
+	return 0, ErrFaultyWriter
+}
+
+func TestCreateRepository(t *testing.T) {
+	initialContentSourceURL := config.Get().ContentSourcesURL
+	initialAPIRepositoriesPath := repositories.APIRepositoriesPath
+	// restore the initial content sources url and apiRepositoriesPath
+	defer func(contentSourcesURL, reposPath string) {
+		config.Get().ContentSourcesURL = contentSourcesURL
+		repositories.APIRepositoriesPath = reposPath
+	}(initialContentSourceURL, initialAPIRepositoriesPath)
+
+	repoToCreate := repositories.Repository{Name: faker.UUIDHyphenated(), URL: faker.URL()}
+	responseRepo := repositories.Repository{UUID: uuid.New(), Name: repoToCreate.Name, URL: repoToCreate.URL}
+
+	testCases := []struct {
+		Name                string
+		ContentSourcesURL   string
+		APIRepositoriesPath string
+		RepoToCreate        repositories.Repository
+		IOReadAll           func(r io.Reader) ([]byte, error)
+		NewJSONEncoder      func(w io.Writer) *json.Encoder
+		HTTPStatus          int
+		Response            *repositories.Repository
+		ResponseText        string
+		ExpectedError       error
+	}{
+		{
+			Name:           "should create repository successfully",
+			RepoToCreate:   repoToCreate,
+			HTTPStatus:     http.StatusCreated,
+			IOReadAll:      io.ReadAll,
+			NewJSONEncoder: json.NewEncoder,
+			Response:       &responseRepo,
+			ExpectedError:  nil,
+		},
+		{
+			Name:           "should return error when http status is not 201",
+			RepoToCreate:   repoToCreate,
+			HTTPStatus:     http.StatusBadRequest,
+			IOReadAll:      io.ReadAll,
+			NewJSONEncoder: json.NewEncoder,
+			ExpectedError:  repositories.ErrRepositoryRequestResponse,
+		},
+		{
+			Name:              "should return error when parsing base url fails",
+			RepoToCreate:      repoToCreate,
+			ContentSourcesURL: "\t",
+			IOReadAll:         io.ReadAll,
+			NewJSONEncoder:    json.NewEncoder,
+			HTTPStatus:        http.StatusCreated,
+			ExpectedError:     repositories.ErrParsingRawURL,
+		},
+		{
+			Name:                "should return error when parsing apiRepositoriesPath fails",
+			RepoToCreate:        repoToCreate,
+			APIRepositoriesPath: "\t",
+			IOReadAll:           io.ReadAll,
+			NewJSONEncoder:      json.NewEncoder,
+			HTTPStatus:          http.StatusCreated,
+			ExpectedError:       repositories.ErrParsingRawURL,
+		},
+		{
+			Name:              "should return error when client Do fail",
+			RepoToCreate:      repoToCreate,
+			ContentSourcesURL: "host-without-schema",
+			IOReadAll:         io.ReadAll,
+			NewJSONEncoder:    json.NewEncoder,
+			HTTPStatus:        http.StatusCreated,
+			ExpectedError:     errors.New("unsupported protocol scheme"),
+		},
+		{
+			Name:           "should return error when malformed json is returned",
+			RepoToCreate:   repoToCreate,
+			HTTPStatus:     http.StatusCreated,
+			IOReadAll:      io.ReadAll,
+			NewJSONEncoder: json.NewEncoder,
+			ResponseText:   `{"data: {}}`,
+			ExpectedError:  errors.New("unexpected end of JSON input"),
+		},
+		{
+			Name:         "should return error when body readAll fails",
+			RepoToCreate: repoToCreate,
+			HTTPStatus:   http.StatusCreated,
+			IOReadAll: func(r io.Reader) ([]byte, error) {
+				return nil, errors.New("expected error for when reading response body fails")
+			},
+			NewJSONEncoder: json.NewEncoder,
+			Response:       nil,
+			ExpectedError:  errors.New("expected error for when reading response body fails"),
+		},
+		{
+			Name:         "should return error when repository json encode fails",
+			RepoToCreate: repoToCreate,
+			IOReadAll:    io.ReadAll,
+			NewJSONEncoder: func(_ io.Writer) *json.Encoder {
+				// ignore any argument a return the FaultyWriter, that returns error when calling its Write function
+				return json.NewEncoder(&FaultyWriter{})
+			},
+			ExpectedError: ErrFaultyWriter,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			initialAPIRepositoriesPath := repositories.APIRepositoriesPath
+			// restore the initial apiRepositoriesPath and IOReadAll
+			defer func(reposPath string) {
+				repositories.APIRepositoriesPath = reposPath
+				repositories.IOReadAll = io.ReadAll
+				repositories.NewJSONEncoder = json.NewEncoder
+			}(initialAPIRepositoriesPath)
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(testCase.HTTPStatus)
+				if testCase.ResponseText != "" {
+					_, err := fmt.Fprint(w, testCase.ResponseText)
+					assert.NoError(t, err)
+					return
+				}
+				if testCase.Response != nil {
+					err := json.NewEncoder(w).Encode(&testCase.Response)
+					assert.NoError(t, err)
+				}
+			}))
+			defer ts.Close()
+
+			repositories.IOReadAll = testCase.IOReadAll
+			repositories.NewJSONEncoder = testCase.NewJSONEncoder
+
+			if testCase.ContentSourcesURL == "" {
+				config.Get().ContentSourcesURL = ts.URL
+			} else {
+				config.Get().ContentSourcesURL = testCase.ContentSourcesURL
+			}
+			if testCase.APIRepositoriesPath != "" {
+				repositories.APIRepositoriesPath = testCase.APIRepositoriesPath
+			}
+
+			client := repositories.InitClient(context.Background(), log.NewEntry(log.StandardLogger()))
+			assert.NotNil(t, client)
+
+			response, err := client.CreateRepository(testCase.RepoToCreate)
+			if testCase.ExpectedError == nil {
+				assert.NoError(t, err)
+				assert.NotNil(t, response)
+				assert.NotNil(t, testCase.Response)
+				assert.Equal(t, *response, *testCase.Response)
+			} else {
+				assert.ErrorContains(t, err, testCase.ExpectedError.Error())
+			}
+		})
+	}
+}

--- a/pkg/clients/repositories/mock_repositories/client.go
+++ b/pkg/clients/repositories/mock_repositories/client.go
@@ -35,6 +35,21 @@ func (m *MockClientInterface) EXPECT() *MockClientInterfaceMockRecorder {
 	return m.recorder
 }
 
+// CreateRepository mocks base method.
+func (m *MockClientInterface) CreateRepository(repository repositories.Repository) (*repositories.Repository, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRepository", repository)
+	ret0, _ := ret[0].(*repositories.Repository)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateRepository indicates an expected call of CreateRepository.
+func (mr *MockClientInterfaceMockRecorder) CreateRepository(repository interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRepository", reflect.TypeOf((*MockClientInterface)(nil).CreateRepository), repository)
+}
+
 // GetBaseURL mocks base method.
 func (m *MockClientInterface) GetBaseURL() (*url.URL, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
# Description
The CreateRepository the repositories function that will be used to create repository in content-sources.

100% coverage

FIXES: THEEDGE-3208


## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

