### PR TITLE
cleanup: Cleanup content of soft deleted devices.

### DIFF
--- a/cmd/cleanup/cleanupdevices/cleanupdevices.go
+++ b/cmd/cleanup/cleanupdevices/cleanupdevices.go
@@ -1,0 +1,341 @@
+package cleanupdevices
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/redhatinsights/edge-api/cmd/cleanup/storage"
+
+	"github.com/redhatinsights/edge-api/pkg/db"
+	"github.com/redhatinsights/edge-api/pkg/models"
+	"github.com/redhatinsights/edge-api/pkg/services/files"
+	feature "github.com/redhatinsights/edge-api/unleash/features"
+
+	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+// ErrCleanupDevicesNotAvailable error returned when the cleanup devices feature flag is disabled
+var ErrCleanupDevicesNotAvailable = errors.New("cleanup devices is not available")
+
+// ErrDeviceNotCleanUpCandidate error returned when the device is not a cleanup candidate
+var ErrDeviceNotCleanUpCandidate = errors.New("device is not a cleanup candidate")
+
+// ErrCleanUpAllDevicesInterrupted error returned when an error is return from anu Device cleanup function
+var ErrCleanUpAllDevicesInterrupted = errors.New("cleanup all devices is interrupted")
+
+// ErrDeleteDeviceWithUpdateTransaction error returned when deleting a device that is linked to an update-transaction
+var ErrDeleteDeviceWithUpdateTransaction = errors.New("device with update-transaction cannot be deleted")
+
+// ErrUpdateTransactionIsNotDefined error retuned when update transaction is not defined
+var ErrUpdateTransactionIsNotDefined = errors.New("update transaction is not defined")
+
+// DefaultDataLimit the default data limit to use when collecting data
+var DefaultDataLimit = 100
+
+// DefaultMaxDataPageNumber the default data pages to handle as preventive way to enter an indefinite loop
+var DefaultMaxDataPageNumber = 3000
+
+// CandidateDevice the device cleanup candidate
+type CandidateDevice struct {
+	DeviceID        uint           `json:"device_id"`
+	DeviceDeletedAt gorm.DeletedAt `json:"device_deleted_at"`
+	UpdateID        *uint          `json:"update_id,omitempty"`
+	RepoID          *uint          `json:"repo_id,omitempty"`
+	RepoStatus      *string        `json:"repo_status,omitempty"`
+	RepoURL         *string        `json:"repo_url"`
+	CommitID        *uint          `json:"commit_id"`
+	ImageID         *uint          `json:"image_id"`
+	CommitRepoID    *uint          `json:"commit_repo_id"`
+}
+
+// IsDeviceCandidate to ensure the device is a candidate
+func IsDeviceCandidate(candidateDevice *CandidateDevice) error {
+	if deviceDeletedAtValue, err := candidateDevice.DeviceDeletedAt.Value(); err != nil {
+		return err
+	} else if deviceDeletedAtValue == nil {
+		return ErrDeviceNotCleanUpCandidate
+	}
+	return nil
+}
+
+func DeleteCommit(tx *gorm.DB, candidateDevice *CandidateDevice) error {
+	if err := IsDeviceCandidate(candidateDevice); err != nil {
+		return err
+	}
+
+	if candidateDevice.CommitID == nil {
+		// the commit does not exist for the candidate device record
+		// do nothing and do not return error
+		return nil
+	}
+
+	// delete commit only if it has no image
+	if candidateDevice.ImageID != nil {
+		// do nothing and do not return error
+		// this will be handled by cleanup-images when update-transaction will be deleted
+		return nil
+	}
+
+	// assume that the update transaction has already been deleted
+
+	// delete commit from updatetransaction_devices with commit_id
+	if err := tx.Exec("DELETE FROM updatetransaction_commits WHERE commit_id=?", *candidateDevice.CommitID).Error; err != nil {
+		return err
+	}
+
+	// delete commit_installed_packages with commit_id
+	if err := tx.Exec("DELETE FROM commit_installed_packages WHERE commit_id=?", *candidateDevice.CommitID).Error; err != nil {
+		return err
+	}
+
+	// delete commit with commit_id
+	if err := tx.Exec("DELETE FROM commits WHERE id=?", *candidateDevice.CommitID).Error; err != nil {
+		return err
+	}
+
+	if candidateDevice.CommitRepoID != nil {
+		// delete commit repo with commit_repo_id
+		// assume we are here because image_id is nil, which mean that the commit repo has been cleared by cleanup-images
+		if err := tx.Exec("DELETE FROM repos WHERE id=?", *candidateDevice.CommitRepoID).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func DeleteUpdateTransaction(candidateDevice *CandidateDevice) error {
+	if err := IsDeviceCandidate(candidateDevice); err != nil {
+		return err
+	}
+
+	if candidateDevice.UpdateID == nil {
+		return ErrUpdateTransactionIsNotDefined
+	}
+
+	logger := log.WithFields(log.Fields{
+		"device_id": candidateDevice.DeviceID,
+		"update_id": *candidateDevice.UpdateID,
+	})
+
+	logger.Debug("deleting update permanently")
+
+	err := db.DB.Transaction(func(tx *gorm.DB) error {
+		// delete update-transaction from updatetransaction_dispatchrecords with update_transaction_id
+		if err := tx.Exec("DELETE FROM updatetransaction_dispatchrecords WHERE update_transaction_id=?", *candidateDevice.UpdateID).Error; err != nil {
+			return err
+		}
+
+		// delete update-transaction from updatetransaction_devices with update_transaction_id
+		if err := tx.Exec("DELETE FROM updatetransaction_devices WHERE update_transaction_id=?", *candidateDevice.UpdateID).Error; err != nil {
+			return err
+		}
+
+		// delete update-transaction from updatetransaction_commits with update_transaction_id
+		if err := tx.Exec("DELETE FROM updatetransaction_commits WHERE update_transaction_id=?", *candidateDevice.UpdateID).Error; err != nil {
+			return err
+		}
+
+		// delete update-transaction with id
+		if err := tx.Unscoped().Where("id", *candidateDevice.UpdateID).Delete(&models.UpdateTransaction{}).Error; err != nil {
+			return err
+		}
+
+		// delete update-transaction repo
+		if candidateDevice.RepoID != nil {
+			if err := tx.Unscoped().Where("id", *candidateDevice.RepoID).Delete(&models.Repo{}).Error; err != nil {
+				return err
+			}
+		}
+
+		err := DeleteCommit(tx, candidateDevice)
+
+		return err
+	})
+
+	if err != nil {
+		logger.WithField("error", err.Error()).Error("error occurred while deleting update")
+	}
+
+	return err
+}
+
+func DeleteDevice(candidateDevice *CandidateDevice) error {
+	if err := IsDeviceCandidate(candidateDevice); err != nil {
+		return err
+	}
+
+	// delete device only when it has no update-transaction
+	if candidateDevice.UpdateID != nil {
+		return ErrDeleteDeviceWithUpdateTransaction
+	}
+
+	logger := log.WithField("device_id", candidateDevice.DeviceID)
+
+	logger.Debug("deleting device permanently")
+
+	err := db.DB.Transaction(func(tx *gorm.DB) error {
+		// delete device dispatch_records
+		if err := tx.Exec("DELETE FROM dispatch_records WHERE device_id=?", candidateDevice.DeviceID).Error; err != nil {
+			return err
+		}
+
+		// delete device from any device_groups_devices
+		if err := tx.Exec("DELETE FROM device_groups_devices WHERE device_id=?", candidateDevice.DeviceID).Error; err != nil {
+			return err
+		}
+
+		// delete device
+		err := tx.Unscoped().Where("id", candidateDevice.DeviceID).Delete(&models.Device{}).Error
+
+		return err
+	})
+
+	if err != nil {
+		logger.WithField("error", err.Error()).Error("error occurred while deleting device")
+	}
+
+	return err
+}
+
+func CleanUpUpdateTransaction(s3Client *files.S3Client, candidateDevice *CandidateDevice) error {
+	if err := IsDeviceCandidate(candidateDevice); err != nil {
+		return err
+	}
+
+	if candidateDevice.UpdateID == nil {
+		return ErrUpdateTransactionIsNotDefined
+	}
+
+	logger := log.WithFields(log.Fields{
+		"device_id": candidateDevice.DeviceID,
+		"update_id": *candidateDevice.UpdateID,
+	})
+
+	if candidateDevice.RepoID != nil && candidateDevice.RepoURL != nil &&
+		*candidateDevice.RepoURL != "" && strings.Contains(*candidateDevice.RepoURL, "/upd/") {
+		// this is an update repo and was build when updating a device
+		logger = logger.WithFields(log.Fields{
+			"repo_url": *candidateDevice.RepoURL,
+		})
+
+		urlPath, err := storage.GetPathFromURL(*candidateDevice.RepoURL)
+		if err != nil {
+			logger.WithField("error", err.Error()).Error("error occurred while getting resource path url")
+			return err
+		}
+		logger = logger.WithField("repo_url_path", urlPath)
+		logger.Debug("deleting repo directory")
+		err = storage.DeleteAWSFolder(s3Client, urlPath)
+		if err != nil {
+			logger.WithField("error", err.Error()).Error("error occurred while deleting repo directory")
+			return err
+		}
+		// clean url and update cleaned status
+		if err := db.DB.Model(&models.Repo{}).Where("id", candidateDevice.RepoID).
+			Updates(map[string]interface{}{"status": models.UpdateStatusStorageCleaned, "url": ""}).Error; err != nil {
+			logger.WithField("error", err.Error()).Error("error occurred while updating repo status to cleaned")
+			return err
+		}
+	}
+
+	if err := DeleteUpdateTransaction(candidateDevice); err != nil {
+		return nil
+	}
+	return nil
+}
+
+func CleanUpDevice(s3Client *files.S3Client, candidateDevice *CandidateDevice) error {
+	if err := IsDeviceCandidate(candidateDevice); err != nil {
+		return err
+	}
+	var err error
+	if candidateDevice.UpdateID != nil {
+		err = CleanUpUpdateTransaction(s3Client, candidateDevice)
+	} else {
+		// we will receive a device without update-transaction when all update-transactions has been cleaned/deleted
+		err = DeleteDevice(candidateDevice)
+	}
+	return err
+}
+
+// GetCandidateDevices returns the data set of devices cleanup candidates
+func GetCandidateDevices(gormDB *gorm.DB) ([]CandidateDevice, error) {
+	var candidateDevices []CandidateDevice
+
+	if err := gormDB.Debug().Table("devices").
+		Select(`devices.id AS device_id, devices.deleted_at AS device_deleted_at, update_transactions.id AS update_id, repos.id AS	repo_id,
+repos.status AS repo_status, repos.URL AS repo_url,	update_transactions.commit_id AS commit_id,	images.id AS image_id, commits.repo_id as commit_repo_id`).
+		Joins("LEFT JOIN updatetransaction_devices ON updatetransaction_devices.device_id = devices.id").
+		Joins("LEFT JOIN update_transactions ON update_transactions.id = updatetransaction_devices.update_transaction_id").
+		Joins("LEFT JOIN repos ON repos.id = update_transactions.repo_id").
+		Joins("LEFT JOIN images ON images.commit_id = update_transactions.commit_id").
+		Joins("LEFT JOIN commits ON commits.id = update_transactions.commit_id").
+		Where("devices.deleted_at IS NOT NULL").
+		Order("devices.id ASC").
+		Order("update_transactions.id ASC").
+		Limit(DefaultDataLimit).
+		Scan(&candidateDevices).Error; err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Error("error occurred when collecting devices candidate")
+	}
+
+	return candidateDevices, nil
+}
+
+func CleanupAllDevices(s3Client *files.S3Client, gormDB *gorm.DB) error {
+	if !feature.CleanUPDevices.IsEnabled() {
+		log.Warning("cleanup of devices feature flag is disabled")
+		return ErrCleanupDevicesNotAvailable
+	}
+	if gormDB == nil {
+		gormDB = db.DB
+	}
+
+	devicesUpdatesCount := 0
+	page := 0
+	for page < DefaultMaxDataPageNumber && feature.CleanUPDevices.IsEnabled() {
+		candidateDevices, err := GetCandidateDevices(gormDB)
+		if err != nil {
+			return err
+		}
+
+		if len(candidateDevices) == 0 {
+			break
+		}
+
+		// create a new channel for each iteration
+		errChan := make(chan error)
+
+		for _, deviceCandidate := range candidateDevices {
+			deviceCandidate := deviceCandidate
+			// handle all the page images candidates at once, by default 30
+			go func(resChan chan error) {
+				resChan <- CleanUpDevice(s3Client, &deviceCandidate)
+			}(errChan)
+		}
+
+		// wait for all results to be returned
+		errCount := 0
+		for range candidateDevices {
+			resError := <-errChan
+			if resError != nil {
+				// errors are logged in the related functions, at this stage need to know if there is an error, to break the loop
+				errCount++
+			}
+		}
+
+		close(errChan)
+
+		devicesUpdatesCount += len(candidateDevices)
+
+		// break on any error
+		if errCount > 0 {
+			log.WithFields(log.Fields{"devices_updates_count": devicesUpdatesCount, "errors_count": errCount}).Info("cleanup devices was interrupted because of cleanup errors")
+			return ErrCleanUpAllDevicesInterrupted
+		}
+		page++
+	}
+
+	log.WithField("devices_updates_count", devicesUpdatesCount).Info("cleanup devices finished")
+	return nil
+}

--- a/cmd/cleanup/cleanupdevices/cleanupdevices_suite_test.go
+++ b/cmd/cleanup/cleanupdevices/cleanupdevices_suite_test.go
@@ -1,0 +1,47 @@
+package cleanupdevices_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/db"
+	"github.com/redhatinsights/edge-api/pkg/models"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMigrate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	dbName := setupTestDB()
+	RunSpecs(t, "Cleanup devices storage Suite")
+	tearDownTestDB(dbName)
+}
+
+func setupTestDB() string {
+	config.Init()
+	config.Get().Debug = true
+	dbName := fmt.Sprintf("%d-cleanupdevices.db", time.Now().UnixNano())
+	config.Get().Database.Name = dbName
+	db.InitDB()
+	err := db.DB.AutoMigrate(
+		&models.Image{},
+		&models.Commit{},
+		&models.Installer{},
+		&models.Repo{},
+		&models.UpdateTransaction{},
+		&models.DispatchRecord{},
+		&models.Device{},
+	)
+	if err != nil {
+		panic(err)
+	}
+	return dbName
+}
+
+func tearDownTestDB(dbName string) {
+	_ = os.Remove(dbName)
+}

