### PR TITLE
content-sources: Apply the same rules as for content-sources repos.

### DIFF
--- a/pkg/models/thirdpartyrepo.go
+++ b/pkg/models/thirdpartyrepo.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
@@ -70,12 +71,31 @@ func (t *ThirdPartyRepo) ValidateRequest() error {
 	return nil
 }
 
+// AddSlashToURL cleanup url from leading and trailing white spaces and add slash "/" at the end if missing
+// e.g. transform " http://repo.url.com/repo "  to "http://repo.url.com/repo/"
+func AddSlashToURL(url string) string {
+	url = strings.TrimSpace(url)
+	if len(url) > 0 && url[len(url)-1] != '/' {
+		url += "/"
+	}
+	return url
+}
+
 // BeforeCreate method is called before creating Third Party Repository, it make sure org_id is not empty
 func (t *ThirdPartyRepo) BeforeCreate(tx *gorm.DB) error {
 	if t.OrgID == "" {
 		log.Error("custom-repository do not have an org_id")
 		return ErrOrgIDIsMandatory
 	}
+	// clean up URL and add slash "/"
+	t.URL = AddSlashToURL(t.URL)
 
+	return nil
+}
+
+// BeforeUpdate is called before updating third party repository
+func (t *ThirdPartyRepo) BeforeUpdate(tx *gorm.DB) error {
+	// clean up URL and add slash "/"
+	t.URL = AddSlashToURL(t.URL)
 	return nil
 }

--- a/pkg/models/thirdpartyrepo_test.go
+++ b/pkg/models/thirdpartyrepo_test.go
@@ -135,3 +135,71 @@ func TestThirdPartyRepoBeforeCreate(t *testing.T) {
 	}
 
 }
+
+func TestAddSlashToURL(t *testing.T) {
+	testCases := []struct {
+		Name        string
+		URL         string
+		ExpectedURL string
+	}{
+		{
+			Name:        "should remove trailing white spaces and add slash",
+			URL:         " http://example.com.repo  ",
+			ExpectedURL: "http://example.com.repo/",
+		},
+		{
+			Name:        "should remove only trailing white spaces",
+			URL:         " http://example.com.repo/  ",
+			ExpectedURL: "http://example.com.repo/",
+		},
+		{
+			Name:        "should not change the URL",
+			URL:         "http://example.com.repo/",
+			ExpectedURL: "http://example.com.repo/",
+		},
+		{
+			Name:        "should not change the URL when empty",
+			URL:         "",
+			ExpectedURL: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			url := AddSlashToURL(testCase.URL)
+			assert.Equal(t, testCase.ExpectedURL, url)
+		})
+	}
+}
+
+func TestCreateThirdPartyRepoWithURL(t *testing.T) {
+	// should clean up url and add a slash "/" when creating repo
+	url := " http://example.com.repo  \t"
+	wantedURL := "http://example.com.repo/"
+	repo := ThirdPartyRepo{
+		Name:  faker.Name(),
+		OrgID: faker.UUIDHyphenated(),
+		URL:   url,
+	}
+	err := db.DB.Create(&repo).Error
+	assert.NoError(t, err)
+	assert.Equal(t, wantedURL, repo.URL)
+}
+
+func TestUpdateThirdPartyRepoWithURL(t *testing.T) {
+	// should clean up url and add a slash "/" when updating repo
+	repo := ThirdPartyRepo{
+		Name:  faker.Name(),
+		OrgID: faker.UUIDHyphenated(),
+		URL:   faker.URL(),
+	}
+	err := db.DB.Create(&repo).Error
+	assert.NoError(t, err)
+
+	url := " http://example.com.repo  \t"
+	wantedURL := "http://example.com.repo/"
+	repo.URL = url
+	err = db.DB.Save(&repo).Error
+	assert.NoError(t, err)
+	assert.Equal(t, wantedURL, repo.URL)
+}

