### PR TITLE
api-doc: FIXES API doc for update endpoints.

### DIFF
--- a/pkg/routes/updates.go
+++ b/pkg/routes/updates.go
@@ -86,8 +86,8 @@ func UpdateCtx(next http.Handler) http.Handler {
 // @Tags         Updates (Systems)
 // @Accept       json
 // @Produce      plain
-// @Param        updateID  path  integer    true  "a unique ID to identify the update the playbook belongs to" example(1042)
-// @Success      200 {string}		"the playbook file content for an update"
+// @Param        updateID  path  int    true  "a unique ID to identify the update the playbook belongs to" example(1042)
+// @Success      200 {string} string "the playbook file content for an update"
 // @Failure      400 {object} errors.BadRequest	"The request sent couldn't be processed."
 // @Failure      404 {object} errors.NotFound	"the device update was not found"
 // @Failure      500 {object} errors.InternalServerError	"There was an internal server error."
@@ -324,7 +324,7 @@ func AddUpdate(w http.ResponseWriter, r *http.Request) {
 // @Tags         Updates (Systems)
 // @Accept       json
 // @Produce      json
-// @Param        updateID  path  integer    true  "a unique ID to identify the update" example(1042)
+// @Param        updateID  path  int    true  "a unique ID to identify the update" example(1042)
 // @Success      200 {object} models.UpdateAPI	"The requested update"
 // @Failure      400 {object} errors.BadRequest	"The request sent couldn't be processed"
 // @Failure      404 {object} errors.NotFound	"The requested update was not found"
@@ -358,7 +358,7 @@ func getUpdate(w http.ResponseWriter, r *http.Request) *models.UpdateTransaction
 // @Tags         Updates (Systems)
 // @Accept       json
 // @Produce      json
-// @Param        updateID  path  integer    true  "a unique ID to identify the update" example(1042)
+// @Param        updateID  path  int    true  "a unique ID to identify the update" example(1042)
 // @Success      200 {object} models.DeviceNotificationAPI "The notification payload"
 // @Failure      400 {object} errors.BadRequest	"The request sent couldn't be processed"
 // @Failure      404 {object} errors.NotFound	"The requested update was not found"


### PR DESCRIPTION
# Description
Fixes the update endpoint API doc:
- replace integer by int
- Put the missing return type (string) for GetUpdatePlaybook

FIXES:

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

