### PR TITLE
cleanup: implement CLEANUP_SUSPEND

### DIFF
--- a/cmd/cleanup/cleanupimages/cleanupimages.go
+++ b/cmd/cleanup/cleanupimages/cleanupimages.go
@@ -26,7 +26,7 @@ var ErrImageNotCleanUPCandidate = errors.New("image is not a cleanup candidate")
 var ErrCleanUpAllImagesInterrupted = errors.New("cleanup all images is interrupted")
 
 // DefaultDataLimit the default data limit to use when collecting data
-var DefaultDataLimit = 30
+var DefaultDataLimit = 45
 
 // DefaultMaxDataPageNumber the default data pages to handle as preventive way to enter an indefinite loop
 var DefaultMaxDataPageNumber = 1000

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -334,6 +334,7 @@ objects:
         schedule: ${CLEANUP_SCHEDULE}
         restartPolicy: Never
         concurrencyPolicy: Forbid
+        suspend: ${{CLEANUP_SUSPEND}}
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
           args:
@@ -530,4 +531,8 @@ parameters:
 - name: LINT_ANNOTATION
   value: 'ignore-check.kube-linter.io/minimum-three-replicas'
 - name: CLEANUP_SCHEDULE
-  value: "0 0 12 * *"
+  value: "0 0 * * 1"
+- description: Whether to suspend the cleanup scheduled job.
+  name: CLEANUP_SUSPEND
+  required: false
+  value: "false"


### PR DESCRIPTION
This will enable to control on which environment we run the cleanup scheduled job, for the moment we run the script only on stage env.

- Add suspend with CLEANUP_SUSPEND env variable.
- Change the scheduler for the job to start weekly.
- Increase the data limit to increase how much images we handle in separate threads.


## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

