### PR TITLE
increase scalability of updates by eliminating redundant repo process

### DIFF
--- a/pkg/services/repobuilder.go
+++ b/pkg/services/repobuilder.go
@@ -64,7 +64,6 @@ func (rb *RepoBuilder) BuildUpdateRepo(id uint) (*models.UpdateTransaction, erro
 		return nil, err
 	}
 
-	rb.log.Info("Starts building update repo...")
 	if update.Commit == nil {
 		rb.log.Error("nil pointer to models.UpdateTransaction.Commit provided")
 		return nil, errors.New("invalid models.UpdateTransaction.Commit Provided: nil pointer")
@@ -76,94 +75,110 @@ func (rb *RepoBuilder) BuildUpdateRepo(id uint) (*models.UpdateTransaction, erro
 		rb.log.Error("Repo is unavailable")
 		return nil, errors.New("repo unavailable")
 	}
-	cfg := config.Get()
-	path := filepath.Clean(filepath.Join(cfg.RepoTempPath, "upd/", strconv.FormatUint(uint64(update.ID), 10)))
-	rb.log.WithField("path", path).Debug("Update path will be created")
-	err := os.MkdirAll(path, os.FileMode(0755))
-	if err != nil {
-		return nil, err
-	}
-	err = os.Chdir(path)
-	if err != nil {
-		return nil, err
-	}
 
-	tarFileName, err := rb.DownloadVersionRepo(update.Commit, path)
-	if err != nil {
-		rb.log.WithField("error", err.Error()).Error("Error downloading tar")
-		return nil, fmt.Errorf("error download repo repo :: %s", err.Error())
-	}
-	err = rb.ExtractVersionRepo(update.Commit, tarFileName, path)
-	if err != nil {
-		rb.log.WithField("error", err.Error()).Error("Error extracting tar")
-		return nil, fmt.Errorf("error extracting repo :: %s", err.Error())
-	}
+	// Skipping this process if the feature flag is enabled.
+	// Without static-deltas, this just downloads a commit repo and re-uploads as an update repo.
+	// This will retain the original commit repo URL as the update URL.
+	// (e.g., for a 2GB commit, this saves 4GB+ in traffic and local disk space on the pod)
+	if !feature.SkipUpdateRepo.IsEnabled() {
+		rb.log.Info("Starts building update repo...")
 
-	if feature.BuildUpdateRepoWithOldCommits.IsEnabled() && len(update.OldCommits) > 0 {
-		rb.log.WithFields(log.Fields{
-			"updateID":   update.ID,
-			"OldCommits": len(update.OldCommits)}).
-			Info("Old commits found to this commit")
-		stagePath := filepath.Clean(filepath.Join(path, "staging"))
-		err = os.MkdirAll(stagePath, os.FileMode(0755))
+		cfg := config.Get()
+		path := filepath.Clean(filepath.Join(cfg.RepoTempPath, "upd/", strconv.FormatUint(uint64(update.ID), 10)))
+		rb.log.WithField("path", path).Debug("Update path will be created")
+		err := os.MkdirAll(path, os.FileMode(0755))
 		if err != nil {
-			rb.log.WithField("error", err.Error()).Error("Error making dir")
-			return nil, fmt.Errorf("error mkdir :: %s", err.Error())
+			return nil, err
 		}
-		err = os.Chdir(stagePath)
-		if err != nil {
-			rb.log.WithField("error", err.Error()).Error("Error changing dir")
-			return nil, fmt.Errorf("error chdir :: %s", err.Error())
-		}
-
-		// If there are any old commits, we need to download them all to be merged
-		// into the update commit repo
-		for _, commit := range update.OldCommits {
-			rb.log.WithFields(log.Fields{
-				"updateID":            update.ID,
-				"commit.OSTreeCommit": commit.OSTreeCommit,
-				"OldCommits":          commit.ID}).
-				Info("Calculate diff from previous commit")
-			commit := commit // this will prevent implicit memory aliasing in the loop
-			stageCommitPath := filepath.Clean(filepath.Join(stagePath, commit.OSTreeCommit))
-			tarFileName, err := rb.DownloadVersionRepo(&commit, stageCommitPath)
-			if err != nil {
-				rb.log.WithField("error", err.Error()).Error("Error downloading tar")
-				return nil, fmt.Errorf("error Upload repo repo :: %s", err.Error())
-			}
-			err = rb.ExtractVersionRepo(update.Commit, tarFileName, stageCommitPath)
-			if err != nil {
-				rb.log.WithField("error", err.Error()).Error("Error extracting repo")
-				return nil, err
-			}
-			// FIXME: hardcoding "repo" in here because that's how it comes from osbuild
-			err = rb.RepoPullLocalStaticDeltas(update.Commit, &commit, filepath.Clean(filepath.Join(path, "repo")),
-				filepath.Clean(filepath.Join(stageCommitPath, "repo")))
-			if err != nil {
-				rb.log.WithField("error", err.Error()).Error("Error pulling static deltas")
-				return nil, err
-			}
-		}
-
-		// Once all the old commits have been pulled into the update commit's repo
-		// and has static deltas generated, then we don't need the old commits
-		// anymore.
-		err = os.RemoveAll(stagePath)
+		err = os.Chdir(path)
 		if err != nil {
 			return nil, err
 		}
 
-	}
-	// NOTE: This relies on the file path being cfg.RepoTempPath/models.Repo.ID/
+		tarFileName, err := rb.DownloadVersionRepo(update.Commit, path)
+		if err != nil {
+			rb.log.WithField("error", err.Error()).Error("Error downloading tar")
+			return nil, fmt.Errorf("error download repo repo :: %s", err.Error())
+		}
+		err = rb.ExtractVersionRepo(update.Commit, tarFileName, path)
+		if err != nil {
+			rb.log.WithField("error", err.Error()).Error("Error extracting tar")
+			return nil, fmt.Errorf("error extracting repo :: %s", err.Error())
+		}
 
-	rb.log.Info("Upload repo")
-	repoURL, err := rb.FilesService.GetUploader().UploadRepo(filepath.Clean(filepath.Join(path, "repo")), strconv.FormatUint(uint64(update.ID), 10), "private")
-	rb.log.Info("Finished uploading repo")
-	if err != nil {
-		return nil, err
+		if feature.BuildUpdateRepoWithOldCommits.IsEnabled() && len(update.OldCommits) > 0 {
+			rb.log.WithFields(log.Fields{
+				"updateID":   update.ID,
+				"OldCommits": len(update.OldCommits)}).
+				Info("Old commits found to this commit")
+			stagePath := filepath.Clean(filepath.Join(path, "staging"))
+			err = os.MkdirAll(stagePath, os.FileMode(0755))
+			if err != nil {
+				rb.log.WithField("error", err.Error()).Error("Error making dir")
+				return nil, fmt.Errorf("error mkdir :: %s", err.Error())
+			}
+			err = os.Chdir(stagePath)
+			if err != nil {
+				rb.log.WithField("error", err.Error()).Error("Error changing dir")
+				return nil, fmt.Errorf("error chdir :: %s", err.Error())
+			}
+
+			// If there are any old commits, we need to download them all to be merged
+			// into the update commit repo
+			for _, commit := range update.OldCommits {
+				rb.log.WithFields(log.Fields{
+					"updateID":            update.ID,
+					"commit.OSTreeCommit": commit.OSTreeCommit,
+					"OldCommits":          commit.ID}).
+					Info("Calculate diff from previous commit")
+				commit := commit // this will prevent implicit memory aliasing in the loop
+				stageCommitPath := filepath.Clean(filepath.Join(stagePath, commit.OSTreeCommit))
+				tarFileName, err := rb.DownloadVersionRepo(&commit, stageCommitPath)
+				if err != nil {
+					rb.log.WithField("error", err.Error()).Error("Error downloading tar")
+					return nil, fmt.Errorf("error Upload repo repo :: %s", err.Error())
+				}
+				err = rb.ExtractVersionRepo(update.Commit, tarFileName, stageCommitPath)
+				if err != nil {
+					rb.log.WithField("error", err.Error()).Error("Error extracting repo")
+					return nil, err
+				}
+				// FIXME: hardcoding "repo" in here because that's how it comes from osbuild
+				err = rb.RepoPullLocalStaticDeltas(update.Commit, &commit, filepath.Clean(filepath.Join(path, "repo")),
+					filepath.Clean(filepath.Join(stageCommitPath, "repo")))
+				if err != nil {
+					rb.log.WithField("error", err.Error()).Error("Error pulling static deltas")
+					return nil, err
+				}
+			}
+
+			// Once all the old commits have been pulled into the update commit's repo
+			// and has static deltas generated, then we don't need the old commits
+			// anymore.
+			err = os.RemoveAll(stagePath)
+			if err != nil {
+				return nil, err
+			}
+
+		}
+		// NOTE: This relies on the file path being cfg.RepoTempPath/models.Repo.ID/
+
+		rb.log.Info("Upload repo")
+		repoURL, err := rb.FilesService.GetUploader().UploadRepo(filepath.Clean(filepath.Join(path, "repo")), strconv.FormatUint(uint64(update.ID), 10), "private")
+		rb.log.Info("Finished uploading repo")
+		if err != nil {
+			return nil, err
+		}
+
+		update.Repo.URL = repoURL
 	}
 
-	update.Repo.URL = repoURL
+	// just need to assign the existing commit repo URL to the update repo URL
+	if feature.SkipUpdateRepo.IsEnabled() {
+		update.Repo.URL = update.Commit.Repo.URL
+	}
+
+	rb.log.WithField("repo", update.Repo.URL).Info("Update repo URL")
 	update.Repo.Status = models.RepoStatusSuccess
 	if err := db.DB.Omit("Devices.*").Save(&update).Error; err != nil {
 		return nil, err

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -90,8 +90,11 @@ var ContentSources = &Flag{Name: "edge-management.content_sources", EnvVar: "FEA
 // MigrateCustomRepositories is a feature flag to use for code related to custom repositories migration to content-sources
 var MigrateCustomRepositories = &Flag{Name: "edge-management.migrate_custom_repositories", EnvVar: "FEATURE_MIGRATE_CUSTOM_REPOSITORIES"}
 
-// PostMigrateDeleteCustomRepositories is a feature flag to use for code related to custom repositories post migration to content-sources
+// PostMigrateDeleteCustomRepositories is a feature flag to use for deletion of repos after migration
 var PostMigrateDeleteCustomRepositories = &Flag{Name: "edge-management.post_migrate_delete_repos", EnvVar: "FEATURE_POST_MIGRATE_DELETE_REPOSITORIES"}
+
+// SkipUpdateRepo is a feature flag to skip the process of download and re-upload of update repositories
+var SkipUpdateRepo = &Flag{Name: "edgemanagement.skip_update_repo", EnvVar: "FEATURE_SKIP_UPDATE_REPO"}
 
 // (ADD FEATURE FLAGS ABOVE)
 // FEATURE FLAG CHECK CODE


### PR DESCRIPTION
* disable update repo process when feature flag is enabled
* bypassing redundant download, unpack, and upload of repo

# Description
This PR provides for the increase of scalability of updates by providing a feature-flag to disable a redundant download, unpack, upload process originally used for creating static deltas. Static deltas were disabled, so the process is now redundant. The repo of the commit will be used in place of creating a new repo for the purpose of updates.

FIXES: THEEDGE-3429

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
