### PR TITLE
devices_test: fixes limit when calling deviceService.GetDevicesView.

### DIFF
--- a/pkg/services/devices_test.go
+++ b/pkg/services/devices_test.go
@@ -1121,7 +1121,7 @@ var _ = Describe("DfseviceService", func() {
 				}
 
 				dbFilter := db.DB.Model(models.Device{}).Where("devices.image_id = ?", imageV1.ID).Order("devices.created_at ASC")
-				devices, err := deviceService.GetDevicesView(0, 0, dbFilter)
+				devices, err := deviceService.GetDevicesView(100, 0, dbFilter)
 				wg.Wait()
 				wg2.Wait()
 				Expect(err).To(BeNil())
@@ -1217,7 +1217,7 @@ var _ = Describe("DfseviceService", func() {
 				}
 
 				dbFilter := db.DB.Model(models.Device{}).Where("devices.image_id = ?", imageV1.ID).Order("devices.created_at ASC")
-				devices, err := deviceService.GetDevicesView(0, 0, dbFilter)
+				devices, err := deviceService.GetDevicesView(100, 0, dbFilter)
 				wg.Wait()
 				wg2.Wait()
 				Expect(err).To(BeNil())
@@ -1256,7 +1256,7 @@ var _ = Describe("DfseviceService", func() {
 					Inventory: mockInventoryClient,
 				}
 
-				devices, err := deviceService.GetDevicesView(0, 0, nil)
+				devices, err := deviceService.GetDevicesView(100, 0, nil)
 				wg.Wait()
 				wg2.Wait()
 				Expect(err).To(BeNil())
@@ -1302,7 +1302,7 @@ var _ = Describe("DfseviceService", func() {
 					Inventory: mockInventoryClient,
 				}
 
-				devices, err := deviceService.GetDevicesView(0, 0, nil)
+				devices, err := deviceService.GetDevicesView(100, 0, nil)
 				wg.Wait()
 				wg2.Wait()
 				Expect(err).To(BeNil())


### PR DESCRIPTION
# Description
New versions of gorm seems passing limit 0 to raw sql, that make the result to be always an empty slice.

This should Fixes dependency PR https://github.com/RedHatInsights/edge-api/pull/2059  testing to pass

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
