### PR TITLE
cleanup: redo back cleanup images values.

### DIFF
--- a/cmd/cleanup/cleanupimages/cleanupimages.go
+++ b/cmd/cleanup/cleanupimages/cleanupimages.go
@@ -23,10 +23,10 @@ var ErrImagesCleanUPNotAvailable = errors.New("images cleanup is not available")
 var ErrImageNotCleanUPCandidate = errors.New("image is not a cleanup candidate")
 
 // DefaultDataLimit the default data limit to use when collecting data
-var DefaultDataLimit = 10
+var DefaultDataLimit = 30
 
 // DefaultMaxDataPageNumber the default data pages to handle as preventive way to enter an indefinite loop
-var DefaultMaxDataPageNumber = 1
+var DefaultMaxDataPageNumber = 1000
 
 type CandidateImage struct {
 	ImageID         uint           `json:"image_id"`

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -530,4 +530,4 @@ parameters:
 - name: LINT_ANNOTATION
   value: 'ignore-check.kube-linter.io/minimum-three-replicas'
 - name: CLEANUP_SCHEDULE
-  value: "0 11 4 * *"
+  value: "0 0 5 * *"


### PR DESCRIPTION
# Description

After a successful test run, where all the expected s3 files and directories were deleted.
- redo back DefaultDataLimit and DefaultMaxDataPageNumber.
- Make the scheduler to run once a month from this midnight.

FIXES: https://issues.redhat.com/browse/THEEDGE-3449

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
