### PR TITLE
cleanup: move storage functions to storage module.

### DIFF
--- a/cmd/cleanup/cleanupimages/cleanupimages_test.go
+++ b/cmd/cleanup/cleanupimages/cleanupimages_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/redhatinsights/edge-api/cmd/cleanup/cleanupimages"
+	"github.com/redhatinsights/edge-api/cmd/cleanup/storage"
 	"github.com/redhatinsights/edge-api/config"
 	"github.com/redhatinsights/edge-api/pkg/db"
 	"github.com/redhatinsights/edge-api/pkg/models"
@@ -143,111 +144,6 @@ var _ = Describe("Cleanup images", func() {
 			})
 		})
 
-		Context("AWS storage", func() {
-			var ctrl *gomock.Controller
-			var s3Client *files.S3Client
-			var s3ClientAPI *mock_files.MockS3ClientAPI
-			var s3FolderDeleter *mock_files.MockBatchFolderDeleterAPI
-			var initialTimeDuration time.Duration
-			var configDeleteAttempts int
-
-			BeforeEach(func() {
-				ctrl = gomock.NewController(GinkgoT())
-				s3ClientAPI = mock_files.NewMockS3ClientAPI(ctrl)
-				s3FolderDeleter = mock_files.NewMockBatchFolderDeleterAPI(ctrl)
-				initialTimeDuration = cleanupimages.DefaultTimeDuration
-				cleanupimages.DefaultTimeDuration = 1 * time.Millisecond
-				configDeleteAttempts = int(config.Get().DeleteFilesAttempts)
-				s3Client = &files.S3Client{
-					Client:        s3ClientAPI,
-					FolderDeleter: s3FolderDeleter,
-				}
-			})
-
-			AfterEach(func() {
-				ctrl.Finish()
-				cleanupimages.DefaultTimeDuration = initialTimeDuration
-			})
-
-			It("should delete aws s3 folder", func() {
-				folderPath := "/test/folder/to/delete"
-				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, strings.TrimPrefix(folderPath, "/")).Return(nil)
-				err := cleanupimages.DeleteAWSFolder(s3Client, strings.TrimPrefix(folderPath, "/"))
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			It("should return error when aws folder deleter returns error with all the attempts ", func() {
-				folderPath := "/test/folder/to/delete"
-				expectedError := errors.New("expected error returned by aws s3 folder deleter")
-				// important to expect that this should be called cleanupimages.DefaultDeleteAttempts times
-				s3FolderDeleter.EXPECT().Delete(
-					config.Get().BucketName, strings.TrimPrefix(folderPath, "/"),
-				).Return(expectedError).Times(int(configDeleteAttempts))
-				err := cleanupimages.DeleteAWSFolder(s3Client, folderPath)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(expectedError))
-			})
-
-			It("should not return error after a successful delete folder retry", func() {
-				folderPath := "/test/folder/to/delete"
-				expectedError := errors.New("expected error returned by aws s3 folder deleter")
-				// expect that error was returned (cleanupimages.DefaultDeleteAttempts -1) times
-				s3FolderDeleter.EXPECT().Delete(
-					config.Get().BucketName, strings.TrimPrefix(folderPath, "/"),
-				).Return(expectedError).Times(configDeleteAttempts - 1)
-				// expect that the latest allowed time was a successful delete
-				s3FolderDeleter.EXPECT().Delete(
-					config.Get().BucketName, strings.TrimPrefix(folderPath, "/"),
-				).Return(nil).Times(1)
-
-				err := cleanupimages.DeleteAWSFolder(s3Client, folderPath)
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			It("should delete aws s3 file", func() {
-				filePath := "/test/file/to/delete"
-				s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
-					Bucket: aws.String(config.Get().BucketName),
-					Key:    aws.String(filePath),
-				}).Return(nil, nil)
-				err := cleanupimages.DeleteAWSFile(s3Client, filePath)
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			It("should return error when aws delete object returns error with all attempts", func() {
-				filePath := "/test/file/to/delete"
-				expectedError := errors.New("expected error returned by aws s3 file deleter")
-				// important to expect that this should be called cleanupimages.DefaultDeleteAttempts times
-				s3ClientAPI.EXPECT().DeleteObject(
-					&s3.DeleteObjectInput{
-						Bucket: aws.String(config.Get().BucketName),
-						Key:    aws.String(filePath),
-					}).Return(nil, expectedError).Times(configDeleteAttempts)
-				err := cleanupimages.DeleteAWSFile(s3Client, filePath)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(expectedError))
-			})
-
-			It("should not return error after a successful delete object retry", func() {
-				filePath := "/test/file/to/delete"
-				expectedError := errors.New("expected error returned by aws s3 file deleter")
-				// expect that error was returned (cleanupimages.DefaultDeleteAttempts -1) times
-				s3ClientAPI.EXPECT().DeleteObject(
-					&s3.DeleteObjectInput{
-						Bucket: aws.String(config.Get().BucketName),
-						Key:    aws.String(filePath),
-					}).Return(nil, expectedError).Times(configDeleteAttempts - 1)
-				// expect that the latest allowed time was a successful delete
-				s3ClientAPI.EXPECT().DeleteObject(
-					&s3.DeleteObjectInput{
-						Bucket: aws.String(config.Get().BucketName),
-						Key:    aws.String(filePath),
-					}).Return(nil, nil).Times(1)
-				err := cleanupimages.DeleteAWSFile(s3Client, filePath)
-				Expect(err).ToNot(HaveOccurred())
-			})
-		})
-
 		Context("CleanUP image", func() {
 			It("should not clean up images that are not soft deleted", func() {
 				err := cleanupimages.CleanUpImage(nil, &cleanupimages.CandidateImage{
@@ -308,8 +204,8 @@ var _ = Describe("Cleanup images", func() {
 					FolderDeleter: s3FolderDeleter,
 				}
 
-				initialTimeDuration = cleanupimages.DefaultTimeDuration
-				cleanupimages.DefaultTimeDuration = 1 * time.Millisecond
+				initialTimeDuration = storage.DefaultTimeDuration
+				storage.DefaultTimeDuration = 1 * time.Millisecond
 				confiDeleteAttempts = int(config.Get().DeleteFilesAttempts)
 
 				orgID = faker.UUIDHyphenated()
@@ -421,7 +317,7 @@ var _ = Describe("Cleanup images", func() {
 
 			AfterEach(func() {
 				ctrl.Finish()
-				cleanupimages.DefaultTimeDuration = initialTimeDuration
+				storage.DefaultTimeDuration = initialTimeDuration
 			})
 
 			It("should delete images and clear s3 content as expected", func() {

--- a/cmd/cleanup/storage/storage.go
+++ b/cmd/cleanup/storage/storage.go
@@ -1,0 +1,75 @@
+package storage
+
+import (
+	url2 "net/url"
+	"strings"
+	"time"
+
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/services/files"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/sirupsen/logrus"
+)
+
+// DefaultTimeDuration the default time duration to use, this will allow to speedup testing
+var DefaultTimeDuration = 1 * time.Second
+
+// GetPathFromURL return the path of an url
+func GetPathFromURL(url string) (string, error) {
+	RepoURL, err := url2.Parse(url)
+	if err != nil {
+		return "", err
+	}
+	return RepoURL.Path, nil
+}
+
+// DeleteAWSFolder delete an AWS S3 bucket folder
+func DeleteAWSFolder(s3Client *files.S3Client, folder string) error {
+	// remove the prefixed url separator if exists
+	folder = strings.TrimPrefix(folder, "/")
+	logger := logrus.WithField("folder-key", folder)
+	configAttempts := config.Get().DeleteFilesAttempts
+	configDelay := time.Duration(config.Get().DeleteFilesRetryDelay) * DefaultTimeDuration
+	var err error
+	for attempt := uint(1); attempt <= configAttempts; attempt++ {
+		err = s3Client.FolderDeleter.Delete(config.Get().BucketName, folder)
+		if err != nil {
+			logger.WithFields(logrus.Fields{"attempt": attempt, "error": err.Error()}).Error("error deleting folder")
+			time.Sleep(configDelay)
+			continue
+		}
+		logger.WithField("attempt", attempt).Info("folder deleted successfully")
+		break
+	}
+	// return the latest error
+	return err
+}
+
+// DeleteAWSFile delete AWS S3 bucket file
+func DeleteAWSFile(client *files.S3Client, fileKey string) error {
+	logger := logrus.WithField("file-key", fileKey)
+	var err error
+	configAttempts := config.Get().DeleteFilesAttempts
+	configDelay := time.Duration(config.Get().DeleteFilesRetryDelay) * DefaultTimeDuration
+	for attempt := uint(1); attempt <= configAttempts; attempt++ {
+		_, err = client.DeleteObject(config.Get().BucketName, fileKey)
+		if err != nil {
+			var contextErr error
+			var errCode string
+			if awsErr, ok := err.(awserr.Error); ok {
+				errCode = awsErr.Code()
+				contextErr = awsErr
+			} else {
+				contextErr = err
+			}
+			logger.WithFields(logrus.Fields{"attempt": attempt, "error": contextErr.Error(), "error-code": errCode}).Error("error deleting file")
+			time.Sleep(configDelay)
+			continue
+		}
+		logger.WithField("attempt", attempt).Info("file deleted successfully")
+		break
+	}
+	// return the latest error
+	return err
+}

--- a/cmd/cleanup/storage/storage_suite_test.go
+++ b/cmd/cleanup/storage/storage_suite_test.go
@@ -1,0 +1,13 @@
+package storage_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMigrate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Storage Suite")
+}

--- a/cmd/cleanup/storage/storage_test.go
+++ b/cmd/cleanup/storage/storage_test.go
@@ -1,0 +1,144 @@
+package storage_test
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/redhatinsights/edge-api/cmd/cleanup/storage"
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/services/files"
+	"github.com/redhatinsights/edge-api/pkg/services/mock_files"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Storage", func() {
+
+	Context("GetPathFromURL", func() {
+		It("should return url path", func() {
+			expectedPath := "/example/repo"
+			url := "https://repos.example.com" + expectedPath
+			urlPath, err := storage.GetPathFromURL(url)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(urlPath).To(Equal(expectedPath))
+		})
+
+		It("should return error when url fails to be parsed", func() {
+			expectedPath := "/example/repo"
+			url := "https\t://repos.example.com\n" + expectedPath
+			_, err := storage.GetPathFromURL(url)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid control character in URL"))
+		})
+	})
+
+	Context("AWS storage", func() {
+		var ctrl *gomock.Controller
+		var s3Client *files.S3Client
+		var s3ClientAPI *mock_files.MockS3ClientAPI
+		var s3FolderDeleter *mock_files.MockBatchFolderDeleterAPI
+		var initialTimeDuration time.Duration
+		var configDeleteAttempts int
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			s3ClientAPI = mock_files.NewMockS3ClientAPI(ctrl)
+			s3FolderDeleter = mock_files.NewMockBatchFolderDeleterAPI(ctrl)
+			initialTimeDuration = storage.DefaultTimeDuration
+			storage.DefaultTimeDuration = 1 * time.Millisecond
+			configDeleteAttempts = int(config.Get().DeleteFilesAttempts)
+			s3Client = &files.S3Client{
+				Client:        s3ClientAPI,
+				FolderDeleter: s3FolderDeleter,
+			}
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+			storage.DefaultTimeDuration = initialTimeDuration
+		})
+
+		It("should delete aws s3 folder", func() {
+			folderPath := "/test/folder/to/delete"
+			s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, strings.TrimPrefix(folderPath, "/")).Return(nil)
+			err := storage.DeleteAWSFolder(s3Client, strings.TrimPrefix(folderPath, "/"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return error when aws folder deleter returns error with all the attempts ", func() {
+			folderPath := "/test/folder/to/delete"
+			expectedError := errors.New("expected error returned by aws s3 folder deleter")
+			// important to expect that this should be called cleanupimages.DefaultDeleteAttempts times
+			s3FolderDeleter.EXPECT().Delete(
+				config.Get().BucketName, strings.TrimPrefix(folderPath, "/"),
+			).Return(expectedError).Times(configDeleteAttempts)
+			err := storage.DeleteAWSFolder(s3Client, folderPath)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(expectedError))
+		})
+
+		It("should not return error after a successful delete folder retry", func() {
+			folderPath := "/test/folder/to/delete"
+			expectedError := errors.New("expected error returned by aws s3 folder deleter")
+			// expect that error was returned (cleanupimages.DefaultDeleteAttempts -1) times
+			s3FolderDeleter.EXPECT().Delete(
+				config.Get().BucketName, strings.TrimPrefix(folderPath, "/"),
+			).Return(expectedError).Times(configDeleteAttempts - 1)
+			// expect that the latest allowed time was a successful delete
+			s3FolderDeleter.EXPECT().Delete(
+				config.Get().BucketName, strings.TrimPrefix(folderPath, "/"),
+			).Return(nil).Times(1)
+
+			err := storage.DeleteAWSFolder(s3Client, folderPath)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should delete aws s3 file", func() {
+			filePath := "/test/file/to/delete"
+			s3ClientAPI.EXPECT().DeleteObject(&s3.DeleteObjectInput{
+				Bucket: aws.String(config.Get().BucketName),
+				Key:    aws.String(filePath),
+			}).Return(nil, nil)
+			err := storage.DeleteAWSFile(s3Client, filePath)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return error when aws delete object returns error with all attempts", func() {
+			filePath := "/test/file/to/delete"
+			expectedError := errors.New("expected error returned by aws s3 file deleter")
+			// important to expect that this should be called cleanupimages.DefaultDeleteAttempts times
+			s3ClientAPI.EXPECT().DeleteObject(
+				&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(filePath),
+				}).Return(nil, expectedError).Times(configDeleteAttempts)
+			err := storage.DeleteAWSFile(s3Client, filePath)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(expectedError))
+		})
+
+		It("should not return error after a successful delete object retry", func() {
+			filePath := "/test/file/to/delete"
+			expectedError := errors.New("expected error returned by aws s3 file deleter")
+			// expect that error was returned (cleanupimages.DefaultDeleteAttempts -1) times
+			s3ClientAPI.EXPECT().DeleteObject(
+				&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(filePath),
+				}).Return(nil, expectedError).Times(configDeleteAttempts - 1)
+			// expect that the latest allowed time was a successful delete
+			s3ClientAPI.EXPECT().DeleteObject(
+				&s3.DeleteObjectInput{
+					Bucket: aws.String(config.Get().BucketName),
+					Key:    aws.String(filePath),
+				}).Return(nil, nil).Times(1)
+			err := storage.DeleteAWSFile(s3Client, filePath)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
# Description
In the context of cleanup instance make some refactoring (**there is no new logic implemented**):
 - move the storage functions to their own standalone module "storage"
 - move the storage functions unit-tests to "storage" module"
 - add a unittest for "GetPathFromURL" 
 
 **This is a preparation work for cleanup devices module.** 
  
 FIXES: https://issues.redhat.com/browse/THEEDGE-3489


## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [X] Refactor

<!--

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

