### PR TITLE
cleanup: implement delete images.

### DIFF
--- a/cmd/cleanup/deleteimages/deleteimages.go
+++ b/cmd/cleanup/deleteimages/deleteimages.go
@@ -1,0 +1,77 @@
+package deleteimages
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/redhatinsights/edge-api/pkg/models"
+	feature "github.com/redhatinsights/edge-api/unleash/features"
+
+	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+// ErrDeleteImagesCleanUpNotAvailable error returned when the delete images clean up feature flag is disabled
+var ErrDeleteImagesCleanUpNotAvailable = errors.New("delete images cleanup is not available")
+
+// DeleteImagesOlderThan delete only the images that are older than this value in days, default value is 7 days
+var DeleteImagesOlderThan = 7 * 24 * time.Hour
+
+var ImagesWithNamesToKeep = []string{
+	"DL-",
+	"IQE-TEST-IMAGE-",
+	"PopcornOS",
+}
+
+// deleteOrphanImages soft delete images that have image-set soft deleted
+func deleteOrphanImages(gormDB *gorm.DB) error {
+
+	imagesCollection := gormDB.Select("images.id").
+		Joins("JOIN image_sets ON image_sets.id = images.image_set_id").
+		Where("images.deleted_at IS NULL AND image_sets.deleted_at IS NOT NULL").
+		Table("images")
+
+	result := gormDB.Debug().Where("images.id IN (?) ", imagesCollection).Delete(&models.Image{})
+	if result.Error != nil {
+		log.WithField("error", result.Error.Error()).Error("error occurred while deleting orphan images")
+		return result.Error
+	}
+	log.WithField("images-deleted", result.RowsAffected).Info("orphan images deleted successfully")
+	return nil
+}
+
+// deleteImages soft delete all images that are not in names to keep and older than one week
+func deleteImages(gormDB *gorm.DB) error {
+
+	imagesCollection := gormDB.Table("images").Select("images.id").
+		Joins("LEFT JOIN devices ON devices.image_id = images.id").
+		Where("images.deleted_at IS NULL AND devices.id IS NULL").
+		Where("images.updated_at < ? ", time.Now().Add(-DeleteImagesOlderThan))
+	// build images names to keep
+	for _, name := range ImagesWithNamesToKeep {
+		imagesCollection = imagesCollection.Where("upper(images.name) NOT LIKE ?", strings.ToUpper(name)+"%")
+	}
+
+	result := gormDB.Debug().Where("images.id IN (?)", imagesCollection).Delete(&models.Image{})
+	if result.Error != nil {
+		log.WithField("error", result.Error.Error()).Error("error occurred while deleting images")
+		return result.Error
+	}
+
+	log.WithField("images-deleted", result.RowsAffected).Info("images deleted successfully")
+	return nil
+}
+
+func DeleteAllImages(gormDB *gorm.DB) error {
+	if !feature.CleanUPDeleteImages.IsEnabled() {
+		log.Warning("flag is disabled for cleanup delete images feature")
+		return ErrDeleteImagesCleanUpNotAvailable
+	}
+
+	if err := deleteOrphanImages(gormDB); err != nil {
+		return err
+	}
+
+	return deleteImages(gormDB)
+}

--- a/cmd/cleanup/deleteimages/deleteimages_suite_test.go
+++ b/cmd/cleanup/deleteimages/deleteimages_suite_test.go
@@ -1,0 +1,43 @@
+package deleteimages_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/db"
+	"github.com/redhatinsights/edge-api/pkg/models"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMigrate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	dbName := setupTestDB()
+	RunSpecs(t, "Cleanup images storage Suite")
+	tearDownTestDB(dbName)
+}
+
+func setupTestDB() string {
+	config.Init()
+	config.Get().Debug = true
+	dbName := fmt.Sprintf("%d-cleanupimages.db", time.Now().UnixNano())
+	config.Get().Database.Name = dbName
+	db.InitDB()
+	err := db.DB.AutoMigrate(
+		&models.ImageSet{},
+		&models.Image{},
+		&models.Device{},
+	)
+	if err != nil {
+		panic(err)
+	}
+	return dbName
+}
+
+func tearDownTestDB(dbName string) {
+	_ = os.Remove(dbName)
+}

