### PR TITLE
content-sources: custom repositories migration - add migrated to conflicting name.

### DIFF
--- a/cmd/migraterepos/migraterepos/migraterepos.go
+++ b/cmd/migraterepos/migraterepos/migraterepos.go
@@ -49,7 +49,7 @@ func createContentSourcesRepository(client repositories.ClientInterface, emRepo 
 		// content-sources repository with repoName does not exist, will keep using the repoName
 	} else {
 		// content-sources repository with repoName does exist, generate a new repoName using an uuid
-		repoName = fmt.Sprintf("%s_%s", repoName, uuid.NewString())
+		repoName = fmt.Sprintf("%s_migrated_%s", repoName, uuid.NewString())
 	}
 
 	logger.WithField("name", repoName).Info("creating content-source repository")

--- a/cmd/migraterepos/migraterepos/migraterepos_test.go
+++ b/cmd/migraterepos/migraterepos/migraterepos_test.go
@@ -312,9 +312,10 @@ var _ = Describe("Migrate custom repositories", func() {
 					// expect that the repo name looks like repoName_uuid
 					Expect(reqRepository.Name).ToNot(BeEmpty())
 					repoNameSlice := strings.Split(reqRepository.Name, "_")
-					Expect(len(repoNameSlice)).To(Equal(2))
+					Expect(len(repoNameSlice)).To(Equal(3))
 					Expect(repoNameSlice[0]).To(Equal(repoName))
-					_, err = uuid.Parse(repoNameSlice[1])
+					Expect(repoNameSlice[1]).To(Equal("migrated"))
+					_, err = uuid.Parse(repoNameSlice[2])
 					Expect(err).ToNot(HaveOccurred())
 					// set a uuid
 					reqRepository.UUID = newUUID


### PR DESCRIPTION
# Description
As per discussions , add  "migrated" for the conflicting repo name, thanks @elyezer for the proposition.

FIXES: THEEDGE-3091

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
