### PR TITLE
cleanup: implement a retry when deleting s3 bucket folders.

### DIFF
--- a/cmd/cleanup/cleanupimages/cleanupimages.go
+++ b/cmd/cleanup/cleanupimages/cleanupimages.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	url2 "net/url"
 	"strings"
+	"time"
 
 	"github.com/redhatinsights/edge-api/config"
 	"github.com/redhatinsights/edge-api/pkg/db"
@@ -27,6 +28,12 @@ var DefaultDataLimit = 30
 
 // DefaultMaxDataPageNumber the default data pages to handle as preventive way to enter an indefinite loop
 var DefaultMaxDataPageNumber = 1000
+
+// DefaultDeleteFoldersAttempts the default delete folder attempts
+var DefaultDeleteFoldersAttempts = 10
+
+// DefaultDeleteFoldersRetryDelay the default delete folder delay before a retry
+var DefaultDeleteFoldersRetryDelay = 5 * time.Second
 
 type CandidateImage struct {
 	ImageID         uint           `json:"image_id"`
@@ -56,13 +63,19 @@ func DeleteAWSFolder(s3Client *files.S3Client, folder string) error {
 	// remove the prefixed url separator if exists
 	folder = strings.TrimPrefix(folder, "/")
 	logger := log.WithField("folder-key", folder)
-	if err := s3Client.FolderDeleter.Delete(config.Get().BucketName, folder); err != nil {
-		logger.WithField("error", err.Error()).Error("error deleting folder")
-		return err
+	var err error
+	for attempt := 1; attempt <= DefaultDeleteFoldersAttempts; attempt++ {
+		err = s3Client.FolderDeleter.Delete(config.Get().BucketName, folder)
+		if err != nil {
+			logger.WithFields(log.Fields{"attempt": attempt, "error": err.Error()}).Error("error deleting folder")
+			time.Sleep(DefaultDeleteFoldersRetryDelay)
+			continue
+		}
+		logger.WithField("attempt", attempt).Info("folder deleted successfully")
+		break
 	}
-	logger.Info("folder deleted successfully")
-	return nil
-
+	// return the latest error
+	return err
 }
 
 func DeleteAWSFile(client *files.S3Client, fileKey string) error {

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -530,4 +530,4 @@ parameters:
 - name: LINT_ANNOTATION
   value: 'ignore-check.kube-linter.io/minimum-three-replicas'
 - name: CLEANUP_SCHEDULE
-  value: "0 0 5 * *"
+  value: "0 0 6 * *"


### PR DESCRIPTION
# Description
When deleting folders, we encounter an error:
"InternalError: We encountered an internal error. Please try again." full error message in the issue. After the job restart the folder is deleted successfully.
- This PR implement a deletion retry with attempts = 10, this maybe a small number for a big folder like a repo. But noticed a one time retry for one file resolve the problem, so think it's sufficient at this time, and will increase if needed, as the error maybe returned for another file of the same folder.
- Change the scheduler to run the job today at midnight.
 
FIXES: https://issues.redhat.com/browse/THEEDGE-3456

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor


# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

