### PR TITLE
handle response code when playbook dispatcher not found(perf)

### DIFF
--- a/pkg/clients/playbookdispatcher/client.go
+++ b/pkg/clients/playbookdispatcher/client.go
@@ -77,8 +77,13 @@ func (c *Client) ExecuteDispatcher(payload DispatcherPayload) ([]Response, error
 	client := clients.ConfigureClientWithTLS(&http.Client{})
 	res, err := client.Do(req)
 	if err != nil {
+		code := 500
+		if res != nil {
+			code = res.StatusCode
+		}
+
 		c.log.WithFields(log.Fields{
-			"statusCode": res.StatusCode,
+			"statusCode": code,
 			"error":      err,
 		}).Error("PlaybookDispatcher ExecuteDispatcher Request Error")
 		return nil, err

--- a/pkg/clients/playbookdispatcher/client.go
+++ b/pkg/clients/playbookdispatcher/client.go
@@ -77,14 +77,8 @@ func (c *Client) ExecuteDispatcher(payload DispatcherPayload) ([]Response, error
 	client := clients.ConfigureClientWithTLS(&http.Client{})
 	res, err := client.Do(req)
 	if err != nil {
-		code := 500
-		if res != nil {
-			code = res.StatusCode
-		}
-
 		c.log.WithFields(log.Fields{
-			"statusCode": code,
-			"error":      err,
+			"error": err,
 		}).Error("PlaybookDispatcher ExecuteDispatcher Request Error")
 		return nil, err
 	}


### PR DESCRIPTION
# Description
Include response code if no response foung

FIXES:  THEEDGE-3209

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
