### PR TITLE
content-sources: migrate custom repositories to content-sources.

### DIFF
--- a/cmd/migraterepos/main.go
+++ b/cmd/migraterepos/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/redhatinsights/edge-api/cmd/migraterepos/migraterepos"
 	"github.com/redhatinsights/edge-api/cmd/migraterepos/repairrepos"
 	"github.com/redhatinsights/edge-api/config"
 	"github.com/redhatinsights/edge-api/logger"
@@ -75,6 +76,11 @@ func main() {
 		}
 
 		if err := repairrepos.RepairDuplicates(); err != nil {
+			cleanupAndExit(err)
+			return
+		}
+
+		if err := migraterepos.MigrateAllCustomRepositories(); err != nil {
 			cleanupAndExit(err)
 			return
 		}

--- a/cmd/migraterepos/migraterepos/migraterepos.go
+++ b/cmd/migraterepos/migraterepos/migraterepos.go
@@ -1,0 +1,193 @@
+package migraterepos
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/redhatinsights/edge-api/cmd/migraterepos/repairrepos"
+	"github.com/redhatinsights/edge-api/pkg/clients/repositories"
+	"github.com/redhatinsights/edge-api/pkg/db"
+	"github.com/redhatinsights/edge-api/pkg/models"
+	"github.com/redhatinsights/edge-api/pkg/routes/common"
+	feature "github.com/redhatinsights/edge-api/unleash/features"
+
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+	"github.com/redhatinsights/platform-go-middlewares/request_id"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+)
+
+func newOrgContentSourcesClient(orgID string) (repositories.ClientInterface, error) {
+	// create a new content-sources client and set organization identity in the initialization context
+	ident := identity.XRHID{Identity: identity.Identity{OrgID: orgID, Type: "User", Internal: identity.Internal{OrgID: orgID}}}
+	jsonIdent, err := json.Marshal(&ident)
+	if err != nil {
+		return nil, err
+	}
+	base64Identity := base64.StdEncoding.EncodeToString(jsonIdent)
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, request_id.RequestIDKey, uuid.NewString())
+	ctx = common.SetOriginalIdentity(ctx, base64Identity)
+
+	client := repositories.InitClient(ctx, log.NewEntry(log.StandardLogger()))
+	return client, nil
+}
+
+func createContentSourcesRepository(client repositories.ClientInterface, emRepo models.ThirdPartyRepo) (*repositories.Repository, error) {
+	logger := log.WithFields(log.Fields{"content": "content-sources-repo-migration-create", "org_id": emRepo.OrgID, "url": emRepo.URL})
+	repoName := emRepo.Name
+
+	logger.Info("getting content-source repository by name")
+	if _, err := client.GetRepositoryByName(repoName); err != nil {
+		if err != repositories.ErrRepositoryNotFound {
+			logger.WithField("error", err.Error()).Error("error occurred while getting content-sources repository by name")
+			return nil, err
+		}
+		// content-sources repository with repoName does not exist, will keep using the repoName
+	} else {
+		// content-sources repository with repoName does exist, generate a new repoName using an uuid
+		repoName = fmt.Sprintf("%s_%s", repoName, uuid.NewString())
+	}
+
+	logger.WithField("name", repoName).Info("creating content-source repository")
+	return client.CreateRepository(repositories.Repository{
+		Name: repoName,
+		URL:  emRepo.URL,
+	})
+}
+
+func migrateCustomRepository(client repositories.ClientInterface, emRepo models.ThirdPartyRepo) error {
+	logger := log.WithFields(log.Fields{"context": "content-sources-repo-migration", "org_id": emRepo.OrgID, "name": emRepo.Name, "url": emRepo.URL})
+	logger.Info("custom repository migration started")
+	// check if content-sources repo already exist with repo url
+	var csRepo *repositories.Repository
+	repo, err := client.GetRepositoryByURL(emRepo.URL)
+	if err != nil {
+		if err != repositories.ErrRepositoryNotFound {
+			logger.WithField("error", err.Error()).Error("error occurred while getting repository by url")
+			return err
+		}
+	} else {
+		csRepo = repo
+	}
+	if csRepo == nil {
+		// The content-sources with url does not exist, create a new content-sources repository
+		repo, err := createContentSourcesRepository(client, emRepo)
+		if err != nil {
+			logger.WithField("error", err.Error()).Error("error occurred while creating content-sources repository")
+			return err
+		}
+		csRepo = repo
+	}
+
+	// update local repo with main content-sources repo data
+	emRepo.UUID = csRepo.UUID.String()
+	emRepo.GpgKey = csRepo.GpgKey
+	emRepo.DistributionArch = csRepo.DistributionArch
+	emRepo.PackageCount = csRepo.PackageCount
+	if err := db.DB.Save(&emRepo).Error; err != nil {
+		logger.WithField("error", err.Error()).Error("error occurred while saving custom repository with updated data from content-sources")
+		return err
+	}
+	logger.WithField("name", emRepo.Name).Info("custom repository migration successfully")
+	return nil
+}
+
+func migrateOrgCustomRepositories(orgID string) error {
+	if orgID == "" {
+		return nil
+	}
+	logger := log.WithFields(log.Fields{"context": "content-sources-org-migration", "org_id": orgID})
+
+	logger.Info("organization content-source repositories migration started")
+
+	client, err := newOrgContentSourcesClient(orgID)
+	if err != nil {
+		logger.WithField("error", err.Error()).Error("error occurred while getting organization content-sources client")
+		return err
+	}
+
+	reposCount := 0
+	page := 0
+	for page < repairrepos.DefaultMaxDataPageNumber {
+		var repos []models.ThirdPartyRepo
+		if err := db.Org(orgID, "").Debug().Where("uuid IS NULL OR UUID = ''").
+			Order("id ASC").
+			Limit(repairrepos.DefaultDataLimit).
+			Find(&repos).Error; err != nil {
+			logger.WithField("error", err.Error()).Error("error occurred while collecting organization custom repositories to migrate")
+			return err
+		}
+
+		if len(repos) == 0 {
+			break
+		}
+		for _, repo := range repos {
+			if err := migrateCustomRepository(client, repo); err != nil {
+				logger.WithField("error", err.Error()).Error("error occurred while migrating organization custom repository")
+				return err
+			}
+		}
+
+		reposCount += len(repos)
+		page++
+	}
+
+	logger.WithField("repos_count", reposCount).Info("organization content-source repositories migration finished")
+
+	return nil
+}
+
+// MigrateAllCustomRepositories migrate all custom repositories to content-sources repositories
+func MigrateAllCustomRepositories() error {
+
+	logger := log.WithField("context", "context-sources-migration")
+	if !feature.MigrateCustomRepositories.IsEnabled() {
+		logger.Info("custom repositories migration feature is disabled, migration is not available")
+		return repairrepos.ErrMigrationNotAvailable
+	}
+
+	// collect all org ids with custom repositories not yet migrated
+	// a custom repository is considered migrated if it's uuid is not null and not empty
+	type OrgMigrationRepos struct {
+		OrgID string
+		Count int
+	}
+
+	page := 0
+	orgsRepos := 0
+	reposCount := 0
+	for page < repairrepos.DefaultMaxDataPageNumber {
+		var orgMigrationRepos []OrgMigrationRepos
+		if err := db.DB.Debug().Model(&models.ThirdPartyRepo{}).
+			Select("distinct(org_id), count(*) as count").
+			Where("uuid IS NULL OR UUID = ''").
+			Group("org_id").
+			Order("org_id ASC").
+			Limit(repairrepos.DefaultDataLimit).
+			Scan(&orgMigrationRepos).Error; err != nil {
+			logger.WithField("error", err.Error()).Error("error occurred while collecting organizations for custom repositories migration")
+			return err
+		}
+		if len(orgMigrationRepos) == 0 {
+			break
+		}
+		for _, orgToMigrate := range orgMigrationRepos {
+			logger.WithFields(log.Fields{"org_id": orgToMigrate.OrgID, "count": orgToMigrate.Count}).Info("starting migration of organization custom repositories")
+			err := migrateOrgCustomRepositories(orgToMigrate.OrgID)
+			if err != nil {
+				logger.WithFields(log.Fields{"org_id": orgToMigrate.OrgID, "count": orgToMigrate.Count, "error": err.Error()}).Error("error occurred while migrating organization custom repositories")
+				return err
+			}
+			reposCount += orgToMigrate.Count
+		}
+		orgsRepos += len(orgMigrationRepos)
+		page++
+	}
+
+	logger.WithFields(log.Fields{"orgs_count": orgsRepos, "repos_count": reposCount}).Info("migration of organizations custom repositories finished")
+	return nil
+}

