### PR TITLE
Configure mergify to squash commit instead of merge. 

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -97,6 +97,7 @@ pull_request_rules:
       queue:
         name: edge-api
         method: squash
+        commit_message_template: "{{ commits[0] }}"
   #
   # Detect when PR conflicts and add label
   - name: warn on conflicts

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -96,7 +96,7 @@ pull_request_rules:
           - invalid
       queue:
         name: edge-api
-        method: merge
+        method: squash
   #
   # Detect when PR conflicts and add label
   - name: warn on conflicts


### PR DESCRIPTION
# Description
In the context to simplify git logs, and to escape some problems faced when merging a PR with many commits
- configure mergify to squash commit instead of merging
- configure mergify commit message to be the first commit message

do it in 2 commits to test the behavior. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

