### PR TITLE
linter: avoid Implicit memory aliasing

### DIFF
--- a/pkg/clients/repositories/clients_test.go
+++ b/pkg/clients/repositories/clients_test.go
@@ -188,6 +188,8 @@ func TestListRepositories(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		// avoid Implicit memory aliasing
+		testCase := testCase
 		t.Run(testCase.Name, func(t *testing.T) {
 			initialAPIRepositoriesPath := repositories.APIRepositoriesPath
 			// restore the initial apiRepositoriesPath and IOReadAll
@@ -501,6 +503,8 @@ func TestGetRepositoryByUUID(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		// avoid Implicit memory aliasing
+		testCase := testCase
 		t.Run(testCase.Name, func(t *testing.T) {
 			initialAPIRepositoriesPath := repositories.APIRepositoriesPath
 			// restore the initial apiRepositoriesPath and IOReadAll
@@ -659,6 +663,8 @@ func TestCreateRepository(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		// avoid Implicit memory aliasing
+		testCase := testCase
 		t.Run(testCase.Name, func(t *testing.T) {
 			initialAPIRepositoriesPath := repositories.APIRepositoriesPath
 			// restore the initial apiRepositoriesPath and IOReadAll
@@ -753,6 +759,8 @@ func TestSearchContentPackage(t *testing.T) {
 	mockRepositoriesService := mock_repositories.NewMockClientInterface(ctrl)
 
 	for _, testCase := range testCases {
+		// avoid Implicit memory aliasing
+		testCase := testCase
 		t.Run(testCase.Name, func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")

--- a/pkg/common/kafka/kafkaconfigmap_test.go
+++ b/pkg/common/kafka/kafkaconfigmap_test.go
@@ -260,6 +260,8 @@ func TestGetKafkaProducerConfigMapSecurityProtocol(t *testing.T) {
 
 	service = kafkacommon.NewKafkaConfigMapService()
 	for _, testCase := range testCases {
+		// avoid Implicit memory aliasing
+		testCase := testCase
 		t.Run(testCase.Name, func(t *testing.T) {
 			config.Get().KafkaBroker = &testCase.BrokerConfig
 
@@ -315,6 +317,8 @@ func TestGetKafkaProducerConfigMapCaCert(t *testing.T) {
 
 	service = kafkacommon.NewKafkaConfigMapService()
 	for _, testCase := range testCases {
+		// avoid Implicit memory aliasing
+		testCase := testCase
 		t.Run(testCase.Name, func(t *testing.T) {
 			config.Get().KafkaBroker = &testCase.BrokerConfig
 			config.Get().KafkaBrokerCaCertPath = testCase.BrokerConfigCaCertPath

--- a/pkg/routes/imagesets.go
+++ b/pkg/routes/imagesets.go
@@ -250,6 +250,8 @@ func ListAllImageSets(w http.ResponseWriter, r *http.Request) {
 		imgSet.ImageSetData.Version = img.Images[0].Version
 		imageSetIsoURLSetten := false
 		for _, i := range img.Images {
+			// avoid Implicit memory aliasing
+			i := i
 			if i.InstallerID != nil {
 				if i.Installer == nil {
 					result = db.DB.First(&i.Installer, &i.InstallerID)

--- a/pkg/routes/thirdpartyrepo.go
+++ b/pkg/routes/thirdpartyrepo.go
@@ -283,6 +283,8 @@ func GetAllContentSourcesRepositories(w http.ResponseWriter, r *http.Request) {
 
 	repos := make([]models.ThirdPartyRepo, 0, len(response.Data))
 	for ind, ContentSourcesRepo := range response.Data {
+		// avoid Implicit memory aliasing
+		ContentSourcesRepo := ContentSourcesRepo
 		// calculate the id to set , that will not have a conflict with the saved one on db,
 		// use an ID superior of any known one in the current context, add overall repos count so that we will not conflict with
 		// ids used on different pages even if we change pagination.Limit when changing pages


### PR DESCRIPTION
# Description

We are facing linter started complaining about the Implicit memory aliasing. This PR should Fix/avoid Implicit memory aliasing in the found places.

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

