### PR TITLE
images: Implement images storage cleanup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,9 @@ RUN go build -o /go/bin/edge-api-ibvents cmd/kafka/main.go
 RUN go build -o /go/bin/edge-api-images-build pkg/services/images_build/main.go
 RUN go build -o /go/bin/edge-api-isos-build pkg/services/images_iso/main.go
 
+# Build utilities binaries
+RUN go build -o /go/bin/edge-api-cleanup cmd/cleanup/main.go
+
 ######################################
 # STEP 2: build the dependencies image
 ######################################

--- a/cmd/cleanup/cleanupimages/cleanupimages.go
+++ b/cmd/cleanup/cleanupimages/cleanupimages.go
@@ -1,0 +1,363 @@
+package cleanupimages
+
+import (
+	"errors"
+	url2 "net/url"
+
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/db"
+	"github.com/redhatinsights/edge-api/pkg/models"
+	"github.com/redhatinsights/edge-api/pkg/services/files"
+	feature "github.com/redhatinsights/edge-api/unleash/features"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+// ErrImagesCleanUPNotAvailable error returned when the images clean up feature flag is disabled
+var ErrImagesCleanUPNotAvailable = errors.New("images cleanup is not available")
+
+// ErrImageNotCleanUPCandidate error returned when the image is not a cleanup candidate
+var ErrImageNotCleanUPCandidate = errors.New("image is not a cleanup candidate")
+
+// DefaultDataLimit the default data limit to use when collecting data
+var DefaultDataLimit = 10
+
+// DefaultMaxDataPageNumber the default data pages to handle as preventive way to enter an indefinite loop
+var DefaultMaxDataPageNumber = 1000
+
+type CandidateImage struct {
+	ImageID         uint           `json:"image_id"`
+	ImageStatus     string         `json:"image_status"`
+	ImageDeletedAt  gorm.DeletedAt `json:"image_deleted_at"`
+	ImageSetID      uint           `json:"image_set_id"`
+	CommitID        uint           `json:"commit_id"`
+	CommitStatus    string         `json:"commit_status"`
+	CommitTarURL    string         `json:"commit_tar_url"`
+	RepoID          uint           `json:"repo_id"`
+	RepoStatus      string         `json:"repo_status"`
+	RepoURL         string         `json:"repo_url"`
+	InstallerID     uint           `json:"installer_id"`
+	InstallerStatus string         `json:"installer_status"`
+	InstallerISOURL string         `json:"installer_iso_url"`
+}
+
+func GetPathFromURL(url string) (string, error) {
+	RepoURL, err := url2.Parse(url)
+	if err != nil {
+		return "", err
+	}
+	return RepoURL.Path, nil
+}
+
+func DeleteAWSFolder(s3Client *files.S3Client, folder string) error {
+	logger := log.WithField("folder-key", folder)
+	if err := s3Client.FolderDeleter.Delete(config.Get().BucketName, folder); err != nil {
+		logger.WithField("error", err.Error()).Error("error deleting folder")
+		return err
+	}
+	logger.Info("folder deleted successfully")
+	return nil
+
+}
+
+func DeleteAWSFile(client *files.S3Client, fileKey string) error {
+	logger := log.WithField("file-key", fileKey)
+	_, err := client.DeleteObject(config.Get().BucketName, fileKey)
+	if err != nil {
+		var contextErr error
+		var errCode string
+		if awsErr, ok := err.(awserr.Error); ok {
+			errCode = awsErr.Code()
+			contextErr = awsErr
+		} else {
+			contextErr = err
+		}
+
+		logger.WithFields(log.Fields{"error": contextErr.Error(), "error-code": errCode}).Error("error when deleting aws s3 file-key")
+		return contextErr
+	}
+	logger.Info("file deleted successfully")
+	return nil
+}
+func cleanUpImageTarFile(s3Client *files.S3Client, candidateImage *CandidateImage) error {
+	logger := log.WithFields(log.Fields{
+		"image_id":      candidateImage.ImageID,
+		"commit_id":     candidateImage.CommitID,
+		"tar-file-url":  candidateImage.CommitTarURL,
+		"commit-status": candidateImage.InstallerStatus,
+	})
+	if candidateImage.CommitStatus == models.ImageStatusSuccess {
+		if candidateImage.CommitTarURL != "" {
+			urlPath, err := GetPathFromURL(candidateImage.CommitTarURL)
+			if err != nil {
+				logger.WithField("error", err.Error()).Error("error occurred while getting resource path url")
+				return err
+			}
+			logger = logger.WithField("tar-file-path", urlPath)
+			logger.Debug("deleting tar file")
+			err = DeleteAWSFile(s3Client, urlPath)
+			if err != nil {
+				logger.WithField("error", err.Error()).Error("error occurred while deleting tar file")
+				return err
+			}
+		}
+		// clean url and update cleaned status
+		if err := db.DB.Debug().Model(&models.Commit{}).Where("id", candidateImage.CommitID).
+			Updates(map[string]interface{}{"status": models.ImageStatusStorageCleaned, "image_build_tar_url": ""}).Error; err != nil {
+			logger.WithField("error", err.Error()).Error("error occurred while updating commit status to cleaned")
+			return err
+		}
+	}
+
+	return nil
+}
+
+func cleanUpImageRepo(s3Client *files.S3Client, candidateImage *CandidateImage) error {
+	logger := log.WithFields(log.Fields{
+		"image_id":    candidateImage.ImageID,
+		"commit_id":   candidateImage.CommitID,
+		"repo-url":    candidateImage.RepoURL,
+		"repo_status": candidateImage.RepoStatus,
+	})
+
+	if candidateImage.RepoStatus == models.ImageStatusSuccess {
+		if candidateImage.RepoURL != "" {
+			urlPath, err := GetPathFromURL(candidateImage.RepoURL)
+			if err != nil {
+				logger.WithField("error", err.Error()).Error("error occurred while getting resource path url")
+				return err
+			}
+			logger = logger.WithField("repo-url-path", urlPath)
+			logger.Debug("deleting repo directory")
+			err = DeleteAWSFolder(s3Client, urlPath)
+			if err != nil {
+				logger.WithField("error", err.Error()).Error("error occurred while deleting repo directory")
+				return err
+			}
+		}
+		// clean url and update cleaned status
+		if err := db.DB.Model(&models.Repo{}).Where("id", candidateImage.RepoID).
+			Updates(map[string]interface{}{"status": models.ImageStatusStorageCleaned, "url": ""}).Error; err != nil {
+			logger.WithField("error", err.Error()).Error("error occurred while updating repo status to cleaned")
+			return err
+		}
+	}
+
+	return nil
+}
+
+func cleanUpImageISOFile(s3Client *files.S3Client, candidateImage *CandidateImage) error {
+	logger := log.WithFields(log.Fields{
+		"image_id":         candidateImage.ImageID,
+		"installer_id":     candidateImage.InstallerID,
+		"iso-file-url":     candidateImage.InstallerISOURL,
+		"installer-status": candidateImage.InstallerStatus,
+	})
+	if candidateImage.InstallerStatus == models.ImageStatusSuccess {
+		if candidateImage.InstallerISOURL != "" {
+			urlPath, err := GetPathFromURL(candidateImage.InstallerISOURL)
+			if err != nil {
+				logger.WithField("error", err.Error()).Error("error occurred while getting resource path url")
+				return err
+			}
+			logger = logger.WithField("iso-file-path", urlPath)
+			logger.Debug("deleting iso file")
+			err = DeleteAWSFile(s3Client, urlPath)
+			if err != nil {
+				logger.WithField("error", err.Error()).Error("error occurred while deleting iso file")
+				return err
+			}
+		}
+		// clean url and update with Cleaned status
+		if err := db.DB.Model(&models.Installer{}).Where("id", candidateImage.InstallerID).
+			Updates(map[string]interface{}{"status": models.ImageStatusStorageCleaned, "image_build_iso_url": ""}).Error; err != nil {
+			logger.WithField("error", err.Error()).Error("error occurred while updating installer status to cleaned")
+			return err
+		}
+	}
+
+	return nil
+}
+
+func cleanUpImageStorage(s3Client *files.S3Client, candidateImage *CandidateImage) error {
+	logger := log.WithField("image_id", candidateImage.ImageID)
+	logger.Info("image storage cleaning started")
+	// cleanup tar file
+	if err := cleanUpImageTarFile(s3Client, candidateImage); err != nil {
+		return err
+	}
+	// cleanup repo
+	if err := cleanUpImageRepo(s3Client, candidateImage); err != nil {
+		return err
+	}
+	// cleanup iso file
+	if err := cleanUpImageISOFile(s3Client, candidateImage); err != nil {
+		return err
+	}
+	logger.Info("image storage cleaning finished successfully")
+	return nil
+}
+
+func DeleteImage(candidateImage *CandidateImage) error {
+	if imageDeletedAtValue, err := candidateImage.ImageDeletedAt.Value(); err != nil {
+		return err
+	} else if imageDeletedAtValue == nil {
+		// delete only soft deleted images
+		return ErrImageNotCleanUPCandidate
+	}
+
+	err := db.DB.Transaction(func(tx *gorm.DB) error {
+
+		// delete images_packages with image_id
+		if err := tx.Exec("DELETE FROM images_packages WHERE image_id=?", candidateImage.ImageID).Error; err != nil {
+			return err
+		}
+
+		// delete images_repos with image_id
+		if err := tx.Exec("DELETE FROM images_repos WHERE image_id=?", candidateImage.ImageID).Error; err != nil {
+			return err
+		}
+
+		// delete images_custom_packages with image_id
+		if err := tx.Exec("DELETE FROM images_custom_packages WHERE image_id=?", candidateImage.ImageID).Error; err != nil {
+			return err
+		}
+
+		// delete commit_installed_packages with commit_id
+		if err := tx.Exec("DELETE FROM commit_installed_packages WHERE commit_id=?", candidateImage.CommitID).Error; err != nil {
+			return err
+		}
+
+		// delete updatetransaction_commits with commit_id
+		if err := tx.Exec("DELETE FROM updatetransaction_commits WHERE commit_id=?", candidateImage.CommitID).Error; err != nil {
+			return err
+		}
+
+		// delete update_transactions with commit_id
+		if err := tx.Unscoped().Where("commit_id", candidateImage.CommitID).Delete(&models.UpdateTransaction{}).Error; err != nil {
+			return err
+		}
+
+		// delete image
+		if err := tx.Unscoped().Where("id", candidateImage.ImageID).Delete(&models.Image{}).Error; err != nil {
+			return err
+		}
+
+		// delete commit
+		if err := tx.Unscoped().Where("id", candidateImage.CommitID).Delete(&models.Commit{}).Error; err != nil {
+			return err
+		}
+
+		// delete repos with commit repo_id
+		if err := tx.Unscoped().Where("id", candidateImage.RepoID).Delete(&models.Repo{}).Error; err != nil {
+			return err
+		}
+
+		// delete installer
+		if err := tx.Unscoped().Where("id", candidateImage.InstallerID).Delete(&models.Installer{}).Error; err != nil {
+			return err
+		}
+
+		// delete image_sets with image_set_id if no images associated
+		var imagesCount int64
+		if err := tx.Unscoped().Model(&models.Image{}).Where("image_set_id = ?", candidateImage.ImageSetID).Count(&imagesCount).Error; err != nil {
+			return nil
+		}
+		if imagesCount == 0 {
+			if err := tx.Unscoped().Where("id", candidateImage.ImageSetID).Delete(&models.ImageSet{}).Error; err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		log.WithFields(log.Fields{"image-id": candidateImage.ImageID, "error": err.Error()}).Error("error occurred while deleting image")
+	}
+
+	return err
+}
+
+func CleanUpImage(s3Client *files.S3Client, candidateImage *CandidateImage) error {
+
+	imageDeletedAtValue, err := candidateImage.ImageDeletedAt.Value()
+	if err != nil {
+		return err
+	}
+	// clean up only deleted images OR images with ERROR status
+	if !(imageDeletedAtValue != nil || candidateImage.ImageStatus == models.ImageStatusError) {
+		return ErrImageNotCleanUPCandidate
+	}
+
+	if err := cleanUpImageStorage(s3Client, candidateImage); err != nil {
+		return err
+	}
+
+	if imageDeletedAtValue != nil {
+		// delete image forever when it's soft deleted
+		if err := DeleteImage(candidateImage); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func GetCandidateImages(gormDB *gorm.DB) ([]CandidateImage, error) {
+	var candidateImages []CandidateImage
+
+	if err := gormDB.Debug().Table("images").
+		Select(`images.id as image_id, images.deleted_at as image_deleted_at, images.status as image_status, images.image_set_id as image_set_id, 
+commits.id as commit_id, commits.status as commit_status, commits.image_build_tar_url as commit_tar_url, 
+repos.id as repo_id, repos.status as repo_status, repos.url repo_url, 
+installers.id as installer_id, installers.status as installer_status, installers.image_build_iso_url as installer_iso_url`).
+		Joins(`JOIN commits ON images.commit_id = commits.id `).
+		Joins(`JOIN installers ON images.installer_id = installers.id `).
+		Joins(`JOIN repos ON commits.repo_id = repos.id`).
+		Where(`images.deleted_at IS NOT NULL`).
+		Or(`images.status = 'ERROR' AND (repos.status='SUCCESS' OR commits.status='SUCCESS' OR installers.status='SUCCESS')`).
+		Order("images.id").
+		Limit(DefaultDataLimit).
+		Scan(&candidateImages).Error; err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Error("error occurred when collecting images candidate")
+		return nil, err
+	}
+
+	return candidateImages, nil
+}
+
+func CleanUpAllImages(s3Client *files.S3Client) error {
+	if !feature.CleanUPImages.IsEnabled() {
+		log.Warning("flag is disabled for cleanup of images feature")
+		return ErrImagesCleanUPNotAvailable
+	}
+
+	imagesCount := 0
+	page := 0
+	for page < DefaultMaxDataPageNumber {
+		candidateImages, err := GetCandidateImages(db.DB)
+		if err != nil {
+			return err
+		}
+
+		if len(candidateImages) == 0 {
+			break
+		}
+
+		for _, image := range candidateImages {
+			image := image
+			if err := CleanUpImage(s3Client, &image); err != nil {
+				return err
+			}
+		}
+
+		imagesCount += len(candidateImages)
+		page++
+	}
+
+	log.WithField("images_count", imagesCount).Info("cleanup images finished")
+	return nil
+}

--- a/cmd/cleanup/cleanupimages/cleanupimages_suite_test.go
+++ b/cmd/cleanup/cleanupimages/cleanupimages_suite_test.go
@@ -1,0 +1,46 @@
+package cleanupimages_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/db"
+	"github.com/redhatinsights/edge-api/pkg/models"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMigrate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	dbName := setupTestDB()
+	RunSpecs(t, "Cleanup images storage Suite")
+	tearDownTestDB(dbName)
+}
+
+func setupTestDB() string {
+	config.Init()
+	config.Get().Debug = true
+	dbName := fmt.Sprintf("%d-cleanupimages.db", time.Now().UnixNano())
+	config.Get().Database.Name = dbName
+	db.InitDB()
+	err := db.DB.AutoMigrate(
+		&models.ImageSet{},
+		&models.Image{},
+		&models.Commit{},
+		&models.Installer{},
+		&models.Repo{},
+		&models.UpdateTransaction{},
+	)
+	if err != nil {
+		panic(err)
+	}
+	return dbName
+}
+
+func tearDownTestDB(dbName string) {
+	_ = os.Remove(dbName)
+}

--- a/cmd/cleanup/cleanupimages/cleanupimages_test.go
+++ b/cmd/cleanup/cleanupimages/cleanupimages_test.go
@@ -1,0 +1,373 @@
+package cleanupimages_test
+
+import (
+	"errors"
+	"os"
+
+	"github.com/redhatinsights/edge-api/cmd/cleanup/cleanupimages"
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/db"
+	"github.com/redhatinsights/edge-api/pkg/models"
+	"github.com/redhatinsights/edge-api/pkg/services/files"
+	"github.com/redhatinsights/edge-api/pkg/services/mock_files"
+	feature "github.com/redhatinsights/edge-api/unleash/features"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/bxcodec/faker/v3"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("Cleanup images", func() {
+
+	Context("CleanUPImages feature flag is disabled", func() {
+
+		BeforeEach(func() {
+			err := os.Unsetenv(feature.CleanUPImages.EnvVar)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not run clean up of images when feature flag is disabled", func() {
+			image := models.Image{Name: faker.UUIDHyphenated()}
+			Expect(image.DeletedAt.Value()).To(BeNil())
+			err := cleanupimages.CleanUpAllImages(nil)
+			Expect(err).To(MatchError(cleanupimages.ErrImagesCleanUPNotAvailable))
+		})
+	})
+
+	Context("CleanUPImages feature flag is enabled", func() {
+
+		BeforeEach(func() {
+
+			err := os.Setenv(feature.CleanUPImages.EnvVar, "true")
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		AfterEach(func() {
+			err := os.Unsetenv(feature.CleanUPImages.EnvVar)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("DeleteImage", func() {
+			var orgID string
+			var existingImage models.Image
+			var image models.Image
+			var imageSet models.ImageSet
+			var customRepos []models.ThirdPartyRepo
+			var updateTransaction models.UpdateTransaction
+
+			BeforeEach(func() {
+				if orgID != "" {
+					// do setup only once
+					return
+				}
+				orgID = faker.UUIDHyphenated()
+				existingImage := models.Image{OrgID: orgID, Name: faker.Name()}
+				err := db.DB.Create(&existingImage).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				imageSet = models.ImageSet{OrgID: orgID, Name: faker.Name()}
+				err = db.DB.Create(&imageSet).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				customRepos = []models.ThirdPartyRepo{
+					{OrgID: orgID, Name: faker.Name(), URL: faker.URL()},
+					{OrgID: orgID, Name: faker.Name(), URL: faker.URL()},
+				}
+				err = db.DB.Create(&customRepos).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				image = models.Image{
+					Name:       imageSet.Name,
+					OrgID:      orgID,
+					Status:     models.ImageStatusSuccess,
+					ImageSetID: &imageSet.ID,
+					Commit: &models.Commit{
+						OrgID:             orgID,
+						Status:            models.ImageStatusSuccess,
+						Repo:              &models.Repo{Status: models.ImageStatusSuccess, URL: faker.URL()},
+						InstalledPackages: []models.InstalledPackage{{Name: "nano"}, {Name: "git"}},
+					},
+					Installer:              &models.Installer{OrgID: orgID, Status: models.ImageStatusSuccess, ImageBuildISOURL: faker.URL()},
+					Packages:               []models.Package{{Name: "nano"}, {Name: "git"}},
+					CustomPackages:         []models.Package{{Name: "BAT"}, {Name: "CAT"}},
+					ThirdPartyRepositories: customRepos,
+				}
+				err = db.DB.Create(&image).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				updateTransaction = models.UpdateTransaction{
+					OrgID:  orgID,
+					Commit: image.Commit,
+				}
+				err = db.DB.Create(&updateTransaction).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				err = db.DB.Delete(&image).Error
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should not DeleteImages that are not soft deleted", func() {
+				candidateImage := cleanupimages.CandidateImage{ImageID: existingImage.ID, ImageDeletedAt: existingImage.DeletedAt}
+				err := cleanupimages.DeleteImage(&candidateImage)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(cleanupimages.ErrImageNotCleanUPCandidate))
+			})
+
+			It("should DeleteImages that are soft deleted", func() {
+				candidatesImages, err := cleanupimages.GetCandidateImages(db.Org(orgID, "images"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(candidatesImages)).To(Equal(1))
+				candidateImage := candidatesImages[0]
+				Expect(candidateImage.ImageID).To(Equal(image.ID))
+				err = cleanupimages.DeleteImage(&candidateImage)
+				Expect(err).ToNot(HaveOccurred())
+
+				// ensure image deleted
+				var deletedImage models.Image
+				err = db.DB.Unscoped().First(&deletedImage, image.ID).Error
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+
+				// ensure imageSet deleted, as have only one image that was deleted
+				var deletedImageSet models.ImageSet
+				err = db.DB.Unscoped().First(&deletedImageSet, imageSet.ID).Error
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+			})
+		})
+
+		Context("AWS storage", func() {
+			var ctrl *gomock.Controller
+			var s3Client *files.S3Client
+			var s3ClientAPI *mock_files.MockS3ClientAPI
+			var s3FolderDeleter *mock_files.MockBatchFolderDeleterAPI
+
+			BeforeEach(func() {
+				ctrl = gomock.NewController(GinkgoT())
+				s3ClientAPI = mock_files.NewMockS3ClientAPI(ctrl)
+				s3FolderDeleter = mock_files.NewMockBatchFolderDeleterAPI(ctrl)
+				s3Client = &files.S3Client{
+					Client:        s3ClientAPI,
+					FolderDeleter: s3FolderDeleter,
+				}
+			})
+
+			AfterEach(func() {
+				ctrl.Finish()
+			})
+
+			It("should delete aws s3 folder", func() {
+				folderPath := "/test/folder/to/delete"
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, folderPath).Return(nil)
+				err := cleanupimages.DeleteAWSFolder(s3Client, folderPath)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should return error when aws folder deleter returns error", func() {
+				folderPath := "/test/folder/to/delete"
+				expectedError := errors.New("expected error returned by aws s3 folder deleter")
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, folderPath).Return(expectedError)
+				err := cleanupimages.DeleteAWSFolder(s3Client, folderPath)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(expectedError))
+			})
+
+			It("should delete aws s3 file", func() {
+				filePath := "/test/file/to/delete"
+				// s3ClientAPI.EXPECT().DeleteObject(config.Get().BucketName, filePath).Return(nil)
+				s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(filePath),
+				}).Return(nil, nil)
+				err := cleanupimages.DeleteAWSFile(s3Client, filePath)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should return error when aws delete object returns error", func() {
+				filePath := "/test/file/to/delete"
+				expectedError := errors.New("expected error returned by aws s3 file deleter")
+				s3ClientAPI.EXPECT().DeleteObject(
+					&s3.DeleteObjectInput{
+						Bucket: aws.String(config.Get().BucketName),
+						Key:    aws.String(filePath),
+					}).Return(nil, expectedError)
+				err := cleanupimages.DeleteAWSFile(s3Client, filePath)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(expectedError))
+			})
+		})
+
+		Context("CleanUP image", func() {
+			It("should not clean up images that are not soft deleted", func() {
+				err := cleanupimages.CleanUpImage(nil, &cleanupimages.CandidateImage{
+					ImageID: uint(100), ImageStatus: models.ImageStatusSuccess, ImageDeletedAt: gorm.DeletedAt{},
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(cleanupimages.ErrImageNotCleanUPCandidate))
+			})
+
+			It("should not clean up images that are not soft deleted and with not with error status", func() {
+				err := cleanupimages.CleanUpImage(nil, &cleanupimages.CandidateImage{
+					ImageID: uint(100), ImageStatus: models.ImageStatusInterrupted, ImageDeletedAt: gorm.DeletedAt{},
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(cleanupimages.ErrImageNotCleanUPCandidate))
+			})
+		})
+
+		Context("CleanUpAllImages", func() {
+			var ctrl *gomock.Controller
+			var s3Client *files.S3Client
+			var s3ClientAPI *mock_files.MockS3ClientAPI
+			var s3FolderDeleter *mock_files.MockBatchFolderDeleterAPI
+
+			var orgID string
+
+			// image should not be deleted, and it's content should not be cleared
+			var existingImage models.Image
+			// image should be deleted, and it's content should be cleared
+			var image models.Image
+			// image should not be deleted, and it's content should be cleared
+			var errImage models.Image
+			var imageSet models.ImageSet
+
+			var imageTarPath string
+			var imageISOPath string
+			var imageRepoPath string
+
+			var errImageTarPath string
+			var errImageRepoPath string
+
+			BeforeEach(func() {
+				ctrl = gomock.NewController(GinkgoT())
+				s3ClientAPI = mock_files.NewMockS3ClientAPI(ctrl)
+				s3FolderDeleter = mock_files.NewMockBatchFolderDeleterAPI(ctrl)
+				s3Client = &files.S3Client{
+					Client:        s3ClientAPI,
+					FolderDeleter: s3FolderDeleter,
+				}
+
+				orgID = faker.UUIDHyphenated()
+
+				imageSet = models.ImageSet{OrgID: orgID, Name: faker.Name()}
+				err := db.DB.Create(&imageSet).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				existingImage = models.Image{OrgID: orgID, Name: faker.Name(), ImageSetID: &imageSet.ID, Status: models.ImageStatusSuccess}
+				err = db.DB.Create(&existingImage).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				imageTarPath = "/image/tar/file/path/" + faker.UUIDHyphenated()
+				imageISOPath = "/image/iso/file/path/" + faker.UUIDHyphenated()
+				imageRepoPath = "/image/repo/path/" + faker.UUIDHyphenated()
+
+				image = models.Image{
+					Name:       imageSet.Name,
+					OrgID:      orgID,
+					Status:     models.ImageStatusSuccess,
+					ImageSetID: &imageSet.ID,
+
+					Commit: &models.Commit{
+						OrgID:  orgID,
+						Status: models.ImageStatusSuccess,
+						Repo: &models.Repo{
+							Status: models.ImageStatusSuccess,
+							URL:    "https://buket.example.com" + imageRepoPath,
+						},
+						ImageBuildTarURL: "https://buket.example.com" + imageTarPath,
+					},
+					Installer: &models.Installer{
+						OrgID:            orgID,
+						Status:           models.ImageStatusSuccess,
+						ImageBuildISOURL: "https://buket.example.com" + imageISOPath,
+					},
+				}
+				err = db.DB.Create(&image).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				// soft delete image
+				err = db.DB.Delete(&image).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				errImageTarPath = "/errImage/tar/file/path/" + faker.UUIDHyphenated()
+				errImageRepoPath = "/errImage/repo/path/" + faker.UUIDHyphenated()
+
+				errImage = models.Image{
+					Name:       imageSet.Name,
+					OrgID:      orgID,
+					Status:     models.ImageStatusError,
+					ImageSetID: &imageSet.ID,
+
+					Commit: &models.Commit{
+						OrgID:  orgID,
+						Status: models.ImageStatusSuccess,
+						Repo: &models.Repo{
+							Status: models.ImageStatusSuccess,
+							URL:    "https://buket.example.com" + errImageRepoPath,
+						},
+						ImageBuildTarURL: "https://buket.example.com" + errImageTarPath,
+					},
+					Installer: &models.Installer{
+						OrgID:  orgID,
+						Status: models.ImageStatusError,
+					},
+				}
+				err = db.DB.Create(&errImage).Error
+				Expect(err).ToNot(HaveOccurred())
+
+			})
+
+			AfterEach(func() {
+				ctrl.Finish()
+			})
+
+			It("should delete images and clear s3 content as expected", func() {
+				// expect all image success aws content to be deleted
+				s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(imageTarPath),
+				}).Return(nil, nil)
+				s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(imageISOPath),
+				}).Return(nil, nil)
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, imageRepoPath).Return(nil)
+
+				// expect all errImage success content to be deleted
+				s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(errImageTarPath),
+				}).Return(nil, nil)
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, errImageRepoPath).Return(nil)
+
+				err := cleanupimages.CleanUpAllImages(s3Client)
+				Expect(err).ToNot(HaveOccurred())
+
+				// expect imageSet with many images should still exist
+				err = db.DB.First(&models.ImageSet{}, imageSet.ID).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				// expect an exitingImage to still exiting
+				err = db.DB.First(&models.Image{}, existingImage.ID).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				// expect image do not exist anymore
+				err = db.DB.Unscoped().First(&models.Image{}, image.ID).Error
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+
+				// expect the image with error status to still exist
+				err = db.DB.Joins("Commit").Preload("Commit.Repo").First(&errImage, errImage.ID).Error
+				Expect(err).ToNot(HaveOccurred())
+				// The commit and Repo status is set to cleared
+				Expect(errImage.Commit.Status).To(Equal(models.ImageStatusStorageCleaned))
+				Expect(errImage.Commit.Repo.Status).To(Equal(models.ImageStatusStorageCleaned))
+			})
+		})
+	})
+})

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/redhatinsights/edge-api/cmd/cleanup/cleanupimages"
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/logger"
+	"github.com/redhatinsights/edge-api/pkg/db"
+	"github.com/redhatinsights/edge-api/pkg/services/files"
+
+	edgeunleash "github.com/redhatinsights/edge-api/unleash"
+
+	"github.com/Unleash/unleash-client-go/v3"
+	log "github.com/sirupsen/logrus"
+)
+
+func initializeUnleash() {
+	cfg := config.Get()
+	if cfg.FeatureFlagsURL != "" {
+		err := unleash.Initialize(
+			unleash.WithListener(&edgeunleash.EdgeListener{}),
+			unleash.WithAppName("edge-api"),
+			unleash.WithUrl(cfg.UnleashURL),
+			unleash.WithRefreshInterval(5*time.Second),
+			unleash.WithMetricsInterval(5*time.Second),
+			unleash.WithCustomHeaders(http.Header{"Authorization": {fmt.Sprintf("Bearer %s", cfg.UnleashSecretName)}}),
+		)
+		if err != nil {
+			log.WithField("Error", err).Error("Unleash client failed to initialize")
+		} else {
+			log.WithField("FeatureFlagURL", cfg.UnleashURL).Info("Unleash client initialized successfully")
+		}
+	} else {
+		log.WithField("FeatureFlagURL", cfg.UnleashURL).Warning("FeatureFlag service initialization was skipped.")
+	}
+}
+
+func initConfiguration() {
+	config.Init()
+	logger.InitLogger(os.Stdout)
+	cfg := config.Get()
+	config.LogConfigAtStartup(cfg)
+	db.InitDB()
+	initializeUnleash()
+}
+
+func flushLogAndExit(err error) {
+	// flush logger before app exit
+	logger.FlushLogger()
+	if err != nil {
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
+func main() {
+	initConfiguration()
+
+	client := files.GetNewS3Client()
+
+	if err := cleanupimages.CleanUpAllImages(client); err != nil {
+		flushLogAndExit(err)
+	}
+}

--- a/pkg/models/images.go
+++ b/pkg/models/images.go
@@ -104,6 +104,11 @@ const (
 	// ImageStatusPending is for when an image or installer is waiting to be built
 	ImageStatusPending = "PENDING"
 
+	// ImageStatusStorageCleaned is for when an image commit or image commit repo or image installer content has storage cleaned
+	// this status is set only for Commit, Repo and Installer models
+	// this happen when an image is going to be deleted forever or when image status is ERROR
+	ImageStatusStorageCleaned = "STORAGE_CLEANED"
+
 	// MissingInstaller is the error message for not passing an installer in the request
 	MissingInstaller = "installer info must be provided"
 	// MissingOrganizationId is the error message for not providing an org id in the request

--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	_ "database/sql" // nolint:blankimport
+	_ "database/sql"
 
 	"github.com/go-chi/chi"
 	kafkacommon "github.com/redhatinsights/edge-api/pkg/common/kafka"

--- a/pkg/services/mock_files/s3.go
+++ b/pkg/services/mock_files/s3.go
@@ -39,6 +39,21 @@ func (m *MockS3ClientAPI) EXPECT() *MockS3ClientAPIMockRecorder {
 	return m.recorder
 }
 
+// DeleteObject mocks base method.
+func (m *MockS3ClientAPI) DeleteObject(input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteObject", input)
+	ret0, _ := ret[0].(*s3.DeleteObjectOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteObject indicates an expected call of DeleteObject.
+func (mr *MockS3ClientAPIMockRecorder) DeleteObject(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObject", reflect.TypeOf((*MockS3ClientAPI)(nil).DeleteObject), input)
+}
+
 // GetObject mocks base method.
 func (m *MockS3ClientAPI) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
 	m.ctrl.T.Helper()
@@ -269,6 +284,21 @@ func (m *MockS3ClientInterface) EXPECT() *MockS3ClientInterfaceMockRecorder {
 	return m.recorder
 }
 
+// DeleteObject mocks base method.
+func (m *MockS3ClientInterface) DeleteObject(bucket, key string) (*s3.DeleteObjectOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteObject", bucket, key)
+	ret0, _ := ret[0].(*s3.DeleteObjectOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteObject indicates an expected call of DeleteObject.
+func (mr *MockS3ClientInterfaceMockRecorder) DeleteObject(bucket, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObject", reflect.TypeOf((*MockS3ClientInterface)(nil).DeleteObject), bucket, key)
+}
+
 // Download mocks base method.
 func (m *MockS3ClientInterface) Download(file io.WriterAt, bucket, key string) (int64, error) {
 	m.ctrl.T.Helper()
@@ -342,4 +372,41 @@ func (m *MockS3ClientInterface) Upload(file io.Reader, bucket, key, acl string) 
 func (mr *MockS3ClientInterfaceMockRecorder) Upload(file, bucket, key, acl interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*MockS3ClientInterface)(nil).Upload), file, bucket, key, acl)
+}
+
+// MockBatchFolderDeleterAPI is a mock of BatchFolderDeleterAPI interface.
+type MockBatchFolderDeleterAPI struct {
+	ctrl     *gomock.Controller
+	recorder *MockBatchFolderDeleterAPIMockRecorder
+}
+
+// MockBatchFolderDeleterAPIMockRecorder is the mock recorder for MockBatchFolderDeleterAPI.
+type MockBatchFolderDeleterAPIMockRecorder struct {
+	mock *MockBatchFolderDeleterAPI
+}
+
+// NewMockBatchFolderDeleterAPI creates a new mock instance.
+func NewMockBatchFolderDeleterAPI(ctrl *gomock.Controller) *MockBatchFolderDeleterAPI {
+	mock := &MockBatchFolderDeleterAPI{ctrl: ctrl}
+	mock.recorder = &MockBatchFolderDeleterAPIMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockBatchFolderDeleterAPI) EXPECT() *MockBatchFolderDeleterAPIMockRecorder {
+	return m.recorder
+}
+
+// Delete mocks base method.
+func (m *MockBatchFolderDeleterAPI) Delete(bucket, folderKey string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", bucket, folderKey)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockBatchFolderDeleterAPIMockRecorder) Delete(bucket, folderKey interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockBatchFolderDeleterAPI)(nil).Delete), bucket, folderKey)
 }

--- a/podman/Containerfile-dev
+++ b/podman/Containerfile-dev
@@ -40,6 +40,9 @@ RUN go run cmd/swagger2openapi/main.go  api/swagger.json api/openapi.json
 #RUN go build -o /usr/local/bin/edge-api-images-iso pkg/services/images_iso/main.go
 #RUN go build -o /usr/local/bin/edge-api-images-status pkg/services/images_status/main.go
 
+# Build utilities
+RUN go build -o /usr/local/bin/edge-api-cleanup cmd/cleanup/main.go
+
 ######################################
 # STEP 2: build the dependencies image
 ######################################

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -93,6 +93,9 @@ var MigrateCustomRepositories = &Flag{Name: "edge-management.migrate_custom_repo
 // PostMigrateDeleteCustomRepositories is a feature flag to use for deletion of repos after migration
 var PostMigrateDeleteCustomRepositories = &Flag{Name: "edge-management.post_migrate_delete_repos", EnvVar: "FEATURE_POST_MIGRATE_DELETE_REPOSITORIES"}
 
+// CleanUPImages is a feature flag to use for cleanup images
+var CleanUPImages = &Flag{Name: "edge-management.cleanup_images", EnvVar: "FEATURE_CLEANUP_IMAGES"}
+
 // SkipUpdateRepo is a feature flag to skip the process of download and re-upload of update repositories
 var SkipUpdateRepo = &Flag{Name: "edgemanagement.skip_update_repo", EnvVar: "FEATURE_SKIP_UPDATE_REPO"}
 


### PR DESCRIPTION
# Description
The goal of the cleanup utility is to remove all unused data stored in AWS S3 bucket. we define unused data by their image status:
- Image is soft-deleted, the cleanup will remove all stored data and delete the image forever.
- Image with status ERROR, the cleanup will remove only the stored data. When removing the stored data the cleanup set the status of commit or repo or installer to STORAGE_CLEANED, this will enable us to identify the already cleaned stored data for images with status ERROR, and for deleted images when app is interrupted.

remain to implement the scheduler for this task.

The linter complained that that there is no "blankimport" directive and it was removed.

FIXES: THEEDGE-3371


## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

