### PR TITLE
migrate-repos: FIXES migrate repos by adding OrgAdmin to user.

### DIFF
--- a/cmd/migraterepos/migraterepos/migraterepos.go
+++ b/cmd/migraterepos/migraterepos/migraterepos.go
@@ -22,7 +22,12 @@ import (
 
 func newOrgContentSourcesClient(orgID string) (repositories.ClientInterface, error) {
 	// create a new content-sources client and set organization identity in the initialization context
-	ident := identity.XRHID{Identity: identity.Identity{OrgID: orgID, Type: "User", Internal: identity.Internal{OrgID: orgID}}}
+	ident := identity.XRHID{Identity: identity.Identity{
+		OrgID:    orgID,
+		Type:     "User",
+		Internal: identity.Internal{OrgID: orgID},
+		User:     identity.User{OrgAdmin: true, Username: "edge-repo-migrator"},
+	}}
 	jsonIdent, err := json.Marshal(&ident)
 	if err != nil {
 		return nil, err

--- a/cmd/migraterepos/migraterepos/migraterepos_test.go
+++ b/cmd/migraterepos/migraterepos/migraterepos_test.go
@@ -72,6 +72,8 @@ var _ = Describe("Migrate custom repositories", func() {
 			ts := httptest.NewServer(dependencies.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				rhIndent, err := common.GetIdentityInstanceFromContext(r.Context())
 				Expect(err).ToNot(HaveOccurred())
+				// ensure identity user OrgAdmin is true
+				Expect(rhIndent.Identity.User.OrgAdmin).To(BeTrue())
 				w.Header().Set("Content-Type", "application/json")
 				var repo models.ThirdPartyRepo
 				switch r.Method {


### PR DESCRIPTION
# Description
OrgAdmin set to true should fix rbac permission failure. 

FIXES: https://issues.redhat.com/browse/THEEDGE-3523


## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

