### PR TITLE
add ostree summary command to static delta gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ EXCLUDE_DIRS=-e /test/ -e /cmd/db -e /cmd/kafka \
 				-e /pkg/clients/imagebuilder/mock_imagebuilder \
 				-e /pkg/imagebuilder/mock_imagebuilder \
 				-e /pkg/clients/inventory/mock_inventory \
-				-e /pkg/errors -e /pkg/services/mock_services -e /unleash
+				-e /pkg/errors -e /pkg/services/mock_services -e /unleash \
+				-e /api
 
 CONTAINERFILE_NAME=Dockerfile
 

--- a/pkg/services/repobuilder.go
+++ b/pkg/services/repobuilder.go
@@ -452,6 +452,16 @@ func (rb *RepoBuilder) RepoPullLocalStaticDeltas(u *models.Commit, o *models.Com
 		).Error("error occurred while running static-delta command")
 		return err
 	}
+
+	// update ostree summary
+	cmd = BuildCommand("/usr/bin/ostree", "summary", "--repo", uprepo, "-u")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		rb.log.WithFields(
+			log.Fields{"error": err.Error(), "OSTreeSummary": uprepo, "output": output},
+		).Error("error occurred while running summary update command")
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
* add ostree summary --repo <repo_path> -u

# Description
Add ostree summary command to static delta generation

FIXES: THEEDGE-3483

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->