### PR TITLE
Add the ginkgolinter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-go@v4
         name: Set up Go 1.x
         with:
-          go-version: 1.18
+          go-version-file: go.mod
 
       - uses: actions/checkout@v3
         name: Checkout edge-api
@@ -38,7 +38,6 @@ jobs:
           # Args should be the same as Makefile
           # Workaround from https://github.com/golangci/golangci-lint-action/issues/119
           args: >
-            --enable=errcheck,gocritic,gofmt,goimports,gosec,gosimple,govet,ineffassign,revive,staticcheck,typecheck,unused,bodyclose
             --fix=false
             --max-same-issues=20
             --out-${NO_FUTURE}format=colored-line-number
@@ -74,7 +73,7 @@ jobs:
       - uses: actions/setup-go@v4
         name: Set up Go 1.x
         with:
-          go-version: 1.18
+          go-version-file: go.mod
 
       - uses: actions/checkout@v3
         name: Checkout edge-api

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+linters:
+  enable:
+  - errcheck
+  - ginkgolinter
+  - gocritic
+  - gofmt
+  - goimports
+  - gosec
+  - gosimple
+  - govet
+  - ineffassign
+  - revive
+  - staticcheck
+  - typecheck
+  - unused
+  - bodyclose
+linters-settings:
+  ginkgolinter:
+    forbid-focus-container: true


### PR DESCRIPTION
The ginkgolinter is a linter that forces some coding standards and prevents some issue when using ginkgo and gomega. See more details in https://github.com/nunnatsa/ginkgolinter.

In addition, some of the golangci-lint moved from the the github action configuration to the .golangci.yml file, so it will be possible to run the same set of linter locally, as in the github action.

And finally, replaced the `go-version` configuration in the github action (the go setup step), with the `go-version-file: go.mod` so the go setup will retrieve the go version from the mod file, and will be up-to-date when bumping golang version.

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
