### PR TITLE
content-sources: update migration repos script add repair images_repos.

### DIFF
--- a/cmd/migraterepos/main.go
+++ b/cmd/migraterepos/main.go
@@ -47,7 +47,7 @@ func initConfiguration() {
 	initializeUnleash()
 }
 
-func handleExist(err error) {
+func cleanupAndExit(err error) {
 	// flush logger before app exit
 	logger.FlushLogger()
 	if err != nil {
@@ -65,17 +65,22 @@ func main() {
 	if feature.MigrateCustomRepositories.IsEnabled() {
 		log.Info("custom repositories migration started")
 		if _, err := repairrepos.RepairUrls(); err != nil {
-			handleExist(err)
+			cleanupAndExit(err)
+			return
+		}
+
+		if err := repairrepos.RepairDuplicateImagesReposURLS(); err != nil {
+			cleanupAndExit(err)
 			return
 		}
 
 		if err := repairrepos.RepairDuplicates(); err != nil {
-			handleExist(err)
+			cleanupAndExit(err)
 			return
 		}
 	} else {
 		log.Info("custom repositories migration feature is disabled")
 	}
 
-	handleExist(nil)
+	cleanupAndExit(nil)
 }


### PR DESCRIPTION
# Description
Repair images_repos images with repos that has duplicate urls, left only one repo with that url and remove the others.

FIXES: THEEDGE-3262

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

