### PR TITLE
cleanup: add unleash.WaitForReady.

### DIFF
--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -37,6 +37,7 @@ func initializeUnleash() {
 	} else {
 		log.WithField("FeatureFlagURL", cfg.UnleashURL).Warning("FeatureFlag service initialization was skipped.")
 	}
+	unleash.WaitForReady()
 }
 
 func initConfiguration() {


### PR DESCRIPTION
# Description
Wait for unleash to be ready at initialization stage instead of time sleep waiting for next refresh.

FIXES: THEEDGE-3371

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

