### PR TITLE
migration-groups: create inventory groups client.

### DIFF
--- a/pkg/clients/inventorygroups/client.go
+++ b/pkg/clients/inventorygroups/client.go
@@ -1,0 +1,356 @@
+package inventorygroups
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	url2 "net/url"
+	"strconv"
+
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/clients"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var ErrParsingURL = errors.New("error occurred while parsing raw url")
+
+var ErrGroupsRequestResponse = errors.New("inventory groups request error response")
+
+var ErrGroupNotFound = errors.New("inventory group not found")
+
+var ErrGroupNameIsMandatory = errors.New("inventory group name is mandatory")
+
+var ErrGroupUUIDIsMandatory = errors.New("inventory group uuid is mandatory")
+
+var ErrGroupHostsAreMandatory = errors.New("inventory group hosts are mandatory")
+
+// BasePath the inventory groups base path
+const BasePath = "api/inventory/v1/groups"
+
+// DefaultPerPage the default per page limit when listing inventory groups
+const DefaultPerPage = 50
+
+// IOReadAll The io body reader
+var IOReadAll = io.ReadAll
+
+// NewJSONEncoder  create a new json encoder
+var NewJSONEncoder = json.NewEncoder
+
+// Group the type representation returned from inventory groups endpoint
+type Group struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	OrgID     string `json:"org_id"`
+	HostCount int    `json:"host_count"`
+}
+
+// Response the result type returned when getting a list of inventory groups
+type Response struct {
+	Total   int     `json:"total"`
+	Count   int     `json:"count"`
+	Page    int     `json:"page"`
+	PerPage int     `json:"per_page"`
+	Results []Group `json:"results"`
+}
+
+// ListGroupsParams the parameters used for list request
+type ListGroupsParams struct {
+	Name     string
+	Page     int
+	PerPage  int
+	OrderBy  string
+	OrderHow string
+}
+
+type CreateGroup struct {
+	Name    string   `json:"name"`
+	HostIDS []string `json:"host_ids,omitempty"`
+}
+
+// ClientInterface is an Interface to make request to inventory Groups
+type ClientInterface interface {
+	GetBaseURL() (*url2.URL, error)
+	GetGroupByName(name string) (*Group, error)
+	GetGroupByUUID(groupUUID string) (*Group, error)
+	CreateGroup(groupName string) (*Group, error)
+	AddHostsToGroup(groupUUID string, hosts []string) (*Group, error)
+	ListGroups(requestParams ListGroupsParams) ([]Group, error)
+}
+
+// Client is the implementation of an ClientInterface
+type Client struct {
+	ctx context.Context
+	log *log.Entry
+}
+
+// InitClient initializes the client for Image Builder
+func InitClient(ctx context.Context, log *log.Entry) *Client {
+	return &Client{ctx: ctx, log: log}
+}
+
+// GetBaseURL return the base url of inventory groups
+func (c *Client) GetBaseURL() (*url2.URL, error) {
+	baseURL := config.Get().InventoryConfig.URL + "/" + BasePath
+	url, err := url2.Parse(baseURL)
+	if err != nil {
+		c.log.WithFields(log.Fields{"url": baseURL, "error": err.Error()}).Error("failed to parse inventory groups base url")
+		return nil, ErrParsingURL
+	}
+	return url, nil
+}
+
+func (c *Client) ListGroups(requestParams ListGroupsParams) (*Response, error) {
+	groupsURL, err := c.GetBaseURL()
+	if err != nil {
+		return nil, err
+	}
+
+	if requestParams.Page <= 0 {
+		requestParams.Page = 1
+	}
+	if requestParams.PerPage <= 0 {
+		requestParams.PerPage = DefaultPerPage
+	}
+
+	queryValues := groupsURL.Query()
+	if requestParams.Name != "" {
+		queryValues.Add("name", requestParams.Name)
+	}
+	if requestParams.OrderBy != "" {
+		queryValues.Add("order_by", requestParams.OrderBy)
+	}
+	if requestParams.OrderHow != "" {
+		queryValues.Add("order_how", requestParams.OrderHow)
+	}
+	queryValues.Add("per_page", strconv.Itoa(requestParams.PerPage))
+	queryValues.Add("page", strconv.Itoa(requestParams.Page))
+
+	// set queryValues to groups url
+	groupsURL.RawQuery = queryValues.Encode()
+	requestURL := groupsURL.String()
+
+	c.log.WithField("url", requestURL).Info("inventory groups request started")
+	req, _ := http.NewRequest(http.MethodGet, requestURL, nil)
+	req.Header.Add("Content-Type", "application/json")
+	headers := clients.GetOutgoingHeaders(c.ctx)
+	for key, value := range headers {
+		req.Header.Add(key, value)
+	}
+	client := clients.ConfigureClientWithTLS(&http.Client{})
+	res, err := client.Do(req)
+	if err != nil {
+		c.log.WithField("error", err.Error()).Error("inventory groups request error")
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	body, err := IOReadAll(res.Body)
+	if err != nil {
+		c.log.WithFields(log.Fields{"statusCode": res.StatusCode, "error": err.Error()}).Error("inventory groups response error")
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		c.log.WithFields(log.Fields{"statusCode": res.StatusCode, "responseBody": string(body)}).Error("inventory groups error response")
+		return nil, ErrGroupsRequestResponse
+	}
+
+	var response Response
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		c.log.WithFields(log.Fields{"error": err.Error(), "response-body": string(body)}).Error("error occurred when unmarshalling response body")
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) GetGroupByName(name string) (*Group, error) {
+	if name == "" {
+		c.log.Error("inventory group name is mandatory")
+		return nil, ErrGroupNameIsMandatory
+	}
+	response, err := c.ListGroups(ListGroupsParams{Name: name, PerPage: 1, Page: 1, OrderBy: "name", OrderHow: "ASC"})
+	if err != nil {
+		c.log.WithFields(log.Fields{"group-name": name, "error": err.Error()}).Error("failed when calling to ListGroups")
+		return nil, err
+	}
+	if len(response.Results) == 0 || response.Results[0].Name != name {
+		// return group not found when no group returned,
+		// or when the first found group has name different from the requested one.
+		c.log.WithFields(log.Fields{"group-name": name, "results-length": strconv.Itoa(len(response.Results))}).Error("group not found")
+		return nil, ErrGroupNotFound
+	}
+	return &response.Results[0], nil
+}
+
+func (c *Client) GetGroupByUUID(groupUUID string) (*Group, error) {
+	if groupUUID == "" {
+		c.log.Error("inventory group uuid is mandatory")
+		return nil, ErrGroupUUIDIsMandatory
+	}
+
+	groupsURL, err := c.GetBaseURL()
+	if err != nil {
+		return nil, err
+	}
+
+	requestURL := groupsURL.String() + "/" + groupUUID
+
+	c.log.WithField("url", requestURL).Info("inventory group request started")
+	req, _ := http.NewRequest(http.MethodGet, requestURL, nil)
+	req.Header.Add("Content-Type", "application/json")
+	headers := clients.GetOutgoingHeaders(c.ctx)
+	for key, value := range headers {
+		req.Header.Add(key, value)
+	}
+	client := clients.ConfigureClientWithTLS(&http.Client{})
+	res, err := client.Do(req)
+	if err != nil {
+		c.log.WithField("error", err.Error()).Error("inventory group request error")
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	body, err := IOReadAll(res.Body)
+	if err != nil {
+		c.log.WithFields(log.Fields{"statusCode": res.StatusCode, "error": err.Error()}).Error("inventory group response error")
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		c.log.WithFields(log.Fields{"statusCode": res.StatusCode, "responseBody": string(body)}).Error("inventory group error response")
+		return nil, ErrGroupsRequestResponse
+	}
+
+	var response Response
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		c.log.WithFields(log.Fields{"error": err.Error(), "response-body": string(body)}).Error("error occurred when unmarshalling response body")
+		return nil, err
+	}
+
+	if len(response.Results) == 0 {
+		c.log.WithField("group-uuid", groupUUID).Error("group not found")
+		return nil, ErrGroupNotFound
+	}
+
+	return &response.Results[0], nil
+}
+
+func (c *Client) CreateGroup(groupName string, hostIDS []string) (*Group, error) {
+	if groupName == "" {
+		c.log.Error("inventory group name is mandatory")
+		return nil, ErrGroupNameIsMandatory
+	}
+
+	groupsURL, err := c.GetBaseURL()
+	if err != nil {
+		return nil, err
+	}
+
+	payloadBuffer := new(bytes.Buffer)
+	if err := NewJSONEncoder(payloadBuffer).Encode(&CreateGroup{Name: groupName, HostIDS: hostIDS}); err != nil {
+		c.log.WithField("error", err.Error()).Error("error occurred while encoding create group")
+		return nil, err
+	}
+
+	requestURL := groupsURL.String()
+	c.log.WithField("url", requestURL).Info("inventory create group request started")
+
+	req, _ := http.NewRequest(http.MethodPost, requestURL, payloadBuffer)
+	req.Header.Add("Content-Type", "application/json")
+	headers := clients.GetOutgoingHeaders(c.ctx)
+	for key, value := range headers {
+		req.Header.Add(key, value)
+	}
+	client := clients.ConfigureClientWithTLS(&http.Client{})
+	res, err := client.Do(req)
+	if err != nil {
+		c.log.WithField("error", err.Error()).Error("inventory create group request error")
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	body, err := IOReadAll(res.Body)
+	if err != nil {
+		c.log.WithFields(log.Fields{"statusCode": res.StatusCode, "error": err.Error()}).Error("inventory create group response error")
+		return nil, err
+	}
+	if res.StatusCode != http.StatusCreated {
+		c.log.WithFields(log.Fields{"statusCode": res.StatusCode, "responseBody": string(body)}).Error("inventory create group error response")
+		return nil, ErrGroupsRequestResponse
+	}
+
+	var group Group
+	err = json.Unmarshal(body, &group)
+	if err != nil {
+		c.log.WithFields(log.Fields{"error": err.Error(), "response-body": string(body)}).Error("error occurred when unmarshalling response body")
+		return nil, err
+	}
+
+	return &group, nil
+}
+
+func (c *Client) AddHostsToGroup(groupUUID string, hosts []string) (*Group, error) {
+	if groupUUID == "" {
+		c.log.Error("inventory group uuid is mandatory")
+		return nil, ErrGroupUUIDIsMandatory
+	}
+
+	if len(hosts) == 0 {
+		c.log.Error("inventory group hosts are mandatory")
+		return nil, ErrGroupHostsAreMandatory
+
+	}
+
+	groupsURL, err := c.GetBaseURL()
+	if err != nil {
+		return nil, err
+	}
+
+	payloadBuffer := new(bytes.Buffer)
+	if err := NewJSONEncoder(payloadBuffer).Encode(&hosts); err != nil {
+		c.log.WithField("error", err.Error()).Error("error occurred while encoding group hosts")
+		return nil, err
+	}
+
+	requestURL := fmt.Sprintf("%s/%s/hosts", groupsURL.String(), groupUUID)
+	c.log.WithField("url", requestURL).Info("inventory add group hosts request started")
+
+	req, _ := http.NewRequest(http.MethodPost, requestURL, payloadBuffer)
+	req.Header.Add("Content-Type", "application/json")
+	headers := clients.GetOutgoingHeaders(c.ctx)
+	for key, value := range headers {
+		req.Header.Add(key, value)
+	}
+	client := clients.ConfigureClientWithTLS(&http.Client{})
+	res, err := client.Do(req)
+	if err != nil {
+		c.log.WithField("error", err.Error()).Error("inventory add group hosts request error")
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	body, err := IOReadAll(res.Body)
+	if err != nil {
+		c.log.WithFields(log.Fields{"statusCode": res.StatusCode, "error": err.Error()}).Error("inventory add group hosts response error")
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		c.log.WithFields(log.Fields{"statusCode": res.StatusCode, "responseBody": string(body)}).Error("inventory add group hosts error response")
+		return nil, ErrGroupsRequestResponse
+	}
+
+	var group Group
+	err = json.Unmarshal(body, &group)
+	if err != nil {
+		c.log.WithField("error", err.Error()).Error("error occurred when unmarshalling response body")
+		return nil, err
+	}
+
+	return &group, nil
+}

--- a/pkg/clients/inventorygroups/client_test.go
+++ b/pkg/clients/inventorygroups/client_test.go
@@ -1,0 +1,762 @@
+package inventorygroups_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/clients/inventorygroups"
+
+	"github.com/bxcodec/faker/v3"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetBaseURL(t *testing.T) {
+	initialInventoryURL := config.Get().InventoryConfig.URL
+	// restore the initial insights inventory url
+	defer func(inventoryURL string) {
+		config.Get().InventoryConfig.URL = inventoryURL
+	}(initialInventoryURL)
+
+	validInventoryHostURL := "http://insights-inventory:8000"
+	testCases := []struct {
+		Name            string
+		InventoryURL    string
+		ExpectedBaseURL string
+		ExpectedError   error
+	}{
+		{
+			Name:            "should return the expected url",
+			InventoryURL:    validInventoryHostURL,
+			ExpectedBaseURL: validInventoryHostURL + "/api/inventory/v1/groups",
+			ExpectedError:   nil,
+		},
+		{
+			Name:            "should return error when content-sources is un-parsable",
+			InventoryURL:    "\t",
+			ExpectedBaseURL: "",
+			ExpectedError:   inventorygroups.ErrParsingURL,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			config.Get().InventoryConfig.URL = testCase.InventoryURL
+			client := inventorygroups.InitClient(context.Background(), log.NewEntry(log.StandardLogger()))
+			assert.NotNil(t, client)
+			url, err := client.GetBaseURL()
+			if testCase.ExpectedError == nil {
+				assert.NoError(t, err)
+				assert.NotNil(t, url)
+				assert.Equal(t, testCase.ExpectedBaseURL, url.String())
+
+			} else {
+				assert.ErrorIs(t, err, testCase.ExpectedError)
+			}
+		})
+	}
+}
+
+func TestListGroups(t *testing.T) {
+	initialInventoryURL := config.Get().InventoryConfig.URL
+
+	// restore the initial variables
+	defer func(inventoryURL string) {
+		config.Get().InventoryConfig.URL = inventoryURL
+	}(initialInventoryURL)
+
+	groupName := faker.UUIDHyphenated()
+	defaultParams := inventorygroups.ListGroupsParams{Name: groupName, OrderBy: "name", OrderHow: "ASC"}
+
+	testCases := []struct {
+		Name              string
+		InventoryURL      string
+		IOReadAll         func(r io.Reader) ([]byte, error)
+		HTTPStatus        int
+		Response          inventorygroups.Response
+		ResponseText      string
+		Params            inventorygroups.ListGroupsParams
+		ExpectedError     error
+		ExpectedURLParams map[string]string
+	}{
+		{
+			Name:       "should return the expected groups",
+			HTTPStatus: http.StatusOK,
+			IOReadAll:  io.ReadAll,
+			Params:     defaultParams,
+			Response: inventorygroups.Response{
+				Results: []inventorygroups.Group{
+					{Name: groupName},
+				},
+				Page: 1, PerPage: inventorygroups.DefaultPerPage, Total: 1, Count: 1,
+			},
+			ExpectedError: nil,
+			ExpectedURLParams: map[string]string{
+				"per_page":  strconv.Itoa(inventorygroups.DefaultPerPage),
+				"page":      strconv.Itoa(1),
+				"order_by":  "name",
+				"order_how": "ASC",
+				"name":      groupName,
+			},
+		},
+		{
+			Name:          "should return error when http status is not 200",
+			HTTPStatus:    http.StatusBadRequest,
+			IOReadAll:     io.ReadAll,
+			Params:        defaultParams,
+			Response:      inventorygroups.Response{},
+			ExpectedError: inventorygroups.ErrGroupsRequestResponse,
+			ExpectedURLParams: map[string]string{
+				"per_page":  strconv.Itoa(inventorygroups.DefaultPerPage),
+				"page":      strconv.Itoa(1),
+				"order_by":  "name",
+				"order_how": "ASC",
+				"name":      groupName,
+			},
+		},
+		{
+			Name:          "should return error when parsing base url fails",
+			InventoryURL:  "\t",
+			IOReadAll:     io.ReadAll,
+			HTTPStatus:    http.StatusOK,
+			Params:        defaultParams,
+			Response:      inventorygroups.Response{},
+			ExpectedError: inventorygroups.ErrParsingURL,
+		},
+		{
+			Name:          "should return error when client Do fail",
+			InventoryURL:  "host-without-schema",
+			IOReadAll:     io.ReadAll,
+			HTTPStatus:    http.StatusOK,
+			Params:        defaultParams,
+			Response:      inventorygroups.Response{},
+			ExpectedError: errors.New("unsupported protocol scheme"),
+		},
+		{
+			Name:          "should return error when malformed json is returned",
+			HTTPStatus:    http.StatusOK,
+			IOReadAll:     io.ReadAll,
+			Params:        defaultParams,
+			ResponseText:  `{"data: {}}`,
+			ExpectedError: errors.New("unexpected end of JSON input"),
+		},
+		{
+			Name:       "should return error when body readAll fails",
+			HTTPStatus: http.StatusOK,
+			IOReadAll: func(r io.Reader) ([]byte, error) {
+				return nil, errors.New("expected error for when reading response body fails")
+			},
+			Params:        defaultParams,
+			Response:      inventorygroups.Response{},
+			ExpectedError: errors.New("expected error for when reading response body fails"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		// avoid Implicit memory aliasing
+		testCase := testCase
+		t.Run(testCase.Name, func(t *testing.T) {
+			// restore the initial variable
+			defer func() {
+				inventorygroups.IOReadAll = io.ReadAll
+				config.Get().InventoryConfig.URL = initialInventoryURL
+			}()
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				urlQueryValues := r.URL.Query()
+				for key, value := range testCase.ExpectedURLParams {
+					assert.Equal(t, value, urlQueryValues.Get(key))
+				}
+				if testCase.ResponseText != "" {
+					_, err := fmt.Fprint(w, testCase.ResponseText)
+					assert.NoError(t, err)
+					return
+				}
+				w.WriteHeader(testCase.HTTPStatus)
+				err := json.NewEncoder(w).Encode(&testCase.Response)
+				assert.NoError(t, err)
+			}))
+			defer ts.Close()
+
+			inventorygroups.IOReadAll = testCase.IOReadAll
+			if testCase.InventoryURL == "" {
+				config.Get().InventoryConfig.URL = ts.URL
+			} else {
+				config.Get().InventoryConfig.URL = testCase.InventoryURL
+			}
+
+			client := inventorygroups.InitClient(context.Background(), log.NewEntry(log.StandardLogger()))
+			assert.NotNil(t, client)
+
+			response, err := client.ListGroups(testCase.Params)
+			if testCase.ExpectedError == nil {
+				assert.NoError(t, err)
+				assert.Equal(t, response.Results, testCase.Response.Results)
+				assert.Equal(t, response.Count, testCase.Response.Count)
+				assert.Equal(t, response.Total, testCase.Response.Total)
+				assert.Equal(t, response.Page, testCase.Response.Page)
+				assert.Equal(t, response.PerPage, testCase.Response.PerPage)
+			} else {
+				assert.ErrorContains(t, err, testCase.ExpectedError.Error())
+			}
+		})
+	}
+}
+
+func TestGetGroupByName(t *testing.T) {
+	initialInventoryURL := config.Get().InventoryConfig.URL
+	// restore the initial content sources url
+	defer func(inventoryURL string) {
+		config.Get().InventoryConfig.URL = inventoryURL
+	}(initialInventoryURL)
+	groupName := faker.UUIDHyphenated()
+	testCases := []struct {
+		Name              string
+		HTTPStatus        int
+		groupName         string
+		Group             *inventorygroups.Group
+		ExpectedURLParams map[string]string
+		ExpectedError     error
+	}{
+		{
+			Name:              "should return group successfully",
+			groupName:         groupName,
+			Group:             &inventorygroups.Group{Name: groupName},
+			HTTPStatus:        http.StatusOK,
+			ExpectedURLParams: map[string]string{"page": strconv.Itoa(1), "per_page": strconv.Itoa(1), "name": groupName},
+			ExpectedError:     nil,
+		},
+		{
+			Name:              "should return error when group not found",
+			groupName:         groupName,
+			Group:             nil,
+			HTTPStatus:        http.StatusOK,
+			ExpectedURLParams: map[string]string{"page": strconv.Itoa(1), "per_page": strconv.Itoa(1), "name": groupName},
+			ExpectedError:     inventorygroups.ErrGroupNotFound,
+		},
+		{
+			Name:              "should return error when the group found has a different name",
+			groupName:         groupName,
+			Group:             &inventorygroups.Group{Name: groupName + faker.UUIDHyphenated()},
+			HTTPStatus:        http.StatusOK,
+			ExpectedURLParams: map[string]string{"page": strconv.Itoa(1), "per_page": strconv.Itoa(1), "name": groupName},
+			ExpectedError:     inventorygroups.ErrGroupNotFound,
+		},
+		{
+			Name:          "should return error when group name is empty",
+			groupName:     "",
+			ExpectedError: inventorygroups.ErrGroupNameIsMandatory,
+		},
+		{
+			Name:          "should return error when ListGroups fails",
+			groupName:     groupName,
+			HTTPStatus:    http.StatusBadRequest,
+			ExpectedError: inventorygroups.ErrGroupsRequestResponse,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				urlQueryValues := r.URL.Query()
+				for key, value := range testCase.ExpectedURLParams {
+					assert.Equal(t, value, urlQueryValues.Get(key))
+				}
+				w.WriteHeader(testCase.HTTPStatus)
+				response := inventorygroups.Response{Results: []inventorygroups.Group{}}
+				if testCase.Group != nil {
+					response.Results = append(response.Results, *testCase.Group)
+				}
+				err := json.NewEncoder(w).Encode(&response)
+				assert.NoError(t, err)
+			}))
+			defer ts.Close()
+			config.Get().InventoryConfig.URL = ts.URL
+
+			client := inventorygroups.InitClient(context.Background(), log.NewEntry(log.StandardLogger()))
+			assert.NotNil(t, client)
+
+			group, err := client.GetGroupByName(testCase.groupName)
+			if testCase.ExpectedError == nil {
+				assert.NoError(t, err)
+				assert.NotNil(t, group)
+				assert.NotNil(t, testCase.Group)
+				assert.Equal(t, *testCase.Group, *group)
+			} else {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, testCase.ExpectedError)
+			}
+		})
+	}
+}
+
+func TestGetGroupByUUID(t *testing.T) {
+	initialInventoryURL := config.Get().InventoryConfig.URL
+
+	// restore the initial inventory url
+	defer func(inventoryURL string) {
+		config.Get().InventoryConfig.URL = inventoryURL
+	}(initialInventoryURL)
+
+	groupUUID := faker.UUIDHyphenated()
+	group := inventorygroups.Group{Name: faker.UUIDHyphenated(), ID: groupUUID}
+
+	testCases := []struct {
+		Name          string
+		InventoryURL  string
+		UUID          string
+		IOReadAll     func(r io.Reader) ([]byte, error)
+		HTTPStatus    int
+		Response      *inventorygroups.Response
+		ResponseText  string
+		ExpectedError error
+	}{
+		{
+			Name:          "should return the expected group",
+			UUID:          groupUUID,
+			HTTPStatus:    http.StatusOK,
+			IOReadAll:     io.ReadAll,
+			Response:      &inventorygroups.Response{Results: []inventorygroups.Group{group}},
+			ExpectedError: nil,
+		},
+		{
+			Name:          "should return ErrGroupNotFound when response result is empty",
+			UUID:          groupUUID,
+			HTTPStatus:    http.StatusOK,
+			IOReadAll:     io.ReadAll,
+			Response:      &inventorygroups.Response{},
+			ExpectedError: inventorygroups.ErrGroupNotFound,
+		},
+		{
+			Name:          "should return error when http status is not 200",
+			UUID:          groupUUID,
+			HTTPStatus:    http.StatusBadRequest,
+			IOReadAll:     io.ReadAll,
+			ExpectedError: inventorygroups.ErrGroupsRequestResponse,
+		},
+		{
+			Name:          "should return error when parsing base url fails",
+			UUID:          groupUUID,
+			InventoryURL:  "\t",
+			IOReadAll:     io.ReadAll,
+			HTTPStatus:    http.StatusOK,
+			ExpectedError: inventorygroups.ErrParsingURL,
+		},
+		{
+			Name:          "should return error when client Do fail",
+			UUID:          groupUUID,
+			InventoryURL:  "host-without-schema",
+			IOReadAll:     io.ReadAll,
+			HTTPStatus:    http.StatusOK,
+			ExpectedError: errors.New("unsupported protocol scheme"),
+		},
+		{
+			Name:          "should return error when malformed json is returned",
+			UUID:          groupUUID,
+			HTTPStatus:    http.StatusOK,
+			IOReadAll:     io.ReadAll,
+			ResponseText:  `{"data: {}}`,
+			ExpectedError: errors.New("unexpected end of JSON input"),
+		},
+		{
+			Name:       "should return error when body readAll fails",
+			UUID:       groupUUID,
+			HTTPStatus: http.StatusOK,
+			IOReadAll: func(r io.Reader) ([]byte, error) {
+				return nil, errors.New("expected error for when reading response body fails")
+			},
+			Response:      nil,
+			ExpectedError: errors.New("expected error for when reading response body fails"),
+		},
+		{
+			Name:          "should return error when uuid is empty",
+			UUID:          "",
+			ExpectedError: inventorygroups.ErrGroupUUIDIsMandatory,
+		},
+	}
+
+	for _, testCase := range testCases {
+		// avoid Implicit memory aliasing
+		testCase := testCase
+		t.Run(testCase.Name, func(t *testing.T) {
+			// restore the initial IOReadAll
+			defer func() {
+				inventorygroups.IOReadAll = io.ReadAll
+			}()
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(testCase.HTTPStatus)
+				if testCase.ResponseText != "" {
+					_, err := fmt.Fprint(w, testCase.ResponseText)
+					assert.NoError(t, err)
+					return
+				}
+				if testCase.Response != nil {
+					err := json.NewEncoder(w).Encode(&testCase.Response)
+					assert.NoError(t, err)
+				}
+			}))
+			defer ts.Close()
+
+			inventorygroups.IOReadAll = testCase.IOReadAll
+			if testCase.InventoryURL == "" {
+				config.Get().InventoryConfig.URL = ts.URL
+			} else {
+				config.Get().InventoryConfig.URL = testCase.InventoryURL
+			}
+
+			client := inventorygroups.InitClient(context.Background(), log.NewEntry(log.StandardLogger()))
+			assert.NotNil(t, client)
+
+			response, err := client.GetGroupByUUID(testCase.UUID)
+			if testCase.ExpectedError == nil {
+				assert.NoError(t, err)
+				assert.NotNil(t, response)
+				assert.Equal(t, *response, testCase.Response.Results[0])
+			} else {
+				assert.ErrorContains(t, err, testCase.ExpectedError.Error())
+			}
+		})
+	}
+}
+
+// ErrFaultyWriter the error returned by FaultWriter's Write function
+var ErrFaultyWriter = errors.New("faulty writer expected write error")
+
+// FaultyWriter a struct that implement a Writer that return always error when writing
+type FaultyWriter struct{}
+
+func (f *FaultyWriter) Write(_ []byte) (n int, err error) {
+	return 0, ErrFaultyWriter
+}
+
+func TestCreateGroup(t *testing.T) {
+	initialInventoryURL := config.Get().InventoryConfig.URL
+
+	// restore the initial inventory url
+	defer func(inventoryURL string) {
+		config.Get().InventoryConfig.URL = inventoryURL
+	}(initialInventoryURL)
+
+	groupNameToCreate := faker.UUIDHyphenated()
+	groupHostIDS := []string{faker.UUIDHyphenated(), faker.UUIDHyphenated()}
+	responseGroup := inventorygroups.Group{
+		Name: groupNameToCreate, ID: faker.UUIDHyphenated(), OrgID: faker.UUIDHyphenated(), HostCount: len(groupHostIDS),
+	}
+
+	testCases := []struct {
+		Name              string
+		InventoryURL      string
+		GroupNameToCreate string
+		GroupHostsToAdd   []string
+		IOReadAll         func(r io.Reader) ([]byte, error)
+		NewJSONEncoder    func(w io.Writer) *json.Encoder
+		HTTPStatus        int
+		Response          *inventorygroups.Group
+		ResponseText      string
+		ExpectedError     error
+	}{
+		{
+			Name:              "should create group successfully",
+			GroupNameToCreate: groupNameToCreate,
+			GroupHostsToAdd:   groupHostIDS,
+			HTTPStatus:        http.StatusCreated,
+			IOReadAll:         io.ReadAll,
+			NewJSONEncoder:    json.NewEncoder,
+			Response:          &responseGroup,
+			ExpectedError:     nil,
+		},
+		{
+			Name:              "should return error when group name is empty",
+			GroupNameToCreate: "",
+			HTTPStatus:        http.StatusCreated,
+			IOReadAll:         io.ReadAll,
+			NewJSONEncoder:    json.NewEncoder,
+			ExpectedError:     inventorygroups.ErrGroupNameIsMandatory,
+		},
+		{
+			Name:              "should return error when http status is not 201",
+			GroupNameToCreate: groupNameToCreate,
+			HTTPStatus:        http.StatusBadRequest,
+			IOReadAll:         io.ReadAll,
+			NewJSONEncoder:    json.NewEncoder,
+			ExpectedError:     inventorygroups.ErrGroupsRequestResponse,
+		},
+		{
+			Name:              "should return error when parsing base url fails",
+			GroupNameToCreate: groupNameToCreate,
+			InventoryURL:      "\t",
+			IOReadAll:         io.ReadAll,
+			NewJSONEncoder:    json.NewEncoder,
+			HTTPStatus:        http.StatusCreated,
+			ExpectedError:     inventorygroups.ErrParsingURL,
+		},
+		{
+			Name:              "should return error when client Do fail",
+			GroupNameToCreate: groupNameToCreate,
+			InventoryURL:      "host-without-schema",
+			IOReadAll:         io.ReadAll,
+			NewJSONEncoder:    json.NewEncoder,
+			HTTPStatus:        http.StatusCreated,
+			ExpectedError:     errors.New("unsupported protocol scheme"),
+		},
+		{
+			Name:              "should return error when malformed json is returned",
+			GroupNameToCreate: groupNameToCreate,
+			HTTPStatus:        http.StatusCreated,
+			IOReadAll:         io.ReadAll,
+			NewJSONEncoder:    json.NewEncoder,
+			ResponseText:      `{"data: {}}`,
+			ExpectedError:     errors.New("unexpected end of JSON input"),
+		},
+		{
+			Name:              "should return error when body readAll fails",
+			GroupNameToCreate: groupNameToCreate,
+			HTTPStatus:        http.StatusCreated,
+			IOReadAll: func(r io.Reader) ([]byte, error) {
+				return nil, errors.New("expected error for when reading response body fails")
+			},
+			NewJSONEncoder: json.NewEncoder,
+			Response:       nil,
+			ExpectedError:  errors.New("expected error for when reading response body fails"),
+		},
+		{
+			Name:              "should return error when payload json encode fails",
+			GroupNameToCreate: groupNameToCreate,
+			IOReadAll:         io.ReadAll,
+			NewJSONEncoder: func(_ io.Writer) *json.Encoder {
+				// ignore any argument and return the FaultyWriter, that returns error when calling its Write function
+				return json.NewEncoder(&FaultyWriter{})
+			},
+			ExpectedError: ErrFaultyWriter,
+		},
+	}
+
+	for _, testCase := range testCases {
+		// avoid Implicit memory aliasing
+		testCase := testCase
+		t.Run(testCase.Name, func(t *testing.T) {
+			// restore the initial IOReadAll and NewJSONEncoder
+			defer func() {
+				inventorygroups.IOReadAll = io.ReadAll
+				inventorygroups.NewJSONEncoder = json.NewEncoder
+			}()
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(testCase.HTTPStatus)
+				if testCase.ResponseText != "" {
+					_, err := fmt.Fprint(w, testCase.ResponseText)
+					assert.NoError(t, err)
+					return
+				}
+				if testCase.Response != nil {
+					err := json.NewEncoder(w).Encode(&testCase.Response)
+					assert.NoError(t, err)
+				}
+			}))
+			defer ts.Close()
+
+			inventorygroups.IOReadAll = testCase.IOReadAll
+			inventorygroups.NewJSONEncoder = testCase.NewJSONEncoder
+
+			if testCase.InventoryURL == "" {
+				config.Get().InventoryConfig.URL = ts.URL
+			} else {
+				config.Get().InventoryConfig.URL = testCase.InventoryURL
+			}
+
+			client := inventorygroups.InitClient(context.Background(), log.NewEntry(log.StandardLogger()))
+			assert.NotNil(t, client)
+
+			response, err := client.CreateGroup(testCase.GroupNameToCreate, testCase.GroupHostsToAdd)
+			if testCase.ExpectedError == nil {
+				assert.NoError(t, err)
+				assert.NotNil(t, response)
+				assert.NotNil(t, testCase.Response)
+				assert.Equal(t, *response, *testCase.Response)
+			} else {
+				assert.ErrorContains(t, err, testCase.ExpectedError.Error())
+			}
+		})
+	}
+}
+
+func TestAddHostsToGroup(t *testing.T) {
+	initialInventoryURL := config.Get().InventoryConfig.URL
+
+	// restore the initial inventory url
+	defer func(inventoryURL string) {
+		config.Get().InventoryConfig.URL = inventoryURL
+	}(initialInventoryURL)
+
+	groupUUID := faker.UUIDHyphenated()
+	hostsToAdd := []string{faker.UUIDHyphenated(), faker.UUIDHyphenated()}
+	responseGroup := inventorygroups.Group{
+		Name: faker.UUIDHyphenated(), ID: groupUUID, OrgID: faker.UUIDHyphenated(), HostCount: len(hostsToAdd),
+	}
+
+	testCases := []struct {
+		Name           string
+		InventoryURL   string
+		GroupUUID      string
+		HostsToAdd     []string
+		IOReadAll      func(r io.Reader) ([]byte, error)
+		NewJSONEncoder func(w io.Writer) *json.Encoder
+		HTTPStatus     int
+		Response       *inventorygroups.Group
+		ResponseText   string
+		ExpectedError  error
+	}{
+		{
+			Name:           "should add hosts to group successfully",
+			GroupUUID:      groupUUID,
+			HostsToAdd:     hostsToAdd,
+			HTTPStatus:     http.StatusOK,
+			IOReadAll:      io.ReadAll,
+			NewJSONEncoder: json.NewEncoder,
+			Response:       &responseGroup,
+			ExpectedError:  nil,
+		},
+		{
+			Name:           "should return error when group uuid is empty",
+			GroupUUID:      "",
+			HostsToAdd:     hostsToAdd,
+			HTTPStatus:     http.StatusOK,
+			IOReadAll:      io.ReadAll,
+			NewJSONEncoder: json.NewEncoder,
+			ExpectedError:  inventorygroups.ErrGroupUUIDIsMandatory,
+		},
+		{
+			Name:           "should return error when no hosts supplied",
+			GroupUUID:      groupUUID,
+			HostsToAdd:     []string{},
+			HTTPStatus:     http.StatusOK,
+			IOReadAll:      io.ReadAll,
+			NewJSONEncoder: json.NewEncoder,
+			ExpectedError:  inventorygroups.ErrGroupHostsAreMandatory,
+		},
+		{
+			Name:           "should return error when http status is not 200",
+			GroupUUID:      groupUUID,
+			HostsToAdd:     hostsToAdd,
+			HTTPStatus:     http.StatusBadRequest,
+			IOReadAll:      io.ReadAll,
+			NewJSONEncoder: json.NewEncoder,
+			ExpectedError:  inventorygroups.ErrGroupsRequestResponse,
+		},
+		{
+			Name:           "should return error when parsing base url fails",
+			GroupUUID:      groupUUID,
+			HostsToAdd:     hostsToAdd,
+			InventoryURL:   "\t",
+			IOReadAll:      io.ReadAll,
+			NewJSONEncoder: json.NewEncoder,
+			HTTPStatus:     http.StatusOK,
+			ExpectedError:  inventorygroups.ErrParsingURL,
+		},
+		{
+			Name:           "should return error when client Do fail",
+			GroupUUID:      groupUUID,
+			HostsToAdd:     hostsToAdd,
+			InventoryURL:   "host-without-schema",
+			IOReadAll:      io.ReadAll,
+			NewJSONEncoder: json.NewEncoder,
+			HTTPStatus:     http.StatusOK,
+			ExpectedError:  errors.New("unsupported protocol scheme"),
+		},
+		{
+			Name:           "should return error when malformed json is returned",
+			GroupUUID:      groupUUID,
+			HostsToAdd:     hostsToAdd,
+			HTTPStatus:     http.StatusOK,
+			IOReadAll:      io.ReadAll,
+			NewJSONEncoder: json.NewEncoder,
+			ResponseText:   `{"data: {}}`,
+			ExpectedError:  errors.New("unexpected end of JSON input"),
+		},
+		{
+			Name:       "should return error when body readAll fails",
+			GroupUUID:  groupUUID,
+			HostsToAdd: hostsToAdd,
+			HTTPStatus: http.StatusOK,
+			IOReadAll: func(r io.Reader) ([]byte, error) {
+				return nil, errors.New("expected error for when reading response body fails")
+			},
+			NewJSONEncoder: json.NewEncoder,
+			Response:       nil,
+			ExpectedError:  errors.New("expected error for when reading response body fails"),
+		},
+		{
+			Name:       "should return error when payload json encode fails",
+			GroupUUID:  groupUUID,
+			HostsToAdd: hostsToAdd,
+			IOReadAll:  io.ReadAll,
+			NewJSONEncoder: func(_ io.Writer) *json.Encoder {
+				// ignore any argument and return the FaultyWriter, that returns error when calling its Write function
+				return json.NewEncoder(&FaultyWriter{})
+			},
+			ExpectedError: ErrFaultyWriter,
+		},
+	}
+
+	for _, testCase := range testCases {
+		// avoid Implicit memory aliasing
+		testCase := testCase
+		t.Run(testCase.Name, func(t *testing.T) {
+			// restore the initial IOReadAll and NewJSONEncoder
+			defer func() {
+				inventorygroups.IOReadAll = io.ReadAll
+				inventorygroups.NewJSONEncoder = json.NewEncoder
+			}()
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(testCase.HTTPStatus)
+				if testCase.ResponseText != "" {
+					_, err := fmt.Fprint(w, testCase.ResponseText)
+					assert.NoError(t, err)
+					return
+				}
+				if testCase.Response != nil {
+					err := json.NewEncoder(w).Encode(&testCase.Response)
+					assert.NoError(t, err)
+				}
+			}))
+			defer ts.Close()
+
+			inventorygroups.IOReadAll = testCase.IOReadAll
+			inventorygroups.NewJSONEncoder = testCase.NewJSONEncoder
+
+			if testCase.InventoryURL == "" {
+				config.Get().InventoryConfig.URL = ts.URL
+			} else {
+				config.Get().InventoryConfig.URL = testCase.InventoryURL
+			}
+
+			client := inventorygroups.InitClient(context.Background(), log.NewEntry(log.StandardLogger()))
+			assert.NotNil(t, client)
+
+			response, err := client.AddHostsToGroup(testCase.GroupUUID, testCase.HostsToAdd)
+			if testCase.ExpectedError == nil {
+				assert.NoError(t, err)
+				assert.NotNil(t, response)
+				assert.NotNil(t, testCase.Response)
+				assert.Equal(t, *response, *testCase.Response)
+			} else {
+				assert.ErrorContains(t, err, testCase.ExpectedError.Error())
+			}
+		})
+	}
+}

--- a/pkg/models/devicegroups.go
+++ b/pkg/models/devicegroups.go
@@ -21,6 +21,7 @@ type DeviceGroup struct {
 	Type        string   `json:"Type" gorm:"default:static;<-:create"`
 	Devices     []Device `faker:"-" json:"Devices" gorm:"many2many:device_groups_devices;"`
 	ValidUpdate bool     `json:"ValidUpdate" gorm:"-:all"`
+	UUID        string   `json:"uuid,omitempty" gorm:"index"`
 }
 
 // DeviceGroupListDetail is a record of Edge Devices Groups with images and status information


### PR DESCRIPTION
# Description
 - create inventory groups client
 - add uuid to devices groups models that will correspond to inventory group id, that way we will be aware about the already migrated groups, and choose only those without uuid for migration, also that will create a link between local groups and inventory groups for later hosts adding (as hosts are added by group uuid).

 FIXES: https://issues.redhat.com/browse/THEEDGE-3553

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