--- a/pkg/routes/thirdpartyrepo.go
+++ b/pkg/routes/thirdpartyrepo.go
@@ -122,7 +122,7 @@ func CreateThirdPartyRepo(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var apiError errors.APIError
 		switch err.(type) {
-		case *services.ThirdPartyRepositoryNameIsEmpty, *services.ThirdPartyRepositoryURLIsEmpty, *services.ThirdPartyRepositoryAlreadyExists:
+		case *services.ThirdPartyRepositoryNameIsEmpty, *services.ThirdPartyRepositoryURLIsEmpty, *services.ThirdPartyRepositoryAlreadyExists, *services.ThirdPartyRepositoryWithURLAlreadyExists:
 			apiError = errors.NewBadRequest(err.Error())
 		default:
 			apiError = errors.NewInternalServerError()
@@ -412,7 +412,7 @@ func UpdateThirdPartyRepo(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var apiError errors.APIError
 		switch err.(type) {
-		case *services.ThirdPartyRepositoryAlreadyExists, *services.ThirdPartyRepositoryImagesExists:
+		case *services.ThirdPartyRepositoryAlreadyExists, *services.ThirdPartyRepositoryImagesExists, *services.ThirdPartyRepositoryWithURLAlreadyExists:
 			apiError = errors.NewBadRequest(err.Error())
 		case *services.ThirdPartyRepositoryNotFound:
 			apiError = errors.NewNotFound(err.Error())

--- a/pkg/services/errors.go
+++ b/pkg/services/errors.go
@@ -14,6 +14,7 @@ const OrgIDNotSetMsg = "Org ID is not set"
 const IDMustBeIntegerMsg = "ID needs to be an integer"
 const ThirdPartyRepositoryNotFoundMsg = "third party repository was not found"
 const ThirdPartyRepositoryAlreadyExistsMsg = "custom repository already exists"
+const ThirdPartyRepositoryWithURLAlreadyExistsMsg = "custom repository with url already exists"
 const ThirdPartyRepositoryNameIsEmptyMsg = "custom repository name cannot be empty"
 const ThirdPartyRepositoryURLIsEmptyMsg = "custom repository URL cannot be empty"
 const ThirdPartyRepositoryInfoIsInvalidMsg = "custom repository info is invalid"
@@ -128,6 +129,13 @@ type ThirdPartyRepositoryAlreadyExists struct{}
 
 func (e *ThirdPartyRepositoryAlreadyExists) Error() string {
 	return ThirdPartyRepositoryAlreadyExistsMsg
+}
+
+// ThirdPartyRepositoryWithURLAlreadyExists indicates the Third Party Repository already exists with the requested url
+type ThirdPartyRepositoryWithURLAlreadyExists struct{}
+
+func (e *ThirdPartyRepositoryWithURLAlreadyExists) Error() string {
+	return ThirdPartyRepositoryWithURLAlreadyExistsMsg
 }
 
 // ThirdPartyRepositoryNameIsEmpty indicates the Third Party Repository name is empty

--- a/pkg/services/errors_test.go
+++ b/pkg/services/errors_test.go
@@ -23,6 +23,7 @@ func TestDeviceNotFoundError(t *testing.T) {
 		{new(services.IDMustBeInteger), services.IDMustBeIntegerMsg},
 		{new(services.ThirdPartyRepositoryNotFound), services.ThirdPartyRepositoryNotFoundMsg},
 		{new(services.ThirdPartyRepositoryAlreadyExists), services.ThirdPartyRepositoryAlreadyExistsMsg},
+		{new(services.ThirdPartyRepositoryWithURLAlreadyExists), services.ThirdPartyRepositoryWithURLAlreadyExistsMsg},
 		{new(services.ThirdPartyRepositoryNameIsEmpty), services.ThirdPartyRepositoryNameIsEmptyMsg},
 		{new(services.ThirdPartyRepositoryURLIsEmpty), services.ThirdPartyRepositoryURLIsEmptyMsg},
 		{new(services.ThirdPartyRepositoryInfoIsInvalid), services.ThirdPartyRepositoryInfoIsInvalidMsg},

--- a/pkg/services/images_test.go
+++ b/pkg/services/images_test.go
@@ -1298,12 +1298,12 @@ var _ = Describe("Image Service Test", func() {
 			csRepos = []repositories.Repository{
 				// add an existing one, but change some data
 				{
-					UUID: uuid.MustParse(existingEMRepo.UUID), Name: faker.UUIDHyphenated(), URL: faker.URL(),
+					UUID: uuid.MustParse(existingEMRepo.UUID), Name: faker.UUIDHyphenated(), URL: models.AddSlashToURL(faker.URL()),
 					DistributionArch: faker.UUIDHyphenated(), GpgKey: faker.UUIDHyphenated(), PackageCount: 200,
 				},
 				// add the other that do not exist in db
 				{
-					UUID: uuid.MustParse(otherEMRepo.UUID), Name: otherEMRepo.Name, URL: faker.URL(), DistributionArch: faker.UUIDHyphenated(),
+					UUID: uuid.MustParse(otherEMRepo.UUID), Name: otherEMRepo.Name, URL: models.AddSlashToURL(faker.URL()), DistributionArch: faker.UUIDHyphenated(),
 					GpgKey: faker.UUIDHyphenated(), PackageCount: 160,
 				},
 			}

--- a/pkg/services/mock_services/thirdpartyrepo.go
+++ b/pkg/services/mock_services/thirdpartyrepo.go
@@ -94,6 +94,21 @@ func (mr *MockThirdPartyRepoServiceInterfaceMockRecorder) ThirdPartyRepoNameExis
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ThirdPartyRepoNameExists", reflect.TypeOf((*MockThirdPartyRepoServiceInterface)(nil).ThirdPartyRepoNameExists), orgID, name)
 }
 
+// ThirdPartyRepoURLExists mocks base method.
+func (m *MockThirdPartyRepoServiceInterface) ThirdPartyRepoURLExists(orgID, url string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ThirdPartyRepoURLExists", orgID, url)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ThirdPartyRepoURLExists indicates an expected call of ThirdPartyRepoURLExists.
+func (mr *MockThirdPartyRepoServiceInterfaceMockRecorder) ThirdPartyRepoURLExists(orgID, url interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ThirdPartyRepoURLExists", reflect.TypeOf((*MockThirdPartyRepoServiceInterface)(nil).ThirdPartyRepoURLExists), orgID, url)
+}
+
 // UpdateThirdPartyRepo mocks base method.
 func (m *MockThirdPartyRepoServiceInterface) UpdateThirdPartyRepo(tprepo *models.ThirdPartyRepo, orgID, ID string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION

# Description

As the edge and content-sources services have different rules, before migration edge-management needs to comply with content-sources rules:
- Create a validator that verifies that the url does not exist before creating a new one.
- When creating/updating repos modify the url to terminate with slash "/"

FIXES: THEEDGE-3261

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor


# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

