### PR TITLE
image-builder-client: Fixes repository gpgkey json representation.

### DIFF
--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -75,7 +75,7 @@ type Customizations struct {
 type Repository struct {
 	BaseURL    string  `json:"baseurl"`
 	CheckGPG   *bool   `json:"check_gpg,omitempty"`
-	GPGKey     *string `json:"gpg_key,omitempty"`
+	GPGKey     *string `json:"gpgkey,omitempty"`
 	IgnoreSSL  *bool   `json:"ignore_ssl,omitempty"`
 	MetaLink   *string `json:"metalink,omitempty"`
 	MirrorList *string `json:"mirrorlist,omitempty"`

--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -381,6 +381,7 @@ var _ = Describe("Image Builder Client Test", func() {
 			body, err := io.ReadAll(r.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).ToNot(BeNil())
+			Expect(string(body)).To(ContainSubstring(`"gpgkey":"some dummy data"`))
 			err = json.Unmarshal(body, &composeRequest)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(composeRequest.Customizations).ToNot(BeNil())


### PR DESCRIPTION
# Description
 Change the image-builder client repository gpgkey json representation to match image-builder schema.

FIXES: https://issues.redhat.com/browse/THEEDGE-3549

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

