### PR TITLE
cleanup: Setup openshift CronJob to never restart on failure.

### DIFF
--- a/cmd/cleanup/cleanupimages/cleanupimages.go
+++ b/cmd/cleanup/cleanupimages/cleanupimages.go
@@ -22,7 +22,7 @@ var ErrImagesCleanUPNotAvailable = errors.New("images cleanup is not available")
 var ErrImageNotCleanUPCandidate = errors.New("image is not a cleanup candidate")
 
 // DefaultDataLimit the default data limit to use when collecting data
-var DefaultDataLimit = 10
+var DefaultDataLimit = 30
 
 // DefaultMaxDataPageNumber the default data pages to handle as preventive way to enter an indefinite loop
 var DefaultMaxDataPageNumber = 1000

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -332,7 +332,7 @@ objects:
     jobs:
       - name: cleanup
         schedule: ${CLEANUP_SCHEDULE}
-        restartPolicy: OnFailure
+        restartPolicy: Never
         concurrencyPolicy: Forbid
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
@@ -530,4 +530,4 @@ parameters:
 - name: LINT_ANNOTATION
   value: 'ignore-check.kube-linter.io/minimum-three-replicas'
 - name: CLEANUP_SCHEDULE
-  value: "0 0 1 * *"
+  value: "0 10 3 * *"


### PR DESCRIPTION
# Description

- Logically we do not need this job to be restarted on failure. The job failed with "BackoffLimitExceeded", so there is a persistent error. when restarted we loose our pods logs, and we are incapable to understand why this happened. https://access.redhat.com/solutions/6965050
- Increased the limit to 30 instead of 10, as we have ~ 26000 of records to handle and with max page = 1000 we will be able to handle that number.
- Changed the scheduler to run in two hours from now for debugging.

FIXES: https://issues.redhat.com/browse/THEEDGE-3449

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
