### PR TITLE
cleanup: run all page cleanup-images in threads.

### DIFF
--- a/cmd/cleanup/cleanupimages/cleanupimages.go
+++ b/cmd/cleanup/cleanupimages/cleanupimages.go
@@ -23,17 +23,16 @@ var ErrImagesCleanUPNotAvailable = errors.New("images cleanup is not available")
 // ErrImageNotCleanUPCandidate error returned when the image is not a cleanup candidate
 var ErrImageNotCleanUPCandidate = errors.New("image is not a cleanup candidate")
 
+var ErrCleanUpAllImagesInterrupted = errors.New("cleanup all images is interrupted")
+
 // DefaultDataLimit the default data limit to use when collecting data
 var DefaultDataLimit = 30
 
 // DefaultMaxDataPageNumber the default data pages to handle as preventive way to enter an indefinite loop
 var DefaultMaxDataPageNumber = 1000
 
-// DefaultDeleteFoldersAttempts the default delete folder attempts
-var DefaultDeleteFoldersAttempts = 10
-
-// DefaultDeleteFoldersRetryDelay the default delete folder delay before a retry
-var DefaultDeleteFoldersRetryDelay = 5 * time.Second
+// DefaultTimeDuration the default time duration to use, this will allow to speedup testing
+var DefaultTimeDuration = 1 * time.Second
 
 type CandidateImage struct {
 	ImageID         uint           `json:"image_id"`
@@ -63,12 +62,14 @@ func DeleteAWSFolder(s3Client *files.S3Client, folder string) error {
 	// remove the prefixed url separator if exists
 	folder = strings.TrimPrefix(folder, "/")
 	logger := log.WithField("folder-key", folder)
+	configAttempts := config.Get().DeleteFilesAttempts
+	configDelay := time.Duration(config.Get().DeleteFilesRetryDelay) * DefaultTimeDuration
 	var err error
-	for attempt := 1; attempt <= DefaultDeleteFoldersAttempts; attempt++ {
+	for attempt := uint(1); attempt <= configAttempts; attempt++ {
 		err = s3Client.FolderDeleter.Delete(config.Get().BucketName, folder)
 		if err != nil {
 			logger.WithFields(log.Fields{"attempt": attempt, "error": err.Error()}).Error("error deleting folder")
-			time.Sleep(DefaultDeleteFoldersRetryDelay)
+			time.Sleep(configDelay)
 			continue
 		}
 		logger.WithField("attempt", attempt).Info("folder deleted successfully")
@@ -80,22 +81,29 @@ func DeleteAWSFolder(s3Client *files.S3Client, folder string) error {
 
 func DeleteAWSFile(client *files.S3Client, fileKey string) error {
 	logger := log.WithField("file-key", fileKey)
-	_, err := client.DeleteObject(config.Get().BucketName, fileKey)
-	if err != nil {
-		var contextErr error
-		var errCode string
-		if awsErr, ok := err.(awserr.Error); ok {
-			errCode = awsErr.Code()
-			contextErr = awsErr
-		} else {
-			contextErr = err
+	var err error
+	configAttempts := config.Get().DeleteFilesAttempts
+	configDelay := time.Duration(config.Get().DeleteFilesRetryDelay) * DefaultTimeDuration
+	for attempt := uint(1); attempt <= configAttempts; attempt++ {
+		_, err = client.DeleteObject(config.Get().BucketName, fileKey)
+		if err != nil {
+			var contextErr error
+			var errCode string
+			if awsErr, ok := err.(awserr.Error); ok {
+				errCode = awsErr.Code()
+				contextErr = awsErr
+			} else {
+				contextErr = err
+			}
+			logger.WithFields(log.Fields{"attempt": attempt, "error": contextErr.Error(), "error-code": errCode}).Error("error deleting file")
+			time.Sleep(configDelay)
+			continue
 		}
-
-		logger.WithFields(log.Fields{"error": contextErr.Error(), "error-code": errCode}).Error("error when deleting aws s3 file-key")
-		return contextErr
+		logger.WithField("attempt", attempt).Info("file deleted successfully")
+		break
 	}
-	logger.Info("file deleted successfully")
-	return nil
+	// return the latest error
+	return err
 }
 func cleanUpImageTarFile(s3Client *files.S3Client, candidateImage *CandidateImage) error {
 	logger := log.WithFields(log.Fields{
@@ -351,7 +359,7 @@ func CleanUpAllImages(s3Client *files.S3Client) error {
 
 	imagesCount := 0
 	page := 0
-	for page < DefaultMaxDataPageNumber {
+	for page < DefaultMaxDataPageNumber && feature.CleanUPImages.IsEnabled() {
 		candidateImages, err := GetCandidateImages(db.DB)
 		if err != nil {
 			return err
@@ -361,14 +369,36 @@ func CleanUpAllImages(s3Client *files.S3Client) error {
 			break
 		}
 
+		// create a new channel for each iteration
+		errChan := make(chan error)
+
 		for _, image := range candidateImages {
 			image := image
-			if err := CleanUpImage(s3Client, &image); err != nil {
-				return err
+			// handle all the page images candidates at once, by default 30
+			go func(resChan chan error) {
+				resChan <- CleanUpImage(s3Client, &image)
+			}(errChan)
+		}
+
+		// wait for all results to be returned
+		errCount := 0
+		for range candidateImages {
+			resError := <-errChan
+			if resError != nil {
+				// errors are logged in the related functions, at this stage need to know if there is an error, to break the loop
+				errCount++
 			}
 		}
 
+		close(errChan)
+
 		imagesCount += len(candidateImages)
+
+		// break on any error
+		if errCount > 0 {
+			log.WithFields(log.Fields{"images_count": imagesCount, "errors_count": errCount}).Info("cleanup images was interrupted because of cleanup errors")
+			return ErrCleanUpAllImagesInterrupted
+		}
 		page++
 	}
 

--- a/cmd/cleanup/cleanupimages/cleanupimages_test.go
+++ b/cmd/cleanup/cleanupimages/cleanupimages_test.go
@@ -148,14 +148,16 @@ var _ = Describe("Cleanup images", func() {
 			var s3Client *files.S3Client
 			var s3ClientAPI *mock_files.MockS3ClientAPI
 			var s3FolderDeleter *mock_files.MockBatchFolderDeleterAPI
-			var initialRetryDelay time.Duration
+			var initialTimeDuration time.Duration
+			var configDeleteAttempts int
 
 			BeforeEach(func() {
 				ctrl = gomock.NewController(GinkgoT())
 				s3ClientAPI = mock_files.NewMockS3ClientAPI(ctrl)
 				s3FolderDeleter = mock_files.NewMockBatchFolderDeleterAPI(ctrl)
-				initialRetryDelay = cleanupimages.DefaultDeleteFoldersRetryDelay
-				cleanupimages.DefaultDeleteFoldersRetryDelay = 1 * time.Millisecond
+				initialTimeDuration = cleanupimages.DefaultTimeDuration
+				cleanupimages.DefaultTimeDuration = 1 * time.Millisecond
+				configDeleteAttempts = int(config.Get().DeleteFilesAttempts)
 				s3Client = &files.S3Client{
 					Client:        s3ClientAPI,
 					FolderDeleter: s3FolderDeleter,
@@ -164,7 +166,7 @@ var _ = Describe("Cleanup images", func() {
 
 			AfterEach(func() {
 				ctrl.Finish()
-				cleanupimages.DefaultDeleteFoldersRetryDelay = initialRetryDelay
+				cleanupimages.DefaultTimeDuration = initialTimeDuration
 			})
 
 			It("should delete aws s3 folder", func() {
@@ -177,10 +179,10 @@ var _ = Describe("Cleanup images", func() {
 			It("should return error when aws folder deleter returns error with all the attempts ", func() {
 				folderPath := "/test/folder/to/delete"
 				expectedError := errors.New("expected error returned by aws s3 folder deleter")
-				// important to expect that this should be called cleanupimages.DefaultDeleteFoldersAttempts times
+				// important to expect that this should be called cleanupimages.DefaultDeleteAttempts times
 				s3FolderDeleter.EXPECT().Delete(
 					config.Get().BucketName, strings.TrimPrefix(folderPath, "/"),
-				).Return(expectedError).Times(cleanupimages.DefaultDeleteFoldersAttempts)
+				).Return(expectedError).Times(int(configDeleteAttempts))
 				err := cleanupimages.DeleteAWSFolder(s3Client, folderPath)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(expectedError))
@@ -189,10 +191,10 @@ var _ = Describe("Cleanup images", func() {
 			It("should not return error after a successful delete folder retry", func() {
 				folderPath := "/test/folder/to/delete"
 				expectedError := errors.New("expected error returned by aws s3 folder deleter")
-				// expect that error was returned (cleanupimages.DefaultDeleteFoldersAttempts -1) times
+				// expect that error was returned (cleanupimages.DefaultDeleteAttempts -1) times
 				s3FolderDeleter.EXPECT().Delete(
 					config.Get().BucketName, strings.TrimPrefix(folderPath, "/"),
-				).Return(expectedError).Times(cleanupimages.DefaultDeleteFoldersAttempts - 1)
+				).Return(expectedError).Times(configDeleteAttempts - 1)
 				// expect that the latest allowed time was a successful delete
 				s3FolderDeleter.EXPECT().Delete(
 					config.Get().BucketName, strings.TrimPrefix(folderPath, "/"),
@@ -204,7 +206,6 @@ var _ = Describe("Cleanup images", func() {
 
 			It("should delete aws s3 file", func() {
 				filePath := "/test/file/to/delete"
-				// s3ClientAPI.EXPECT().DeleteObject(config.Get().BucketName, filePath).Return(nil)
 				s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
 					Bucket: aws.String(config.Get().BucketName),
 					Key:    aws.String(filePath),
@@ -213,17 +214,37 @@ var _ = Describe("Cleanup images", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("should return error when aws delete object returns error", func() {
+			It("should return error when aws delete object returns error with all attempts", func() {
 				filePath := "/test/file/to/delete"
 				expectedError := errors.New("expected error returned by aws s3 file deleter")
+				// important to expect that this should be called cleanupimages.DefaultDeleteAttempts times
 				s3ClientAPI.EXPECT().DeleteObject(
 					&s3.DeleteObjectInput{
 						Bucket: aws.String(config.Get().BucketName),
 						Key:    aws.String(filePath),
-					}).Return(nil, expectedError)
+					}).Return(nil, expectedError).Times(configDeleteAttempts)
 				err := cleanupimages.DeleteAWSFile(s3Client, filePath)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(expectedError))
+			})
+
+			It("should not return error after a successful delete object retry", func() {
+				filePath := "/test/file/to/delete"
+				expectedError := errors.New("expected error returned by aws s3 file deleter")
+				// expect that error was returned (cleanupimages.DefaultDeleteAttempts -1) times
+				s3ClientAPI.EXPECT().DeleteObject(
+					&s3.DeleteObjectInput{
+						Bucket: aws.String(config.Get().BucketName),
+						Key:    aws.String(filePath),
+					}).Return(nil, expectedError).Times(configDeleteAttempts - 1)
+				// expect that the latest allowed time was a successful delete
+				s3ClientAPI.EXPECT().DeleteObject(
+					&s3.DeleteObjectInput{
+						Bucket: aws.String(config.Get().BucketName),
+						Key:    aws.String(filePath),
+					}).Return(nil, nil).Times(1)
+				err := cleanupimages.DeleteAWSFile(s3Client, filePath)
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
@@ -275,6 +296,9 @@ var _ = Describe("Cleanup images", func() {
 			var errImageTarPath string
 			var errImageRepoPath string
 
+			var initialTimeDuration time.Duration
+			var confiDeleteAttempts int
+
 			BeforeEach(func() {
 				ctrl = gomock.NewController(GinkgoT())
 				s3ClientAPI = mock_files.NewMockS3ClientAPI(ctrl)
@@ -283,6 +307,10 @@ var _ = Describe("Cleanup images", func() {
 					Client:        s3ClientAPI,
 					FolderDeleter: s3FolderDeleter,
 				}
+
+				initialTimeDuration = cleanupimages.DefaultTimeDuration
+				cleanupimages.DefaultTimeDuration = 1 * time.Millisecond
+				confiDeleteAttempts = int(config.Get().DeleteFilesAttempts)
 
 				orgID = faker.UUIDHyphenated()
 
@@ -393,6 +421,7 @@ var _ = Describe("Cleanup images", func() {
 
 			AfterEach(func() {
 				ctrl.Finish()
+				cleanupimages.DefaultTimeDuration = initialTimeDuration
 			})
 
 			It("should delete images and clear s3 content as expected", func() {
@@ -461,6 +490,83 @@ var _ = Describe("Cleanup images", func() {
 				// The commit and Repo status is set to cleared
 				Expect(errImage.Commit.Status).To(Equal(models.ImageStatusStorageCleaned))
 				Expect(errImage.Commit.Repo.Status).To(Equal(models.ImageStatusStorageCleaned))
+			})
+
+			It("should interrupt when any folder delete error persists", func() {
+				expectedError := errors.New("expected folder delete error")
+				defer func() {
+					// teardown: remove image to not conflict with other tests
+					candidateImage := cleanupimages.CandidateImage{ImageID: image.ID, ImageDeletedAt: image.DeletedAt}
+					_ = cleanupimages.DeleteImage(&candidateImage)
+				}()
+
+				s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(imageTarPath),
+				}).Return(nil, nil)
+				s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(image2TarPath),
+				}).Return(nil, nil)
+				s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(imageISOPath),
+				}).Return(nil, nil).Times(0)
+				s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(image2ISOPath),
+				}).Return(nil, nil)
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, strings.TrimPrefix(imageRepoPath, "/")).Return(expectedError).Times(confiDeleteAttempts)
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, strings.TrimPrefix(image2RepoPath, "/")).Return(nil)
+
+				// expect all errImage success content to be deleted
+				s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(errImageTarPath),
+				}).Return(nil, nil)
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, strings.TrimPrefix(errImageRepoPath, "/")).Return(nil)
+
+				err := cleanupimages.CleanUpAllImages(s3Client)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(cleanupimages.ErrCleanUpAllImagesInterrupted))
+			})
+
+			It("should interrupt when any file delete error persists", func() {
+				expectedError := errors.New("expected file delete error")
+				defer func() {
+					// teardown: remove image to not conflict with other tests
+					candidateImage := cleanupimages.CandidateImage{ImageID: image.ID, ImageDeletedAt: image.DeletedAt}
+					_ = cleanupimages.DeleteImage(&candidateImage)
+				}()
+				s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(imageTarPath),
+				}).Return(nil, expectedError).Times(confiDeleteAttempts)
+				s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(image2TarPath),
+				}).Return(nil, nil)
+				s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(imageISOPath),
+				}).Return(nil, nil).Times(0)
+				s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(image2ISOPath),
+				}).Return(nil, nil)
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, strings.TrimPrefix(imageRepoPath, "/")).Return(nil).Times(0)
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, strings.TrimPrefix(image2RepoPath, "/")).Return(nil)
+
+				// expect all errImage success content to be deleted
+				s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(errImageTarPath),
+				}).Return(nil, nil)
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, strings.TrimPrefix(errImageRepoPath, "/")).Return(nil)
+
+				err := cleanupimages.CleanUpAllImages(s3Client)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(cleanupimages.ErrCleanUpAllImagesInterrupted))
 			})
 		})
 	})

--- a/config/config.go
+++ b/config/config.go
@@ -73,6 +73,8 @@ type EdgeConfig struct {
 	TlsCAPath                  string                    `json:"Tls_CA_path,omitempty"`
 	RepoFileUploadAttempts     uint                      `json:"repo_file_upload_attempts"`
 	RepoFileUploadDelay        uint                      `json:"repo_file_upload_delay"`
+	DeleteFilesAttempts        uint                      `json:"delete_files_attempts"`
+	DeleteFilesRetryDelay      uint                      `json:"delete_files_retry_delay"`
 }
 
 type dbConfig struct {
@@ -160,6 +162,8 @@ func CreateEdgeAPIConfig() (*EdgeConfig, error) {
 	options.SetDefault("TlsCAPath", "/tmp/tls_path.txt")
 	options.SetDefault("RepoFileUploadAttempts", 3)
 	options.SetDefault("RepoFileUploadDelay", 1)
+	options.SetDefault("DeleteFilesAttempts", 10)
+	options.SetDefault("DeleteFilesRetryDelay", 5)
 	options.AutomaticEnv()
 
 	if options.GetBool("Debug") {
@@ -262,6 +266,8 @@ func CreateEdgeAPIConfig() (*EdgeConfig, error) {
 		GlitchtipDsn:               options.GetString("GlitchtipDsn"),
 		TlsCAPath:                  options.GetString("/tmp/tls_path.txt"),
 		RepoFileUploadAttempts:     options.GetUint("RepoFileUploadAttempts"),
+		DeleteFilesAttempts:        options.GetUint("DeleteFilesAttempts"),
+		DeleteFilesRetryDelay:      options.GetUint("DeleteFilesRetryDelay"),
 	}
 	if edgeConfig.TenantTranslatorHost != "" && edgeConfig.TenantTranslatorPort != "" {
 		edgeConfig.TenantTranslatorURL = fmt.Sprintf("http://%s:%s", edgeConfig.TenantTranslatorHost, edgeConfig.TenantTranslatorPort)


### PR DESCRIPTION
# Description
The images cleaning is very slow, this PR will increase the number of images cleaned. the main reason is that the directory deleting is taking from 7 to  8 min to complete and we have more than 22000 images to cleanup, the implementation as is today will take ~ 122 days to complete, the current PR should decrease it to ~ 4 days . this is max numbers as not all images has repos to cleanup (if 1/3 of images has repos to clean up this will take 40 days in the current implementation and  1.4 day with the current PR).
 
- default page limit is 30. this PR will handle cleaning all page images in threads.
- retry deleting file.
- unit-tests coverage.
- exit the loop if feature flag is disabled.

FIXES: THEEDGE-3456

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor


# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