--- a/cmd/migraterepos/migraterepos/migraterepos_suite_test.go
+++ b/cmd/migraterepos/migraterepos/migraterepos_suite_test.go
@@ -1,0 +1,40 @@
+package migraterepos_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/db"
+	"github.com/redhatinsights/edge-api/pkg/models"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMigrate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	dbName := setupTestDB()
+	defer tearDownTestDB(dbName)
+	RunSpecs(t, "Migrate custom repositories Suite")
+}
+
+func setupTestDB() string {
+	config.Init()
+	dbName := fmt.Sprintf("%d-migraterepos.db", time.Now().UnixNano())
+	config.Get().Database.Name = dbName
+	db.InitDB()
+	if err := db.DB.AutoMigrate(
+		&models.Image{},
+		&models.ThirdPartyRepo{},
+	); err != nil {
+		panic(err)
+	}
+	return dbName
+}
+
+func tearDownTestDB(dbName string) {
+	_ = os.Remove(dbName)
+}

--- a/cmd/migraterepos/migraterepos/migraterepos_test.go
+++ b/cmd/migraterepos/migraterepos/migraterepos_test.go
@@ -1,0 +1,388 @@
+package migraterepos_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+
+	"github.com/redhatinsights/edge-api/cmd/migraterepos/migraterepos"
+	"github.com/redhatinsights/edge-api/cmd/migraterepos/repairrepos"
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/clients/repositories"
+	"github.com/redhatinsights/edge-api/pkg/db"
+	"github.com/redhatinsights/edge-api/pkg/dependencies"
+	"github.com/redhatinsights/edge-api/pkg/models"
+	"github.com/redhatinsights/edge-api/pkg/routes/common"
+	feature "github.com/redhatinsights/edge-api/unleash/features"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Migrate custom repositories", func() {
+
+	Context("MigrateAllCustomRepositories", func() {
+		// in this scenario all the repos urls does not exist in remote content-sources repositories
+		var initialDefaultLimit int
+		var initialConfAuth bool
+		var orgID1 string
+		var orgID2 string
+
+		var repos []models.ThirdPartyRepo
+
+		BeforeEach(func() {
+			initialDefaultLimit = repairrepos.DefaultDataLimit
+			repairrepos.DefaultDataLimit = 1
+			initialConfAuth = config.Get().Auth
+			// force auth, this should make the client to put the identity in the request headers
+			config.Get().Auth = true
+
+			// enable migration feature
+			err := os.Setenv(feature.MigrateCustomRepositories.EnvVar, "true")
+			Expect(err).ToNot(HaveOccurred())
+
+			// use org prefixes to preserve sorting
+			orgID1 = "orgID1" + faker.UUIDHyphenated()
+			orgID2 = "orgID2" + faker.UUIDHyphenated()
+			repos = []models.ThirdPartyRepo{
+				{OrgID: orgID1, Name: faker.Name(), URL: faker.URL()},
+				{OrgID: orgID1, Name: faker.Name(), URL: faker.URL()},
+				{OrgID: orgID2, Name: faker.Name(), URL: faker.URL()},
+				{OrgID: orgID2, Name: faker.Name(), URL: faker.URL()},
+			}
+			err = db.DB.Create(&repos).Error
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			config.Get().Auth = initialConfAuth
+			err := os.Unsetenv(feature.MigrateCustomRepositories.EnvVar)
+			Expect(err).ToNot(HaveOccurred())
+			repairrepos.DefaultDataLimit = initialDefaultLimit
+		})
+
+		It("migrate all repos successfully", func() {
+			contentSourcesGetCallIndex := 0
+			contentSourcesPostCallIndex := 0
+			ts := httptest.NewServer(dependencies.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				rhIndent, err := common.GetIdentityInstanceFromContext(r.Context())
+				Expect(err).ToNot(HaveOccurred())
+				w.Header().Set("Content-Type", "application/json")
+				var repo models.ThirdPartyRepo
+				switch r.Method {
+				case http.MethodGet:
+					// for any GET request return an empty response , that should be interpreted as
+					// "repo with url" or "repo with name" does not exist
+					// this should be called twice the number of repos
+					// one time for each repo with GET repo by url
+					// one time for each repo with GET repo by name
+					repoIndex := int32(contentSourcesGetCallIndex / 2)
+					repo = repos[repoIndex]
+					urlQueryValues := r.URL.Query()
+
+					if (contentSourcesGetCallIndex+1)%2 == 1 {
+						// this is the repo first GET call, the url query one
+						url := urlQueryValues.Get("url")
+						Expect(url).To(Equal(repo.URL))
+
+					} else {
+						// this is the repo second GET call, the name query one
+						name := urlQueryValues.Get("name")
+						Expect(name).To(Equal(repo.Name))
+					}
+					w.WriteHeader(http.StatusOK)
+					err := json.NewEncoder(w).Encode(&repositories.ListRepositoriesResponse{})
+					Expect(err).ToNot(HaveOccurred())
+					contentSourcesGetCallIndex++
+				case http.MethodPost:
+					// this should be one time call for each repo
+					w.WriteHeader(http.StatusCreated)
+					repo = repos[contentSourcesPostCallIndex]
+					var reqRepository repositories.Repository
+					body, err := io.ReadAll(r.Body)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(body).ToNot(BeNil())
+					err = json.Unmarshal(body, &reqRepository)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(reqRepository.Name).To(Equal(repo.Name))
+					Expect(reqRepository.URL).To(Equal(repo.URL))
+
+					// ensure the identity orgID is the same as the currently processed repo
+					Expect(repo.OrgID).To(Equal(rhIndent.Identity.OrgID))
+
+					// set a new uuid
+					reqRepository.UUID = uuid.New()
+					// set orgID from identity (note the org is not sent in the post body request payload)
+					reqRepository.OrgID = rhIndent.Identity.OrgID
+					// return the updated content-sources repo
+					err = json.NewEncoder(w).Encode(&reqRepository)
+					Expect(err).ToNot(HaveOccurred())
+					contentSourcesPostCallIndex++
+				default:
+					w.WriteHeader(http.StatusBadRequest)
+				}
+			})))
+			defer ts.Close()
+			config.Get().ContentSourcesURL = ts.URL
+
+			err := migraterepos.MigrateAllCustomRepositories()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(contentSourcesGetCallIndex).To(Equal(2 * len(repos)))
+			Expect(contentSourcesPostCallIndex).To(Equal(len(repos)))
+
+			var dbRepos []models.ThirdPartyRepo
+			err = db.DB.Where("org_id IN (?)", []string{orgID1, orgID2}).Order("org_id ASC, id ASC").Find(&dbRepos).Error
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(len(dbRepos)).To(Equal(len(repos)))
+			for ind, repo := range dbRepos {
+				initialRepo := repos[ind]
+				Expect(repo.Name).To(Equal(initialRepo.Name))
+				Expect(repo.OrgID).To(Equal(initialRepo.OrgID))
+				Expect(repo.URL).To(Equal(initialRepo.URL))
+				// the initial uuid was empty
+				Expect(initialRepo.UUID).To(BeEmpty())
+				// after repo migration to content-sources repository an uuid is assigned to local db repo
+				Expect(repo.UUID).ToNot(BeEmpty())
+				_, err := uuid.Parse(repo.UUID)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	})
+
+	Context("MigrateAllCustomRepositories with existing content-sources repo url", func() {
+		// in this scenario a repo with url exists in content sources repository
+		var initialDefaultLimit int
+		var orgID string
+		var url string
+
+		var repo models.ThirdPartyRepo
+		var contentSourcesRepo repositories.Repository
+
+		BeforeEach(func() {
+			initialDefaultLimit = repairrepos.DefaultDataLimit
+			repairrepos.DefaultDataLimit = 1
+
+			// enable migration feature
+			err := os.Setenv(feature.MigrateCustomRepositories.EnvVar, "true")
+			Expect(err).ToNot(HaveOccurred())
+
+			// use org prefixes to preserve sorting
+			orgID = faker.UUIDHyphenated()
+			url = faker.URL()
+			repo = models.ThirdPartyRepo{OrgID: orgID, Name: faker.Name(), URL: url}
+			err = db.DB.Create(&repo).Error
+			Expect(err).ToNot(HaveOccurred())
+			contentSourcesRepo = repositories.Repository{
+				Name:             faker.Name(),
+				URL:              url,
+				OrgID:            orgID,
+				UUID:             uuid.New(),
+				GpgKey:           faker.UUIDHyphenated(),
+				DistributionArch: "x86_64",
+				PackageCount:     12,
+			}
+		})
+
+		AfterEach(func() {
+			err := os.Unsetenv(feature.MigrateCustomRepositories.EnvVar)
+			Expect(err).ToNot(HaveOccurred())
+			repairrepos.DefaultDataLimit = initialDefaultLimit
+		})
+
+		It("repository migrated successfully", func() {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.Method {
+				case http.MethodGet:
+					urlQueryValues := r.URL.Query()
+					// in this scenario we send only one request to content-sources, the url one
+					url := urlQueryValues.Get("url")
+					Expect(url).To(Equal(repo.URL))
+
+					w.WriteHeader(http.StatusOK)
+					// sent the contentSourcesRepo as the requested existing content-sources repo
+					err := json.NewEncoder(w).Encode(&repositories.ListRepositoriesResponse{Data: []repositories.Repository{contentSourcesRepo}})
+					Expect(err).ToNot(HaveOccurred())
+				default:
+					w.WriteHeader(http.StatusBadRequest)
+				}
+			}))
+			defer ts.Close()
+			config.Get().ContentSourcesURL = ts.URL
+
+			err := migraterepos.MigrateAllCustomRepositories()
+			Expect(err).ToNot(HaveOccurred())
+
+			// ensure local repo has been updated with remote content-sources repository uuid, and other data
+			var dbRepo models.ThirdPartyRepo
+			err = db.DB.First(&dbRepo, repo.ID).Error
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(dbRepo.UUID).To(Equal(contentSourcesRepo.UUID.String()))
+			Expect(dbRepo.GpgKey).To(Equal(contentSourcesRepo.GpgKey))
+			Expect(dbRepo.DistributionArch).To(Equal(contentSourcesRepo.DistributionArch))
+			Expect(dbRepo.PackageCount).To(Equal(contentSourcesRepo.PackageCount))
+		})
+	})
+
+	Context("MigrateAllCustomRepositories with existing content-sources repo name", func() {
+		// in this scenario a repo with same name exists in content sources repository
+		// a new name should be generated with original repo name as prefix
+		var initialDefaultLimit int
+		var orgID string
+		var repoName string
+		var newUUID uuid.UUID
+
+		var repo models.ThirdPartyRepo
+
+		BeforeEach(func() {
+			initialDefaultLimit = repairrepos.DefaultDataLimit
+			repairrepos.DefaultDataLimit = 1
+			newUUID = uuid.New()
+
+			// enable migration feature
+			err := os.Setenv(feature.MigrateCustomRepositories.EnvVar, "true")
+			Expect(err).ToNot(HaveOccurred())
+
+			// use org prefixes to preserve sorting
+			orgID = faker.UUIDHyphenated()
+			repoName = faker.Name()
+			repo = models.ThirdPartyRepo{OrgID: orgID, Name: repoName, URL: faker.URL()}
+			err = db.DB.Create(&repo).Error
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			err := os.Unsetenv(feature.MigrateCustomRepositories.EnvVar)
+			Expect(err).ToNot(HaveOccurred())
+			repairrepos.DefaultDataLimit = initialDefaultLimit
+		})
+
+		It("repository migrated successfully", func() {
+			contentSourcesGetCallIndex := 0
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.Method {
+				case http.MethodGet:
+					switch contentSourcesGetCallIndex {
+					case 0:
+						// for url call should return an empty list as content-source repo with url has not to exist
+						urlQueryValues := r.URL.Query()
+						url := urlQueryValues.Get("url")
+						Expect(url).To(Equal(repo.URL))
+
+						w.WriteHeader(http.StatusOK)
+						err := json.NewEncoder(w).Encode(&repositories.ListRepositoriesResponse{Data: []repositories.Repository{}})
+						Expect(err).ToNot(HaveOccurred())
+					case 1:
+						// for name call should return an arbitrary repo to show that content-source repo with name exists
+						urlQueryValues := r.URL.Query()
+						name := urlQueryValues.Get("name")
+						Expect(name).To(Equal(repoName))
+
+						w.WriteHeader(http.StatusOK)
+						err := json.NewEncoder(w).Encode(&repositories.ListRepositoriesResponse{
+							Data: []repositories.Repository{{
+								Name:  repoName,
+								URL:   faker.URL(),
+								OrgID: orgID,
+							}},
+						})
+						Expect(err).ToNot(HaveOccurred())
+					default:
+						w.WriteHeader(http.StatusBadRequest)
+					}
+					contentSourcesGetCallIndex++
+				case http.MethodPost:
+					w.WriteHeader(http.StatusCreated)
+					var reqRepository repositories.Repository
+					body, err := io.ReadAll(r.Body)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(body).ToNot(BeNil())
+					err = json.Unmarshal(body, &reqRepository)
+					Expect(err).ToNot(HaveOccurred())
+					// expect that the repo name looks like repoName_uuid
+					Expect(reqRepository.Name).ToNot(BeEmpty())
+					repoNameSlice := strings.Split(reqRepository.Name, "_")
+					Expect(len(repoNameSlice)).To(Equal(2))
+					Expect(repoNameSlice[0]).To(Equal(repoName))
+					_, err = uuid.Parse(repoNameSlice[1])
+					Expect(err).ToNot(HaveOccurred())
+					// set a uuid
+					reqRepository.UUID = newUUID
+					err = json.NewEncoder(w).Encode(&reqRepository)
+					Expect(err).ToNot(HaveOccurred())
+				default:
+					w.WriteHeader(http.StatusBadRequest)
+				}
+			}))
+			defer ts.Close()
+			config.Get().ContentSourcesURL = ts.URL
+
+			err := migraterepos.MigrateAllCustomRepositories()
+			Expect(err).ToNot(HaveOccurred())
+
+			// ensure local repo has been updated with remote content-sources repository uuid
+			var dbRepo models.ThirdPartyRepo
+			err = db.DB.First(&dbRepo, repo.ID).Error
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dbRepo.UUID).To(Equal(newUUID.String()))
+		})
+	})
+
+	Context("MigrateAllCustomRepositories: return error on client failure", func() {
+		var orgID string
+		var repo models.ThirdPartyRepo
+
+		BeforeEach(func() {
+			// enable migration feature
+			err := os.Setenv(feature.MigrateCustomRepositories.EnvVar, "true")
+			Expect(err).ToNot(HaveOccurred())
+			orgID = faker.UUIDHyphenated()
+			repo = models.ThirdPartyRepo{OrgID: orgID, Name: faker.Name(), URL: faker.URL()}
+			err = db.DB.Create(&repo).Error
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			err := os.Unsetenv(feature.MigrateCustomRepositories.EnvVar)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return error when client fail", func() {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+			}))
+			defer ts.Close()
+			config.Get().ContentSourcesURL = ts.URL
+
+			err := migraterepos.MigrateAllCustomRepositories()
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(repositories.ErrRepositoryRequestResponse))
+		})
+	})
+
+	Context("migration feature disabled", func() {
+
+		BeforeEach(func() {
+			// ensure migration feature is disabled, feature should be disabled by default
+			err := os.Unsetenv(feature.MigrateCustomRepositories.EnvVar)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("repair urls should not be available", func() {
+			err := migraterepos.MigrateAllCustomRepositories()
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(repairrepos.ErrMigrationNotAvailable))
+		})
+	})
+})


### PR DESCRIPTION
# Description
Collect all orgs custom repositories without uuid and create the same at content-sources and then update the local one by the corresponding uuid and other data. 

- In case the repo url already exist in content-sources , update the local with corresponding remote one data (uuid ...).
-  In Case the repo name already exist, generate a new name to submit like repoName_UUID.

FIXES: THEEDGE-3091

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
