### PR TITLE
cleanup: fixes constraint violations errors.

### DIFF
--- a/cmd/cleanup/cleanupimages/cleanupimages.go
+++ b/cmd/cleanup/cleanupimages/cleanupimages.go
@@ -192,6 +192,11 @@ func DeleteImage(candidateImage *CandidateImage) error {
 			return err
 		}
 
+		// delete commit from updatetransaction_commits with commit_id
+		if err := tx.Exec("DELETE FROM updatetransaction_commits WHERE commit_id=?", candidateImage.CommitID).Error; err != nil {
+			return err
+		}
+
 		// delete image
 		if err := tx.Unscoped().Where("id", candidateImage.ImageID).Delete(&models.Image{}).Error; err != nil {
 			return err

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -531,7 +531,7 @@ parameters:
 - name: LINT_ANNOTATION
   value: 'ignore-check.kube-linter.io/minimum-three-replicas'
 - name: CLEANUP_SCHEDULE
-  value: "0 0 * * 5"
+  value: "0 0 * * 6"
 - description: Whether to suspend the cleanup scheduled job.
   name: CLEANUP_SUSPEND
   required: false


### PR DESCRIPTION
# Description
This is related to some old data rules, and old columns not used any more
- fixes to delete update repo only if there is no other updates using it.
- fixes delete commit from updatetransaction_commits before delete (where there is no direct update-transaction).
- fixes orphan commits to take into consideration only those commits not linked to repos.commit_id feild that exist only in stage env, seems some old rules still reflected in stage data base.
- set scheduler to run on saturday 0 hour.


## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor


# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