--- a/cmd/cleanup/deleteimages/deleteimages_test.go
+++ b/cmd/cleanup/deleteimages/deleteimages_test.go
@@ -1,0 +1,206 @@
+package deleteimages_test
+
+import (
+	"os"
+	"time"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/redhatinsights/edge-api/cmd/cleanup/deleteimages"
+	"github.com/redhatinsights/edge-api/pkg/db"
+	"github.com/redhatinsights/edge-api/pkg/models"
+	feature "github.com/redhatinsights/edge-api/unleash/features"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("Delete Images", func() {
+
+	Context("BuildImagesNamesToKeepQuery", func() {
+		var initialImagesWithNamesToKeep []string
+
+		BeforeEach(func() {
+			initialImagesWithNamesToKeep = deleteimages.ImagesWithNamesToKeep
+			deleteimages.ImagesWithNamesToKeep = []string{
+				faker.Name(),
+				faker.Name(),
+			}
+		})
+
+		AfterEach(func() {
+			deleteimages.ImagesWithNamesToKeep = initialImagesWithNamesToKeep
+		})
+
+	})
+
+	When("CleanUPDeleteImages feature flag is disabled", func() {
+
+		BeforeEach(func() {
+			err := os.Unsetenv(feature.CleanUPDeleteImages.EnvVar)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not run DeleteAllImages when feature flag is disabled", func() {
+			err := deleteimages.DeleteAllImages(nil)
+			Expect(err).To(MatchError(deleteimages.ErrDeleteImagesCleanUpNotAvailable))
+		})
+	})
+
+	When("CleanUPDeleteImages feature flag is enabled", func() {
+
+		var initialImagesWithNamesToKeep []string
+
+		BeforeEach(func() {
+			err := os.Setenv(feature.CleanUPDeleteImages.EnvVar, "true")
+			Expect(err).NotTo(HaveOccurred())
+
+			initialImagesWithNamesToKeep = deleteimages.ImagesWithNamesToKeep
+			deleteimages.ImagesWithNamesToKeep = []string{
+				faker.Name(),
+				faker.Name(),
+			}
+		})
+
+		AfterEach(func() {
+			err := os.Unsetenv(feature.CleanUPDeleteImages.EnvVar)
+			Expect(err).NotTo(HaveOccurred())
+			deleteimages.ImagesWithNamesToKeep = initialImagesWithNamesToKeep
+		})
+
+		Context("Delete Orphan images", func() {
+			var orgID string
+			var imageSet models.ImageSet
+			var image models.Image
+			var deletedImageSet models.ImageSet
+			var imageToDelete models.Image
+
+			BeforeEach(func() {
+				// setup only once
+				if orgID == "" {
+					orgID = faker.UUIDHyphenated()
+					imageSet = models.ImageSet{OrgID: orgID, Name: faker.Name()}
+					err := db.DB.Create(&imageSet).Error
+					Expect(err).ToNot(HaveOccurred())
+
+					image = models.Image{OrgID: orgID, Name: imageSet.Name, ImageSetID: &imageSet.ID}
+					err = db.DB.Create(&image).Error
+					Expect(err).ToNot(HaveOccurred())
+
+					deletedImageSet = models.ImageSet{OrgID: orgID, Name: faker.Name()}
+					err = db.DB.Create(&deletedImageSet).Error
+					Expect(err).ToNot(HaveOccurred())
+
+					imageToDelete = models.Image{OrgID: orgID, Name: deletedImageSet.Name, ImageSetID: &deletedImageSet.ID}
+					err = db.DB.Create(&imageToDelete).Error
+					Expect(err).ToNot(HaveOccurred())
+
+					// delete deletedimageset
+					err = db.DB.Delete(&deletedImageSet).Error
+					Expect(err).ToNot(HaveOccurred())
+				}
+			})
+
+			It("should run DeleteAllImages successfully", func() {
+				err := deleteimages.DeleteAllImages(db.DB.Where("images.org_id = ?", orgID).Session(&gorm.Session{}))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("imageToDelete should have been soft", func() {
+				err := db.DB.First(&imageToDelete).Error
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+
+				// ensure imageToDelete still exist in db
+				err = db.DB.Unscoped().First(&imageToDelete).Error
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("image should not have been affected", func() {
+				err := db.DB.First(&image).Error
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("Delete images", func() {
+			var orgID string
+			var device models.Device
+			// old image to keep , because a device is linked to it
+			var deviceImage models.Image
+			// old image that should be deleted
+			var oldImageToDelete models.Image
+			// old image to keep , because it's name is in the list to keep
+			var oldImageToKeep models.Image
+			// new image to keep even it's name is not in the list to keep
+			var newImageToKeep models.Image
+
+			var initialDeleteImagesOlderThan = deleteimages.DeleteImagesOlderThan
+
+			BeforeEach(func() {
+				// setup only once
+				if orgID == "" {
+					orgID = faker.UUIDHyphenated()
+					deviceImage = models.Image{OrgID: orgID, Name: faker.Name()}
+					err := db.DB.Create(&deviceImage).Error
+					Expect(err).ToNot(HaveOccurred())
+
+					device = models.Device{OrgID: orgID, ImageID: deviceImage.ID}
+					err = db.DB.Create(&device).Error
+					Expect(err).ToNot(HaveOccurred())
+
+					oldImageToDelete = models.Image{OrgID: orgID, Name: faker.Name()}
+					err = db.DB.Create(&oldImageToDelete).Error
+					Expect(err).ToNot(HaveOccurred())
+
+					oldImageToKeep = models.Image{OrgID: orgID, Name: deleteimages.ImagesWithNamesToKeep[0]}
+					err = db.DB.Create(&oldImageToKeep).Error
+					Expect(err).ToNot(HaveOccurred())
+
+					// create a new DeleteImagesOlderThan to speed up tests, as we cannot wait for 7 days
+					deleteimages.DeleteImagesOlderThan = 100 * time.Millisecond
+
+					// make time elapse for same amount to force consider the already created mages as old images
+					time.Sleep(deleteimages.DeleteImagesOlderThan + 10*time.Millisecond)
+
+					newImageToKeep = models.Image{OrgID: orgID, Name: faker.Name()}
+					err = db.DB.Create(&newImageToKeep).Error
+					Expect(err).ToNot(HaveOccurred())
+				}
+			})
+
+			AfterEach(func() {
+				deleteimages.DeleteImagesOlderThan = initialDeleteImagesOlderThan
+			})
+
+			It("should run DeleteAllImages successfully", func() {
+				err := deleteimages.DeleteAllImages(db.DB.Where("images.org_id = ?", orgID).Session(&gorm.Session{}))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should delete old images with name not in the list", func() {
+				err := db.DB.First(&oldImageToDelete).Error
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(gorm.ErrRecordNotFound))
+
+				// ensure record still in db
+				err = db.DB.Unscoped().First(&oldImageToDelete).Error
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should keep images with name in the list", func() {
+				err := db.DB.First(&oldImageToKeep).Error
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should keep images with linked devices", func() {
+				err := db.DB.First(&deviceImage).Error
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should keep new images", func() {
+				err := db.DB.First(&newImageToKeep).Error
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+})

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/redhatinsights/edge-api/cmd/cleanup/cleanupdevices"
 	"github.com/redhatinsights/edge-api/cmd/cleanup/cleanupimages"
 	"github.com/redhatinsights/edge-api/cmd/cleanup/cleanuporphancommits"
+	"github.com/redhatinsights/edge-api/cmd/cleanup/deleteimages"
 	"github.com/redhatinsights/edge-api/config"
 	"github.com/redhatinsights/edge-api/logger"
 	"github.com/redhatinsights/edge-api/pkg/db"
@@ -67,11 +68,18 @@ func main() {
 
 	var mainErr error
 
-	if err := cleanupimages.CleanUpAllImages(client); err != nil {
+	if err := deleteimages.DeleteAllImages(db.DB); err != nil &&
+		err != deleteimages.ErrDeleteImagesCleanUpNotAvailable {
 		mainErr = err
 	}
 
-	if err := cleanupdevices.CleanupAllDevices(client, db.DB); err != nil {
+	if err := cleanupimages.CleanUpAllImages(client); err != nil &&
+		err != cleanupimages.ErrImagesCleanUPNotAvailable {
+		mainErr = err
+	}
+
+	if err := cleanupdevices.CleanupAllDevices(client, db.DB); err != nil &&
+		err != cleanupdevices.ErrCleanupDevicesNotAvailable {
 		mainErr = err
 	}
 

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -96,6 +96,9 @@ var PostMigrateDeleteCustomRepositories = &Flag{Name: "edge-management.post_migr
 // CleanUPImages is a feature flag to use for cleanup images
 var CleanUPImages = &Flag{Name: "edge-management.cleanup_images", EnvVar: "FEATURE_CLEANUP_IMAGES"}
 
+// CleanUPDeleteImages is a feature flag to use for cleanup delete images
+var CleanUPDeleteImages = &Flag{Name: "edge-management.cleanup_delete_images", EnvVar: "FEATURE_CLEANUP_DELETE_IMAGES"}
+
 // CleanUPDevices is a feature flag to use for cleanup devices
 var CleanUPDevices = &Flag{Name: "edge-management.cleanup_devices", EnvVar: "FEATURE_CLEANUP_DEVICES"}
 


### PR DESCRIPTION
# Description
- implement delete images with the following conditions:
  - images names are not in the list
  - updated_at of images is older than one week
  - image is not linked to any device. 
- implement delete of orphan images (orphan images are images that has image-set already deleted) 
- updated the main function to not return error if one of the features is not available 

NOTES: 
- all images are soft deleted as described and tested in unittests. 
- Put it in do not merge , to allow updating the list to keep ImagesWithNamesToKeep.

FIXES:  https://issues.redhat.com/browse/THEEDGE-3490


## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