--- a/cmd/cleanup/cleanupdevices/cleanupdevices_test.go
+++ b/cmd/cleanup/cleanupdevices/cleanupdevices_test.go
@@ -1,0 +1,867 @@
+package cleanupdevices_test
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	"github.com/redhatinsights/edge-api/cmd/cleanup/cleanupdevices"
+
+	"github.com/redhatinsights/edge-api/cmd/cleanup/storage"
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/db"
+	"github.com/redhatinsights/edge-api/pkg/models"
+	"github.com/redhatinsights/edge-api/pkg/services/files"
+	"github.com/redhatinsights/edge-api/pkg/services/mock_files"
+	feature "github.com/redhatinsights/edge-api/unleash/features"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("Cleanup devices", func() {
+	var ctrl *gomock.Controller
+	var s3Client *files.S3Client
+	var s3ClientAPI *mock_files.MockS3ClientAPI
+	var s3FolderDeleter *mock_files.MockBatchFolderDeleterAPI
+
+	var initialTimeDuration time.Duration
+	var configDeleteAttempts int
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		s3ClientAPI = mock_files.NewMockS3ClientAPI(ctrl)
+		s3FolderDeleter = mock_files.NewMockBatchFolderDeleterAPI(ctrl)
+		s3Client = &files.S3Client{
+			Client:        s3ClientAPI,
+			FolderDeleter: s3FolderDeleter,
+		}
+
+		initialTimeDuration = storage.DefaultTimeDuration
+		storage.DefaultTimeDuration = 1 * time.Millisecond
+		configDeleteAttempts = int(config.Get().DeleteFilesAttempts)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+		storage.DefaultTimeDuration = initialTimeDuration
+	})
+
+	Context("IsDeviceCandidate", func() {
+
+		It("should return error when deleted_at is null ", func() {
+			deviceData := cleanupdevices.CandidateDevice{DeviceID: 128}
+			deviceDeletedAtValue, err := deviceData.DeviceDeletedAt.Value()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deviceDeletedAtValue).To(BeNil())
+
+			err = cleanupdevices.IsDeviceCandidate(&deviceData)
+			Expect(err).To(MatchError(cleanupdevices.ErrDeviceNotCleanUpCandidate))
+		})
+	})
+
+	When("Device not a candidate", func() {
+		var deviceData cleanupdevices.CandidateDevice
+
+		BeforeEach(func() {
+			deviceData = cleanupdevices.CandidateDevice{DeviceID: 128}
+		})
+
+		It("DeleteUpdateTransaction should return error", func() {
+			err := cleanupdevices.DeleteUpdateTransaction(&deviceData)
+			Expect(err).To(MatchError(cleanupdevices.ErrDeviceNotCleanUpCandidate))
+		})
+	})
+
+	Context("DeleteCommit", func() {
+		var orgID string
+		var installedPackages []models.InstalledPackage
+		var image models.Image
+		var commit models.Commit
+		var repo models.Repo
+		// orphan commit is a commit without image
+		var orphanCommit models.Commit
+
+		BeforeEach(func() {
+			// setup only once
+			if orgID == "" {
+				orgID = faker.UUIDHyphenated()
+
+				installedPackages = []models.InstalledPackage{
+					{Name: "git"},
+					{Name: "gcc"},
+				}
+				err := db.DB.Create(&installedPackages).Error
+				Expect(err).ToNot(HaveOccurred())
+				commit = models.Commit{OrgID: orgID}
+				image = models.Image{Name: faker.Name(), OrgID: orgID, Commit: &commit}
+				err = db.DB.Create(&image).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				repo = models.Repo{URL: faker.URL(), Status: models.ImageStatusPending}
+				err = db.DB.Create(&repo).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				orphanCommit = models.Commit{OrgID: orgID, InstalledPackages: installedPackages, Repo: &repo}
+				err = db.DB.Create(&orphanCommit).Error
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		It("should return error when device candidate is not valid", func() {
+			err := cleanupdevices.DeleteCommit(nil, &cleanupdevices.CandidateDevice{DeviceID: 125})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(cleanupdevices.ErrDeviceNotCleanUpCandidate))
+		})
+
+		It("device candidate without commit return no error ", func() {
+			err := cleanupdevices.DeleteCommit(nil, &cleanupdevices.CandidateDevice{
+				DeviceID: 125, DeviceDeletedAt: gorm.DeletedAt{Time: time.Now(), Valid: true},
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("commit with image is not deleted and return no error", func() {
+			err := cleanupdevices.DeleteCommit(nil, &cleanupdevices.CandidateDevice{
+				DeviceID:        125,
+				DeviceDeletedAt: gorm.DeletedAt{Time: time.Now(), Valid: true},
+				CommitID:        &commit.ID,
+				ImageID:         &image.ID,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			// refresh commit from database and ensure still exists
+			err = db.DB.First(&commit, commit.ID).Error
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("commit without image is deleted successfully", func() {
+			// ensure commits installed packages exists
+			var currentInstalledPackages models.CommitInstalledPackages
+			err := db.DB.Where("commit_id", orphanCommit.ID).First(&currentInstalledPackages).Error
+			Expect(err).ToNot(HaveOccurred())
+			err = cleanupdevices.DeleteCommit(db.DB, &cleanupdevices.CandidateDevice{
+				DeviceID:        125,
+				DeviceDeletedAt: gorm.DeletedAt{Time: time.Now(), Valid: true},
+				CommitID:        &orphanCommit.ID,
+				ImageID:         nil,
+				CommitRepoID:    &repo.ID,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			orphanCommitID := orphanCommit.ID
+			// refresh commit from database and ensure that the commit does not exit
+			err = db.DB.First(&orphanCommit, orphanCommitID).Error
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+			// ensure repo does not exits
+			err = db.DB.First(&repo, repo.ID).Error
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+			// ensure commits installed packages does exists
+			err = db.DB.Where("commit_id", orphanCommitID).First(&currentInstalledPackages).Error
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+		})
+	})
+
+	Context("DeleteUpdateTransaction", func() {
+
+		var orgID string
+		var updateTransaction models.UpdateTransaction
+		var dispatcherRecord models.DispatchRecord
+		var device models.Device
+		var commit models.Commit
+		var oldCommit models.Commit
+		var updateRepo models.Repo
+
+		BeforeEach(func() {
+			// setup only once
+			if orgID == "" {
+				orgID = faker.UUIDHyphenated()
+
+				commit = models.Commit{OrgID: orgID}
+				err := db.DB.Create(&commit).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				oldCommit = models.Commit{OrgID: orgID}
+				err = db.DB.Create(&oldCommit).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				device = models.Device{OrgID: orgID, UUID: faker.UUIDHyphenated()}
+				err = db.DB.Create(&device).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				dispatcherRecord = models.DispatchRecord{Device: &device, DeviceID: device.ID, PlaybookDispatcherID: faker.UUIDHyphenated()}
+				err = db.DB.Omit("Device").Create(&dispatcherRecord).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				updateRepo = models.Repo{URL: faker.URL(), Status: models.ImageStatusPending}
+				err = db.DB.Create(&updateRepo).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				updateTransaction = models.UpdateTransaction{
+					OrgID:           orgID,
+					Devices:         []models.Device{device},
+					DispatchRecords: []models.DispatchRecord{dispatcherRecord},
+					Commit:          &commit,
+					OldCommits:      []models.Commit{oldCommit},
+					Repo:            &updateRepo,
+				}
+
+				err = db.DB.Omit("Devices.*, DispatchRecords.Device").Create(&updateTransaction).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				// soft delete the device to make it a candidate
+				err = db.DB.Delete(&device, device.ID).Error
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		It("should return error when device candidate is not valid", func() {
+			err := cleanupdevices.DeleteUpdateTransaction(&cleanupdevices.CandidateDevice{DeviceID: 125})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(cleanupdevices.ErrDeviceNotCleanUpCandidate))
+		})
+
+		It("should return error when update-transaction is not defined", func() {
+			err := cleanupdevices.DeleteUpdateTransaction(&cleanupdevices.CandidateDevice{
+				DeviceID: 125, DeviceDeletedAt: gorm.DeletedAt{Time: time.Now(), Valid: true}, UpdateID: nil,
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(cleanupdevices.ErrUpdateTransactionIsNotDefined))
+		})
+
+		It("should delete update-transaction successfully", func() {
+			updateTransactionID := updateTransaction.ID
+			// ensure update transactions commits does exists
+			type UpdateTransactionCommit struct {
+				UpdateTransactionID uint `json:"update_transaction_id"`
+				CommitID            uint `json:"commit_id"`
+			}
+			var updateTransactionCommits []UpdateTransactionCommit
+			err := db.DB.Table("updatetransaction_commits").Select("update_transaction_id, commit_id").
+				Where("update_transaction_id = ?", updateTransactionID).Scan(&updateTransactionCommits).Error
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(updateTransactionCommits)).To(Equal(1))
+			Expect(updateTransactionCommits[0].CommitID).To(Equal(oldCommit.ID))
+
+			// ensure update-transaction devices does exist
+			type UpdateTransactionDevice struct {
+				UpdateTransactionID uint `json:"update_transaction_id"`
+				DeviceID            uint `json:"device_id"`
+			}
+			var updateTransactionDevices []UpdateTransactionDevice
+			err = db.DB.Table("updatetransaction_devices").Select("update_transaction_id, device_id").
+				Where("update_transaction_id = ?", updateTransactionID).Scan(&updateTransactionDevices).Error
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(updateTransactionDevices)).To(Equal(1))
+			Expect(updateTransactionDevices[0].DeviceID).To(Equal(device.ID))
+
+			// ensure update-transaction dispatcher-record does exit
+			type UpdateTransactionDispatcherRecord struct {
+				UpdateTransactionID uint `json:"update_transaction_id"`
+				DispatchRecordID    uint `json:"dispatch_record_id"`
+			}
+			var updateTransactionDispatcherRecords []UpdateTransactionDispatcherRecord
+			err = db.DB.Table("updatetransaction_dispatchrecords").Select("update_transaction_id, dispatch_record_id").
+				Where("update_transaction_id = ?", updateTransactionID).Scan(&updateTransactionDispatcherRecords).Error
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(updateTransactionDevices)).To(Equal(1))
+			Expect(updateTransactionDevices[0].DeviceID).To(Equal(dispatcherRecord.ID))
+
+			err = cleanupdevices.DeleteUpdateTransaction(&cleanupdevices.CandidateDevice{
+				DeviceID:        device.ID,
+				DeviceDeletedAt: device.DeletedAt,
+				UpdateID:        &updateTransaction.ID,
+				RepoID:          &updateRepo.ID,
+				CommitID:        &commit.ID,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			// ensure update transaction does not exist
+			err = db.DB.First(&updateTransaction, updateTransaction.ID).Error
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+
+			// ensure update-transaction repo does not exist
+			err = db.DB.First(&updateRepo, updateRepo.ID).Error
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+
+			// ensure commit record does not exist
+			err = db.DB.First(&commit, commit.ID).Error
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+
+			// ensure update transactions commits does not exists
+			updateTransactionCommits = nil // clear current value
+			err = db.DB.Table("updatetransaction_commits").Select("update_transaction_id, commit_id").
+				Where("update_transaction_id = ?", updateTransactionID).Scan(&updateTransactionCommits).Error
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(updateTransactionCommits)).To(Equal(0))
+
+			// ensure update-transaction devices does not exist
+			updateTransactionDevices = nil // clear current value
+			err = db.DB.Table("updatetransaction_devices").Select("update_transaction_id, device_id").
+				Where("update_transaction_id = ?", updateTransactionID).Scan(&updateTransactionDevices).Error
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(updateTransactionDevices)).To(Equal(0))
+
+			// ensure update-transaction dispatcher-record does not exit
+			updateTransactionDispatcherRecords = nil // clear current value
+			err = db.DB.Table("updatetransaction_dispatchrecords").Select("update_transaction_id, dispatch_record_id").
+				Where("update_transaction_id = ?", updateTransactionID).Scan(&updateTransactionDispatcherRecords).Error
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(updateTransactionDevices)).To(Equal(0))
+		})
+	})
+
+	Context("DeleteDevice", func() {
+		var orgID string
+		var dispatcherRecord models.DispatchRecord
+		var deviceGroup models.DeviceGroup
+		var device models.Device
+
+		BeforeEach(func() {
+			// setup only once
+			if orgID == "" {
+				orgID = faker.UUIDHyphenated()
+
+				device = models.Device{OrgID: orgID, UUID: faker.UUIDHyphenated()}
+				err := db.DB.Create(&device).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				deviceGroup = models.DeviceGroup{OrgID: orgID, Name: faker.Name(), Devices: []models.Device{device}}
+				err = db.DB.Omit("Devices.*").Create(&deviceGroup).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				dispatcherRecord = models.DispatchRecord{Device: &device, DeviceID: device.ID, PlaybookDispatcherID: faker.UUIDHyphenated()}
+				err = db.DB.Omit("Device").Create(&dispatcherRecord).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				// soft delete the device to make it a candidate
+				err = db.DB.Delete(&device, device.ID).Error
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		It("should return error when device candidate is not valid", func() {
+			err := cleanupdevices.DeleteUpdateTransaction(&cleanupdevices.CandidateDevice{DeviceID: 125})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(cleanupdevices.ErrDeviceNotCleanUpCandidate))
+		})
+
+		It("should return error when device is linked to update transaction", func() {
+			var updateID uint = 123
+			err := cleanupdevices.DeleteDevice(&cleanupdevices.CandidateDevice{
+				DeviceID: 125, DeviceDeletedAt: gorm.DeletedAt{Time: time.Now(), Valid: true}, UpdateID: &updateID,
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(cleanupdevices.ErrDeleteDeviceWithUpdateTransaction))
+		})
+
+		It("should delete device successfully", func() {
+			deviceID := device.ID
+			// ensure device does exists
+			err := db.DB.Unscoped().First(&device, deviceID).Error
+			Expect(err).ToNot(HaveOccurred())
+			// ensure dispatcher-record does exists
+			err = db.DB.Unscoped().First(&dispatcherRecord, dispatcherRecord.ID).Error
+			Expect(err).ToNot(HaveOccurred())
+			// ensure device-group device does exist
+			err = db.DB.Unscoped().Preload("Devices").First(&deviceGroup, deviceGroup.ID).Error
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(deviceGroup.Devices)).To(Equal(1))
+			Expect(deviceGroup.Devices[0].ID).To(Equal(deviceID))
+
+			err = cleanupdevices.DeleteDevice(&cleanupdevices.CandidateDevice{DeviceID: deviceID, DeviceDeletedAt: device.DeletedAt})
+			Expect(err).ToNot(HaveOccurred())
+
+			// ensure device does not exists
+			err = db.DB.Unscoped().First(&device, deviceID).Error
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+
+			// ensure dispatcher-record does not exists
+			err = db.DB.Unscoped().First(&dispatcherRecord, dispatcherRecord.ID).Error
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+
+			// ensure device-group device does not exist
+			err = db.DB.Unscoped().Preload("Devices").First(&deviceGroup, deviceGroup.ID).Error
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(deviceGroup.Devices)).To(Equal(0))
+		})
+	})
+
+	Context("CleanUpUpdateTransaction", func() {
+
+		It("should return error when device candidate is not valid", func() {
+			err := cleanupdevices.CleanUpUpdateTransaction(nil, &cleanupdevices.CandidateDevice{DeviceID: 125})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(cleanupdevices.ErrDeviceNotCleanUpCandidate))
+		})
+
+		It("should return error when update-transaction is undefined", func() {
+			err := cleanupdevices.CleanUpUpdateTransaction(
+				nil,
+				&cleanupdevices.CandidateDevice{DeviceID: 125, DeviceDeletedAt: gorm.DeletedAt{Time: time.Now(), Valid: true}},
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(cleanupdevices.ErrUpdateTransactionIsNotDefined))
+		})
+
+		When("repo is update repo", func() {
+			// a repo is an update repo when it has been built for the update-transaction and has "/upd/" as part of its url path
+			var orgID string
+			var updateTransaction models.UpdateTransaction
+			var device models.Device
+			var updateRepo models.Repo
+			var updateRepoPath string
+			var deviceCandidate *cleanupdevices.CandidateDevice
+
+			BeforeEach(func() {
+				// setup only once
+				if orgID == "" {
+					orgID = faker.UUIDHyphenated()
+
+					device = models.Device{OrgID: orgID, UUID: faker.UUIDHyphenated()}
+					err := db.DB.Create(&device).Error
+					Expect(err).ToNot(HaveOccurred())
+
+					// repo has "/upd/" as part of the path
+					updateRepoPath = "repo/path/upd/" + faker.UUIDHyphenated()
+					updateRepo = models.Repo{URL: "https://bucket.example.com/" + updateRepoPath, Status: models.ImageStatusPending}
+					err = db.DB.Create(&updateRepo).Error
+					Expect(err).ToNot(HaveOccurred())
+
+					updateTransaction = models.UpdateTransaction{
+						OrgID:   orgID,
+						Devices: []models.Device{device},
+						Repo:    &updateRepo,
+					}
+					err = db.DB.Omit("Devices.*").Create(&updateTransaction).Error
+					Expect(err).ToNot(HaveOccurred())
+
+					// soft delete the device to make it a candidate
+					err = db.DB.Delete(&device, device.ID).Error
+					Expect(err).ToNot(HaveOccurred())
+
+					deviceCandidates, err := cleanupdevices.GetCandidateDevices(db.DB.Where("devices.org_id = ?", orgID))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(len(deviceCandidates)).To(Equal(1))
+					deviceCandidate = &deviceCandidates[0]
+				}
+			})
+
+			It("deviceCandidate is correct", func() {
+				Expect(deviceCandidate.DeviceID).To(Equal(device.ID))
+				Expect(deviceCandidate.UpdateID).ToNot(BeNil())
+				Expect(*deviceCandidate.UpdateID).To(Equal(updateTransaction.ID))
+				Expect(deviceCandidate.RepoID).ToNot(BeNil())
+				Expect(*deviceCandidate.RepoID).To(Equal(updateRepo.ID))
+			})
+
+			It("should return error when delete folder fails", func() {
+				expectedError := errors.New("expected delete folder error")
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, updateRepoPath).Return(expectedError).Times(configDeleteAttempts)
+				err := cleanupdevices.CleanUpUpdateTransaction(s3Client, deviceCandidate)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(expectedError))
+			})
+
+			It("should cleanup update transaction successfully", func() {
+				// will succeed deleting folder on last attempts
+				alternateError := errors.New("some aws s3 error")
+				Expect(configDeleteAttempts > 1).To(BeTrue())
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, updateRepoPath).Return(alternateError).Times(configDeleteAttempts - 1)
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, updateRepoPath).Return(nil).Times(1)
+				err := cleanupdevices.CleanUpUpdateTransaction(s3Client, deviceCandidate)
+				Expect(err).ToNot(HaveOccurred())
+				// update transaction is deleted
+				err = db.DB.First(&updateTransaction, updateTransaction.ID).Error
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+
+				// update-transaction repo is deleted
+				err = db.DB.First(&updateRepo, updateRepo.ID).Error
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+			})
+		})
+
+		When("repo is commit repo", func() {
+			// a repo is a commit repo when it has been built for the image commit and has no "/upd/" in path url
+			var orgID string
+			var updateTransaction models.UpdateTransaction
+			var device models.Device
+			var updateRepo models.Repo
+			var updateRepoPath string
+			var deviceCandidate *cleanupdevices.CandidateDevice
+
+			BeforeEach(func() {
+				// setup only once
+				if orgID == "" {
+					orgID = faker.UUIDHyphenated()
+
+					device = models.Device{OrgID: orgID, UUID: faker.UUIDHyphenated()}
+					err := db.DB.Create(&device).Error
+					Expect(err).ToNot(HaveOccurred())
+
+					// repo has not "/upd/" as part of the path
+					updateRepoPath = "repo/path/" + faker.UUIDHyphenated()
+					updateRepo = models.Repo{URL: "https://bucket.example.com/" + updateRepoPath, Status: models.ImageStatusPending}
+					err = db.DB.Create(&updateRepo).Error
+					Expect(err).ToNot(HaveOccurred())
+
+					updateTransaction = models.UpdateTransaction{
+						OrgID:   orgID,
+						Devices: []models.Device{device},
+						Repo:    &updateRepo,
+					}
+					err = db.DB.Omit("Devices.*").Create(&updateTransaction).Error
+					Expect(err).ToNot(HaveOccurred())
+
+					// soft delete the device to make it a candidate
+					err = db.DB.Delete(&device, device.ID).Error
+					Expect(err).ToNot(HaveOccurred())
+
+					deviceCandidates, err := cleanupdevices.GetCandidateDevices(db.DB.Where("devices.org_id = ?", orgID))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(len(deviceCandidates)).To(Equal(1))
+					deviceCandidate = &deviceCandidates[0]
+				}
+			})
+
+			It("deviceCandidate is correct", func() {
+				Expect(deviceCandidate.DeviceID).To(Equal(device.ID))
+				Expect(deviceCandidate.UpdateID).ToNot(BeNil())
+				Expect(*deviceCandidate.UpdateID).To(Equal(updateTransaction.ID))
+				Expect(deviceCandidate.RepoID).ToNot(BeNil())
+				Expect(*deviceCandidate.RepoID).To(Equal(updateRepo.ID))
+			})
+
+			It("should cleanup update transaction successfully", func() {
+				// delete repo is not called
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, updateRepoPath).Return(nil).Times(0)
+				err := cleanupdevices.CleanUpUpdateTransaction(s3Client, deviceCandidate)
+				Expect(err).ToNot(HaveOccurred())
+				// update transaction is deleted
+				err = db.DB.First(&updateTransaction, updateTransaction.ID).Error
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+
+				// update-transaction repo is deleted
+				err = db.DB.First(&updateRepo, updateRepo.ID).Error
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+			})
+		})
+	})
+
+	Context("CleanUpDevice", func() {
+		var orgID string
+		var updateTransaction models.UpdateTransaction
+		var device models.Device
+		var device2 models.Device
+		var updateRepo models.Repo
+		var updateRepoPath string
+		var deviceCandidates []cleanupdevices.CandidateDevice
+
+		BeforeEach(func() {
+			// setup only once
+			if orgID == "" {
+				orgID = faker.UUIDHyphenated()
+
+				device = models.Device{OrgID: orgID, UUID: faker.UUIDHyphenated()}
+				err := db.DB.Create(&device).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				device2 = models.Device{OrgID: orgID, UUID: faker.UUIDHyphenated()}
+				err = db.DB.Create(&device2).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				// repo has "/upd/" as part of the path
+				updateRepoPath = "repo/path/upd/" + faker.UUIDHyphenated()
+				updateRepo = models.Repo{URL: "https://bucket.example.com/" + updateRepoPath, Status: models.ImageStatusPending}
+				err = db.DB.Create(&updateRepo).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				updateTransaction = models.UpdateTransaction{
+					OrgID:   orgID,
+					Devices: []models.Device{device},
+					Repo:    &updateRepo,
+				}
+				err = db.DB.Omit("Devices.*").Create(&updateTransaction).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				// soft delete the device to make it a candidate
+				err = db.DB.Delete(&device, device.ID).Error
+				Expect(err).ToNot(HaveOccurred())
+				// soft delete the device2 to make it a candidate
+				err = db.DB.Delete(&device2, device2.ID).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				deviceCandidates, err = cleanupdevices.GetCandidateDevices(db.DB.Where("devices.org_id = ?", orgID))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(deviceCandidates)).To(Equal(2))
+			}
+		})
+
+		It("should return error when device candidate is not valid", func() {
+			err := cleanupdevices.CleanUpDevice(nil, &cleanupdevices.CandidateDevice{DeviceID: 125})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(cleanupdevices.ErrDeviceNotCleanUpCandidate))
+		})
+
+		It("deviceCandidates data collection is correct", func() {
+			Expect(len(deviceCandidates)).To(Equal(2))
+			Expect(deviceCandidates[0].DeviceID).To(Equal(device.ID))
+			Expect(deviceCandidates[0].UpdateID).ToNot(BeNil())
+			Expect(*deviceCandidates[0].UpdateID).To(Equal(updateTransaction.ID))
+			Expect(deviceCandidates[0].RepoID).ToNot(BeNil())
+			Expect(*deviceCandidates[0].RepoID).To(Equal(updateRepo.ID))
+			Expect(deviceCandidates[0].RepoURL).ToNot(BeNil())
+			Expect(*deviceCandidates[0].RepoURL).To(Equal(updateRepo.URL))
+			Expect(deviceCandidates[1].DeviceID).To(Equal(device2.ID))
+			Expect(deviceCandidates[1].UpdateID).To(BeNil())
+		})
+
+		It("should return error when delete folder fails", func() {
+			expectedError := errors.New("expected delete folder error")
+			s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, updateRepoPath).Return(expectedError).Times(configDeleteAttempts)
+			err := cleanupdevices.CleanUpDevice(s3Client, &deviceCandidates[0])
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(expectedError))
+		})
+
+		It("should cleanup update transaction successfully", func() {
+			// delete repo is not called
+			s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, updateRepoPath).Return(nil).Times(1)
+			err := cleanupdevices.CleanUpDevice(s3Client, &deviceCandidates[0])
+			Expect(err).ToNot(HaveOccurred())
+			// update transaction is deleted
+			err = db.DB.First(&updateTransaction, updateTransaction.ID).Error
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+
+			// update-transaction repo is deleted
+			err = db.DB.First(&updateRepo, updateRepo.ID).Error
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+
+			// at this stage device is not deleted forever
+		})
+
+		It("should delete device2 successfully", func() {
+			err := cleanupdevices.CleanUpDevice(s3Client, &deviceCandidates[1])
+			Expect(err).ToNot(HaveOccurred())
+			// ensure device2 transaction is deleted
+			err = db.DB.First(&device2, device2.ID).Error
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+		})
+
+		It("device became a candidate after it's update-transaction was deleted", func() {
+			// device2 is not more a candidate as it was deleted forever
+			// device still a candidate but this time without update-transaction next call to ClearDevice should delete it forever as device2
+			deviceCandidates, err := cleanupdevices.GetCandidateDevices(db.DB.Where("devices.org_id = ?", orgID))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(deviceCandidates)).To(Equal(1))
+			Expect(deviceCandidates[0].DeviceID).To(Equal(device.ID))
+			Expect(deviceCandidates[0].UpdateID).To(BeNil())
+		})
+	})
+
+	When("feature flag is disabled", func() {
+
+		BeforeEach(func() {
+			err := os.Unsetenv(feature.CleanUPDevices.EnvVar)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not run cleanup devices", func() {
+			image := models.Image{Name: faker.UUIDHyphenated()}
+			Expect(image.DeletedAt.Value()).To(BeNil())
+			err := cleanupdevices.CleanupAllDevices(nil, nil)
+			Expect(err).To(MatchError(cleanupdevices.ErrCleanupDevicesNotAvailable))
+		})
+	})
+
+	When("feature flag is enabled", func() {
+		var orgID string
+		var image models.Image
+
+		var updateTransaction models.UpdateTransaction
+		var updateTransaction2 models.UpdateTransaction
+		var device models.Device
+		var device2 models.Device
+		var device3 models.Device
+		var undeletedDevice models.Device
+		// var updateRepo models.Repo
+		var updateRepoPath string
+		var updateRepoPath2 string
+
+		BeforeEach(func() {
+			err := os.Setenv(feature.CleanUPDevices.EnvVar, "true")
+			Expect(err).NotTo(HaveOccurred())
+
+			// setup only once
+			if orgID == "" {
+				orgID = faker.UUIDHyphenated()
+
+				image = models.Image{OrgID: orgID, Commit: &models.Commit{OrgID: orgID, Repo: &models.Repo{URL: faker.URL()}}}
+				err := db.DB.Create(&image).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				device = models.Device{OrgID: orgID, UUID: faker.UUIDHyphenated()}
+				err = db.DB.Create(&device).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				undeletedDevice = models.Device{OrgID: orgID, UUID: faker.UUIDHyphenated()}
+				err = db.DB.Create(&undeletedDevice).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				device2 = models.Device{OrgID: orgID, UUID: faker.UUIDHyphenated()}
+				err = db.DB.Create(&device2).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				device3 = models.Device{OrgID: orgID, UUID: faker.UUIDHyphenated()}
+				err = db.DB.Create(&device3).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				updateRepoPath = "repo/path/upd/" + faker.UUIDHyphenated()
+				// updateRepo = models.Repo{URL: "https://bucket.example.com/" + updateRepoPath, Status: models.ImageStatusPending}
+				// err = db.DB.Create(&updateRepo).Error
+				// Expect(err).ToNot(HaveOccurred())
+
+				updateTransaction = models.UpdateTransaction{
+					OrgID:    orgID,
+					CommitID: image.Commit.ID,
+					Commit:   image.Commit,
+					Devices:  []models.Device{device},
+					Repo:     &models.Repo{URL: "https://bucket.example.com/" + updateRepoPath, Status: models.ImageStatusPending},
+				}
+				err = db.DB.Omit("Devices.*").Create(&updateTransaction).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				updateRepoPath2 = "repo/path/upd/" + faker.UUIDHyphenated()
+				updateTransaction2 = models.UpdateTransaction{
+					OrgID:   orgID,
+					Commit:  &models.Commit{OrgID: orgID, Repo: &models.Repo{URL: faker.URL()}},
+					Devices: []models.Device{device2},
+					Repo:    &models.Repo{URL: "https://bucket.example.com/" + updateRepoPath2, Status: models.ImageStatusPending},
+				}
+				err = db.DB.Omit("Devices.*").Create(&updateTransaction2).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				// soft delete the devices to make them candidates
+				err = db.DB.Delete(&device, device.ID).Error
+				Expect(err).ToNot(HaveOccurred())
+				err = db.DB.Delete(&device2, device2.ID).Error
+				Expect(err).ToNot(HaveOccurred())
+				err = db.DB.Delete(&device3, device3.ID).Error
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		AfterEach(func() {
+			err := os.Unsetenv(feature.CleanUPDevices.EnvVar)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("GetCandidateDevices", func() {
+			It("should return the expected devices records", func() {
+				deviceCandidates, err := cleanupdevices.GetCandidateDevices(db.DB.Where("devices.org_id = ?", orgID))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(deviceCandidates).ToNot(BeNil())
+				Expect(len(deviceCandidates)).To(Equal(3))
+				Expect(deviceCandidates[0].DeviceID).To(Equal(device.ID))
+				Expect(deviceCandidates[0].DeviceDeletedAt.Time.Equal(device.DeletedAt.Time)).To(BeTrue())
+				Expect(*deviceCandidates[0].UpdateID).To(Equal(updateTransaction.ID))
+				Expect(*deviceCandidates[0].RepoID).To(Equal(updateTransaction.Repo.ID))
+				Expect(*deviceCandidates[0].RepoURL).To(Equal(updateTransaction.Repo.URL))
+				Expect(*deviceCandidates[0].CommitID).To(Equal(updateTransaction.CommitID))
+				Expect(*deviceCandidates[0].ImageID).To(Equal(image.ID))
+				Expect(*deviceCandidates[0].CommitRepoID).To(Equal(image.Commit.Repo.ID))
+
+				Expect(deviceCandidates[1].DeviceID).To(Equal(device2.ID))
+				Expect(deviceCandidates[1].DeviceDeletedAt.Time.Equal(device2.DeletedAt.Time)).To(BeTrue())
+				Expect(*deviceCandidates[1].UpdateID).To(Equal(updateTransaction2.ID))
+				Expect(*deviceCandidates[1].RepoID).To(Equal(updateTransaction2.Repo.ID))
+				Expect(*deviceCandidates[1].RepoURL).To(Equal(updateTransaction2.Repo.URL))
+				Expect(*deviceCandidates[1].CommitID).To(Equal(updateTransaction2.CommitID))
+				Expect(deviceCandidates[1].ImageID).To(BeNil())
+				Expect(*deviceCandidates[1].CommitRepoID).To(Equal(updateTransaction2.Commit.Repo.ID))
+
+				Expect(deviceCandidates[2].DeviceID).To(Equal(device3.ID))
+				Expect(deviceCandidates[2].DeviceDeletedAt.Time.Equal(device3.DeletedAt.Time)).To(BeTrue())
+				Expect(deviceCandidates[2].UpdateID).To(BeNil())
+				Expect(deviceCandidates[2].RepoID).To(BeNil())
+				Expect(deviceCandidates[2].RepoURL).To(BeNil())
+				Expect(deviceCandidates[2].CommitID).To(BeNil())
+				Expect(deviceCandidates[2].ImageID).To(BeNil())
+				Expect(deviceCandidates[2].CommitRepoID).To(BeNil())
+			})
+		})
+
+		Context("CleanupAllDevices", func() {
+			var initialDefaultDataLimit int
+			BeforeEach(func() {
+				initialDefaultDataLimit = cleanupdevices.DefaultDataLimit
+				cleanupdevices.DefaultDataLimit = 1
+			})
+
+			AfterEach(func() {
+				// restore DefaultDataLimit
+				cleanupdevices.DefaultDataLimit = initialDefaultDataLimit
+			})
+
+			It("should return error when folder delete failed", func() {
+				expectedError := errors.New("an expected folder delete error")
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, updateRepoPath).Return(expectedError).Times(configDeleteAttempts)
+				err := cleanupdevices.CleanupAllDevices(s3Client, db.DB.Where("devices.org_id = ?", orgID))
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(cleanupdevices.ErrCleanUpAllDevicesInterrupted))
+			})
+
+			It("cleanup devices successfully", func() {
+
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, updateRepoPath).Return(nil).Times(1)
+				s3FolderDeleter.EXPECT().Delete(config.Get().BucketName, updateRepoPath2).Return(nil).Times(1)
+
+				err := cleanupdevices.CleanupAllDevices(s3Client, db.DB.Where("devices.org_id = ?", orgID))
+				Expect(err).ToNot(HaveOccurred())
+				// device does not exist
+				err = db.DB.First(&device, device.ID).Error
+				Expect(err).To(HaveOccurred())
+				// device2 does not exist
+				err = db.DB.First(&device2, device2.ID).Error
+				Expect(err).To(HaveOccurred())
+				// device2 does not exist
+				err = db.DB.First(&device3, device3.ID).Error
+				Expect(err).To(HaveOccurred())
+
+				// updateTransaction does not exist
+				err = db.DB.First(&updateTransaction, updateTransaction.ID).Error
+				Expect(err).To(HaveOccurred())
+				// updateTransaction commit still exist (because has image)
+				err = db.DB.First(&updateTransaction.Commit, updateTransaction.Commit.ID).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				// updateTransaction2 does not exist
+				err = db.DB.First(&updateTransaction2, updateTransaction2.ID).Error
+				Expect(err).To(HaveOccurred())
+				// updateTransaction2 commit does not exist (because has no image)
+				err = db.DB.First(&updateTransaction2.Commit, updateTransaction2.Commit.ID).Error
+				Expect(err).To(HaveOccurred())
+
+				// undeletedDevice still exist (because not a candidate)
+				err = db.DB.First(&undeletedDevice, undeletedDevice.ID).Error
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+})

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/redhatinsights/edge-api/cmd/cleanup/cleanupdevices"
 	"github.com/redhatinsights/edge-api/cmd/cleanup/cleanupimages"
 	"github.com/redhatinsights/edge-api/config"
 	"github.com/redhatinsights/edge-api/logger"
@@ -63,7 +64,15 @@ func main() {
 
 	client := files.GetNewS3Client()
 
+	var mainErr error
+
 	if err := cleanupimages.CleanUpAllImages(client); err != nil {
-		flushLogAndExit(err)
+		mainErr = err
 	}
+
+	if err := cleanupdevices.CleanupAllDevices(client, db.DB); err != nil {
+		mainErr = err
+	}
+
+	flushLogAndExit(mainErr)
 }

--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -68,6 +68,9 @@ const (
 	UpdateStatusDeviceDisconnected = "DISCONNECTED"
 	// UpdateStatusDeviceUnresponsive is for when an update is UpdateStatusDeviceUnresponsive
 	UpdateStatusDeviceUnresponsive = "UNRESPONSIVE"
+	// UpdateStatusStorageCleaned is for when an update-transaction repo content has storage cleaned
+	// this happen when an update-transaction is going to be deleted forever
+	UpdateStatusStorageCleaned = "STORAGE_CLEANED"
 )
 
 const (

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -96,6 +96,9 @@ var PostMigrateDeleteCustomRepositories = &Flag{Name: "edge-management.post_migr
 // CleanUPImages is a feature flag to use for cleanup images
 var CleanUPImages = &Flag{Name: "edge-management.cleanup_images", EnvVar: "FEATURE_CLEANUP_IMAGES"}
 
+// CleanUPDevices is a feature flag to use for cleanup devices
+var CleanUPDevices = &Flag{Name: "edge-management.cleanup_devices", EnvVar: "FEATURE_CLEANUP_DEVICES"}
+
 // SkipUpdateRepo is a feature flag to skip the process of download and re-upload of update repositories
 var SkipUpdateRepo = &Flag{Name: "edgemanagement.skip_update_repo", EnvVar: "FEATURE_SKIP_UPDATE_REPO"}
 


### PR DESCRIPTION
# Description
In the context of the cleanup script implement cleanup-devices of soft deleted devices:
- cleanup aws s3 bucket update-transaction repo of soft deleted device.
- delete forever update-transaction.
- delete forever update-transaction commit if have no image linked (this mean that image has been cleared but because the commit was linked to update transaction, the commit was not deleted).
- delete forever device. 

FIXES: https://issues.redhat.com/browse/THEEDGE-3489


What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

