### PR TITLE
content-sources: update migration repos script to configure unleash client

### DIFF
--- a/cmd/migraterepos/main.go
+++ b/cmd/migraterepos/main.go
@@ -1,16 +1,42 @@
 package main
 
 import (
+	"fmt"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/redhatinsights/edge-api/cmd/migraterepos/repairrepos"
-	feature "github.com/redhatinsights/edge-api/unleash/features"
-
 	"github.com/redhatinsights/edge-api/config"
 	"github.com/redhatinsights/edge-api/logger"
 	"github.com/redhatinsights/edge-api/pkg/db"
+	edgeunleash "github.com/redhatinsights/edge-api/unleash"
+	feature "github.com/redhatinsights/edge-api/unleash/features"
+
+	"github.com/Unleash/unleash-client-go/v3"
 	log "github.com/sirupsen/logrus"
 )
+
+func initializeUnleash() {
+	cfg := config.Get()
+	if cfg.FeatureFlagsURL != "" {
+		err := unleash.Initialize(
+			unleash.WithListener(&edgeunleash.EdgeListener{}),
+			unleash.WithAppName("edge-api"),
+			unleash.WithUrl(cfg.UnleashURL),
+			unleash.WithRefreshInterval(5*time.Second),
+			unleash.WithMetricsInterval(5*time.Second),
+			unleash.WithCustomHeaders(http.Header{"Authorization": {fmt.Sprintf("Bearer %s", cfg.UnleashSecretName)}}),
+		)
+		if err != nil {
+			log.WithField("Error", err).Error("Unleash client failed to initialize")
+		} else {
+			log.WithField("FeatureFlagURL", cfg.UnleashURL).Info("Unleash client initialized successfully")
+		}
+	} else {
+		log.WithField("FeatureFlagURL", cfg.UnleashURL).Warning("FeatureFlag service initialization was skipped.")
+	}
+}
 
 func initConfiguration() {
 	config.Init()
@@ -18,6 +44,7 @@ func initConfiguration() {
 	cfg := config.Get()
 	config.LogConfigAtStartup(cfg)
 	db.InitDB()
+	initializeUnleash()
 }
 
 func handleExist(err error) {


### PR DESCRIPTION
# Description
The unleash initialization was missing from migration repos to content-sources, that's why the migration feature appear always as disabled.


## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
