### PR TITLE
THEEDGE-3348: Create structs for /updates REST endpoints (wip)

### DIFF
--- a/pkg/routes/updates_api.go
+++ b/pkg/routes/updates_api.go
@@ -1,0 +1,97 @@
+package routes
+
+// @Summary      Gets all device updates
+// @Tags         Updates
+// @Accept       json
+// @Produce      json
+// @Param        id         path  int  true  "Account ID"
+// @Param        sort_by    query enumstring false "One of created_at, updated_at"
+// @Param        created_at query string     false "An ISO-8601 date in YYYY-MM-DD format"
+// @Param        updated_at query string     false "An ISO-8601 date in YYYY-MM-DD format"
+// @Param        status     query string     false "Filter by status"
+// @Param        limit      query int        false "The number of updates to return" default(30)
+// @Param        offset     query int        false "The offset to begin returning updates"
+// @Success      200 {object} models.SuccessPlaceholderResponse
+// @Failure      400 {object} errors.BadRequest
+// @Failure      500 {object} errors.InternalServerError
+// @Router       /updates [get]
+type GetUpdatesAllDevicesEndpoint struct{}
+
+// @Summary      Return list of available updates for a device
+// @Tags         Updates
+// @Accept       json
+// @Produce      json
+// @param        DeviceUUID path  string    true  "The device UUID"
+// @Success      200 {object} models.SuccessPlaceholderResponse
+// @Failure      400 {object} errors.BadRequest
+// @Router       /updates/device/{DeviceUUID} [get]
+type GetUpdatesDeviceByIDEndpoint struct{}
+
+// @Summary      Return image running on device
+// @Tags         Updates
+// @Accept       json
+// @Produce      json
+// @param        DeviceUUID path  string    true  "The device UUID"
+// @Success      200 {object} models.SuccessPlaceholderResponse
+// @Failure      400 {object} errors.BadRequest
+// @Failure      500 {object} errors.InternalServerError
+// @Router       /updates/device/{DeviceUUID}/image [get]
+type GetUpdatesDeviceByIDImageEndpoint struct{}
+
+// @Summary      Return list of available updates for a device
+// @Tags         Updates
+// @Accept       json
+// @Produce      json
+// @param        DeviceUUID path  string     true  "The device UUID"
+// @param        latest     query enumstring false "One of: latest, all"
+// @Success      200 {object} models.SuccessPlaceholderResponse
+// @Failure      400 {object} models.BadRequest
+// @Failure      500 {object} errors.InternalServerError
+// @Router       /updates/device/{DeviceUUID}/updates [get]
+type GetUpdatesDeviceByIDUpdatesEndpoint struct{}
+
+// @Summary      Gets a single requested update
+// @Tags         Updates
+// @Accept       json
+// @Produce      json
+// @Param        updateID   path  int        true  "A unique ID to identify the update"
+// @Success      200 {object} models.SuccessPlaceholderResponse
+// @Failure      400 {object} models.BadRequest
+// @Failure      404 {object} errors.NotFound
+// @Failure      500 {object} errors.InternalServerError
+// @Router       /updates/{UpdateID} [get]
+type GetUpdatesSingleUpdateByIDEndpoint struct{}
+
+// @Summary      Returns the playbook for a update transaction
+// @Tags         Updates
+// @Accept       json
+// @Produce      json
+// @Param        updateID   path  int        true  "A unique ID to identify the update"
+// @Success      200 {object} models.SuccessPlaceholderResponse
+// @Failure      400 {object} models.BadRequest
+// @Failure      404 {object} errors.NotFound
+// @Failure      500 {object} errors.InternalServerError
+// @Router       /updates/{updateID}/update-playbook.yml [get]
+type GetUpdatesSingleUpdateByIDPlaybookEndpoint struct{}
+
+// @Summary      Executes a device update
+// @Tags         Updates
+// @Accept       json
+// @Produce      json
+// @Param        CommitID    body  int         false "A unique ID to identify a commit" minimum(0)
+// @Param        DevicesUUID body  []string    false "An array of unique device IDs"
+// @Success      200 {object} models.SuccessPlaceholderResponse
+// @Failure      400 {object} models.BadRequest
+// @Failure      500 {object} errors.InternalServerError
+// @Router       /updates [post]
+type PostUpdatesDeviceEndpoint struct{}
+
+// @Summary      Validates if it's possible to update the images selection
+// @Tags         Updates
+// @Accept       json
+// @Produce      json
+// @Success      200 {object} models.SuccessPlaceholderResponse
+// @Failure      400 {object} models.BadRequest
+// @Failure      500 {object} errors.InternalServerError
+// @Router       /updates/validate [post]
+type PostUpdatesValidateEndpoint struct{}


### PR DESCRIPTION
# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This creates structs under `pkg/routes/updates_api.go` to document the various REST endpoints under the `/updates` route. 

Some things I'm wondering/to check:
 - Hopefully this is right :-) I used the [swaggo/swag](https://github.com/swaggo/swag) documentation and partially referenced an old PR #2056 to create this. Please lmk if I'm going in the right direction and what to change!
 - One of the requirements listed is "A new openapi.json file is created". I wasn't sure to commit this since `openapi.json` is already under `.gitignore`?
 - [ ] Add the request body schema for `/updates/validate` (`PostUpdatesValidateEndpoint`)

FIXES: [THEEDGE-3348](https://issues.redhat.com/browse/THEEDGE-3348)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
