### PR TITLE
add feature flag to block the api request

### DIFF
--- a/pkg/routes/devicegroups.go
+++ b/pkg/routes/devicegroups.go
@@ -321,7 +321,11 @@ func GetAllDeviceGroups(w http.ResponseWriter, r *http.Request) {
 func CreateDeviceGroup(w http.ResponseWriter, r *http.Request) {
 	ctxServices := dependencies.ServicesFromContext(r.Context())
 
-	if feature.CreateGroup.IsEnabled() {
+	if feature.HideCreateGroup.IsEnabled() {
+		w.WriteHeader(http.StatusUnauthorized)
+		respondWithJSONBody(w, ctxServices.Log, nil)
+		return
+	} else {
 		deviceGroup, err := createDeviceRequest(w, r)
 		if err != nil {
 			return
@@ -345,9 +349,6 @@ func CreateDeviceGroup(w http.ResponseWriter, r *http.Request) {
 
 		w.WriteHeader(http.StatusOK)
 		respondWithJSONBody(w, ctxServices.Log, &deviceGroup)
-	} else {
-		w.WriteHeader(http.StatusUnauthorized)
-		respondWithJSONBody(w, ctxServices.Log, feature.CreateGroup.IsEnabled())
 	}
 }
 

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -120,6 +120,9 @@ var StaticDeltaShortCircuit = &Flag{Name: "edge-management.static_delta_shortcir
 // StaticDeltaGenerate toggles creation of static deltas
 var StaticDeltaGenerate = &Flag{Name: "edge-management.static_delta_generate", EnvVar: "FEATURE_STATIC_DELTA_GENERATE"}
 
+// CreateGroup toggles creation of static deltas
+var CreateGroup = &Flag{Name: "edgeParity.create-group", EnvVar: "FEATURE_EDGE_PARITY_CREATE_GROUP"}
+
 // DB LOGGING FLAGS
 
 // SilentGormLogging toggles noisy logging from Gorm (using for tests during development on slow machines/connections

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -121,7 +121,7 @@ var StaticDeltaShortCircuit = &Flag{Name: "edge-management.static_delta_shortcir
 var StaticDeltaGenerate = &Flag{Name: "edge-management.static_delta_generate", EnvVar: "FEATURE_STATIC_DELTA_GENERATE"}
 
 // CreateGroup toggles creation of static deltas
-var CreateGroup = &Flag{Name: "edgeParity.create-group", EnvVar: "FEATURE_EDGE_PARITY_CREATE_GROUP"}
+var HideCreateGroup = &Flag{Name: "edge-management.hide-create-group", EnvVar: "FEATURE_HIDE_CREATE_GROUP"}
 
 // DB LOGGING FLAGS
 


### PR DESCRIPTION
# Description
Enable use of feature flag to hide the option to create edge-groups and avoid data leak during the migration execution

Fixes # (THEEDGE-3576)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
