### PR TITLE
add static delta state struct and db schema migrate

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -164,6 +164,11 @@ func main() {
 
 	modelsInterfaces = append(modelsInterfaces,
 		ModelInterface{
+			label:             "StaticDeltaState",
+			interfaceInstance: &models.StaticDeltaState{}})
+
+	modelsInterfaces = append(modelsInterfaces,
+		ModelInterface{
 			label:             "ThirdPartyRepo",
 			interfaceInstance: &models.ThirdPartyRepo{}})
 

--- a/pkg/models/staticdelta.go
+++ b/pkg/models/staticdelta.go
@@ -1,0 +1,25 @@
+package models
+
+// StaticDeltaState models the state of an existing static delta
+type StaticDeltaState struct {
+	Model
+	Name   string `json:"name" gorm:"index;<-:create"` // the fromcommit-tocommit static delta name
+	OrgID  string `json:"org_id"`                      // the owner of the static delta
+	Status string `json:"status"`                      // the status of the generation process
+	URL    string `json:"url"`                         // url for the repo where the static delta is stored
+}
+
+// values for the StaticDeltaState Status field
+const (
+	// StaticDeltaStatusError represents there has been an error in the process
+	StaticDeltaStatusError = "ERROR"
+
+	// StaticDeltaStatusGenerating represents static delta generation is in process
+	StaticDeltaStatusGenerating = "GENERATING"
+
+	// StaticDeltaStatusReady represents the static delta is ready to be used for an update
+	StaticDeltaStatusReady = "READY"
+
+	// StaticDeltaStatusUploading represents the delta is being uploaded to repo storage
+	StaticDeltaStatusUploading = "UPLOADING"
+)

--- a/pkg/models/staticdelta_test.go
+++ b/pkg/models/staticdelta_test.go
@@ -1,0 +1,30 @@
+package models
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStaticDeltaStateStruct(t *testing.T) {
+	orgID := faker.UUIDHyphenated()
+	url := faker.URL()
+	fromCommit := faker.UUIDDigit()
+	toCommit := faker.UUIDDigit()
+	name := fmt.Sprintf("%s-%s", fromCommit, toCommit)
+	status := StaticDeltaStatusGenerating
+
+	state := &StaticDeltaState{
+		Name:   name,
+		OrgID:  orgID,
+		Status: status,
+		URL:    url,
+	}
+
+	assert.Equal(t, state.Name, name, "Name is not equal to the expected value")
+	assert.Equal(t, state.OrgID, orgID, "OrgID is not equal to the expected value")
+	assert.Equal(t, state.Status, status, "Status is not equal to the expected value")
+	assert.Equal(t, state.URL, url, "URL is not equal to the expected value")
+}


### PR DESCRIPTION
* add static delta state struct
* add static delta state status field constants
* add db migrate for static delta state store
* add simple struct test

# Description
Add a struct to track the state of a static delta and associated Gorm DB migration

FIXES: THEEDGE-3482

Related to bug: THEEDGE-3430

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
