### PR TITLE
devices-view: return inventory groups with devices.

### DIFF
--- a/pkg/models/devices.go
+++ b/pkg/models/devices.go
@@ -58,6 +58,8 @@ type DeviceView struct {
 	DeviceGroups     []DeviceDeviceGroup `json:"DeviceGroups"`
 	DispatcherStatus string              `json:"DispatcherStatus"`
 	DispatcherReason string              `json:"DispatcherReason"`
+	GroupName        string              `json:"GroupName"` // the inventory group name
+	GroupUUID        string              `json:"GroupUUID"` // the inventory group id
 }
 
 // DeviceDeviceGroup is a struct of device group name and id needed for DeviceView
@@ -97,6 +99,8 @@ type Device struct {
 	UpdateAvailable   bool                 `json:"UpdateAvailable"`
 	DevicesGroups     []DeviceGroup        `faker:"-" gorm:"many2many:device_groups_devices;save_association:false" json:"DevicesGroups"`
 	UpdateTransaction *[]UpdateTransaction `faker:"-" gorm:"many2many:updatetransaction_devices;" json:"UpdateTransaction"`
+	GroupName         string               `json:"group_name"` // the inventory group name
+	GroupUUID         string               `json:"group_uuid"` // the inventory group id
 }
 
 // BeforeCreate method is called before creating devices, it make sure org_id is not empty


### PR DESCRIPTION
# Description

- Catch the inventory device group via created/updated system event
- Save the main information (id and name) in device record
- return the inventory group in devices-view to be displayed. 
 
insights events doc: [created_event](https://consoledot.pages.redhat.com/docs/dev/services/inventory.html#_created_event),  [updated_event](https://consoledot.pages.redhat.com/docs/dev/services/inventory.html#_updated_event)
FIXES: https://issues.redhat.com/browse/THEEDGE-3580


## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor


# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

