### PR TITLE
images: FIXES orphan images raised when building images.

### DIFF
--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -252,7 +252,7 @@ func CreateImage(w http.ResponseWriter, r *http.Request) {
 	// FALL THROUGH IF NOT EDA
 
 	// TODO: this is going to go away with EDA
-	ctxServices.ImageService.ProcessImage(r.Context(), image)
+	ctxServices.ImageService.ProcessImage(r.Context(), image, true)
 
 	ctxServices.Log.WithFields(log.Fields{
 		"imageId": image.ID,
@@ -331,7 +331,7 @@ func CreateImageUpdate(w http.ResponseWriter, r *http.Request) {
 	// FALL THROUGH IF NOT EDA
 
 	// TODO: this is going to go away with EDA
-	ctxServices.ImageService.ProcessImage(r.Context(), image)
+	ctxServices.ImageService.ProcessImage(r.Context(), image, true)
 
 	w.WriteHeader(http.StatusOK)
 	respondWithJSONBody(w, ctxServices.Log, image)

--- a/pkg/routes/images_test.go
+++ b/pkg/routes/images_test.go
@@ -130,7 +130,7 @@ func TestCreate(t *testing.T) {
 	defer ctrl.Finish()
 	mockImageService := mock_services.NewMockImageServiceInterface(ctrl)
 	mockImageService.EXPECT().CreateImage(gomock.Any()).Return(nil)
-	mockImageService.EXPECT().ProcessImage(gomock.Any(), gomock.Any()).Return(nil)
+	mockImageService.EXPECT().ProcessImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	ctx = dependencies.ContextWithServices(ctx, &dependencies.EdgeAPIServices{
 		ImageService: mockImageService,
 		Log:          log.NewEntry(log.StandardLogger()),
@@ -1325,7 +1325,7 @@ var _ = Describe("Images Route Tests", func() {
 				// but as it's un-marshaled it's using an other pointer, most important assertions are those at the end of the test
 				mockImagesService.EXPECT().UpdateImage(gomock.Any(), &image).Return(nil)
 				// same here for context and updateImage
-				mockImagesService.EXPECT().ProcessImage(gomock.Any(), gomock.Any())
+				mockImagesService.EXPECT().ProcessImage(gomock.Any(), gomock.Any(), gomock.Any())
 				httpTestRecorder := httptest.NewRecorder()
 				router.ServeHTTP(httpTestRecorder, req)
 
@@ -1411,7 +1411,7 @@ var _ = Describe("Images Route Tests", func() {
 				// but as it's un-marshaled it's using another pointer.
 				mockImagesService.EXPECT().UpdateImage(gomock.AssignableToTypeOf(&updateImage), &image).Return(nil)
 				// same here for context and updateImage
-				mockImagesService.EXPECT().ProcessImage(gomock.Any(), gomock.AssignableToTypeOf(&updateImage))
+				mockImagesService.EXPECT().ProcessImage(gomock.Any(), gomock.AssignableToTypeOf(&updateImage), gomock.Any())
 
 				httpTestRecorder := httptest.NewRecorder()
 				router.ServeHTTP(httpTestRecorder, req)

--- a/pkg/services/image/event_image_requested.go
+++ b/pkg/services/image/event_image_requested.go
@@ -17,7 +17,7 @@ import (
 
 // imageService is the interface representation of ImageService to facilitate testing
 type imageService interface {
-	ProcessImage(context.Context, *models.Image) error
+	ProcessImage(ctx context.Context, img *models.Image, handleInterruptSignal bool) error
 	SetLog(log *log.Entry)
 }
 
@@ -73,7 +73,7 @@ func (ev EventImageRequestedBuildHandler) Consume(ctx context.Context, imgServic
 	imgService.SetLog(log)
 
 	// process the image
-	err = imgService.ProcessImage(ctx, img)
+	err = imgService.ProcessImage(ctx, img, true)
 	if err != nil {
 		log.Error("Error processing the image")
 	}

--- a/pkg/services/image/event_image_requested_test.go
+++ b/pkg/services/image/event_image_requested_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Event Image Build Requested Test", func() {
 					Expect(edgePayload).ToNot(BeNil())
 
 					mockImageService.EXPECT().SetLog(gomock.Any()).Return()
-					mockImageService.EXPECT().ProcessImage(gomock.Any(), gomock.Any()).Return(nil)
+					mockImageService.EXPECT().ProcessImage(gomock.Any(), gomock.Any(), true).Return(nil)
 					event := &EventImageRequestedBuildHandler{}
 					event.Data = *edgePayload
 					event.Consume(ctx, mockImageService)
@@ -93,7 +93,7 @@ var _ = Describe("Event Image Build Requested Test", func() {
 						}
 
 						mockImageService.EXPECT().SetLog(gomock.Any()).Return()
-						mockImageService.EXPECT().ProcessImage(gomock.Any(), gomock.Any()).Return(errors.New("this failed"))
+						mockImageService.EXPECT().ProcessImage(gomock.Any(), gomock.Any(), true).Return(errors.New("this failed"))
 						event := &EventImageRequestedBuildHandler{}
 						event.Data = *edgePayload
 						event.Consume(ctx, mockImageService)

--- a/pkg/services/image/event_image_update_requested.go
+++ b/pkg/services/image/event_image_update_requested.go
@@ -66,7 +66,7 @@ func (ev EventImageUpdateRequestedBuildHandler) Consume(ctx context.Context) {
 	// get the services from the context
 	edgeAPIServices := dependencies.ServicesFromContext(ctx)
 	imageService := edgeAPIServices.ImageService
-	err = imageService.ProcessImage(ctx, image)
+	err = imageService.ProcessImage(ctx, image, true)
 	if err != nil {
 		log.Error("Error processing the image")
 	}

--- a/pkg/services/image/event_image_update_requested_test.go
+++ b/pkg/services/image/event_image_update_requested_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Event Image Update Requested Test", func() {
 					}
 					Expect(edgePayload).ToNot(BeNil())
 
-					mockImageService.EXPECT().ProcessImage(gomock.Any(), gomock.Any()).Return(nil)
+					mockImageService.EXPECT().ProcessImage(gomock.Any(), gomock.Any(), true).Return(nil)
 					event := &EventImageUpdateRequestedBuildHandler{}
 
 					event.Data = *edgePayload
@@ -104,7 +104,7 @@ var _ = Describe("Event Image Update Requested Test", func() {
 							NewImage: *image,
 						}
 
-						mockImageService.EXPECT().ProcessImage(gomock.Any(), gomock.Any()).Return(errors.New("error processing the image"))
+						mockImageService.EXPECT().ProcessImage(gomock.Any(), gomock.Any(), true).Return(errors.New("error processing the image"))
 						event := &EventImageUpdateRequestedBuildHandler{}
 						event.Data = *edgePayload
 						event.Consume(ctx)

--- a/pkg/services/mock_services/images.go
+++ b/pkg/services/mock_services/images.go
@@ -291,17 +291,17 @@ func (mr *MockImageServiceInterfaceMockRecorder) GetUpdateInfo(image interface{}
 }
 
 // ProcessImage mocks base method.
-func (m *MockImageServiceInterface) ProcessImage(arg0 context.Context, arg1 *models.Image) error {
+func (m *MockImageServiceInterface) ProcessImage(ctx context.Context, img *models.Image, handleInterruptSignal bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessImage", arg0, arg1)
+	ret := m.ctrl.Call(m, "ProcessImage", ctx, img, handleInterruptSignal)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ProcessImage indicates an expected call of ProcessImage.
-func (mr *MockImageServiceInterfaceMockRecorder) ProcessImage(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockImageServiceInterfaceMockRecorder) ProcessImage(ctx, img, handleInterruptSignal interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessImage", reflect.TypeOf((*MockImageServiceInterface)(nil).ProcessImage), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessImage", reflect.TypeOf((*MockImageServiceInterface)(nil).ProcessImage), ctx, img, handleInterruptSignal)
 }
 
 // ResumeCreateImage mocks base method.


### PR DESCRIPTION
# Description
This orphan images in this context happen when we delete an image-set when an image is building. 
When we delete an image-set we delete all images first, but if one of them is building, when the final status is returned we are saving that image that is passed through all the function (the image has have the deleted_at not nil), and this restore the image automatically and left it orphan as image-set is already deleted. 

The current PR is reloading the image from db at each iteration, the other changes are related to make this PR testable, without race condition returned from the testing framework because of the interrupt detection procedure.

FIXES: THEEDGE-3414


## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor


# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

