### PR TITLE
cleanup: increase memory and cpu limits.

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -393,11 +393,11 @@ objects:
               value: ${TENANT_TRANSLATOR_PORT}
           resources:
             limits:
+              cpu: 900m
+              memory: 1Gi
+            requests:
               cpu: 500m
               memory: 512Mi
-            requests:
-              cpu: 250m
-              memory: 256Mi
     objectStore:
     - ${EDGE_TARBALLS_BUCKET}
     database:


### PR DESCRIPTION
# Description
The cleanup script is reaching memory and cpu limits and the pod get killed. 
This is an attempt to resolve this behavior.

setup tested to work on ephemeral. 

FIXES: https://issues.redhat.com/browse/THEEDGE-3489

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

