### PR TITLE
add wait for ready to static delta process

### DIFF
--- a/pkg/models/staticdelta.go
+++ b/pkg/models/staticdelta.go
@@ -38,8 +38,17 @@ type StaticDeltaState struct {
 
 // values for the StaticDeltaState Status field
 const (
+	// StaticDeltaStatusDownloading represents the to and from commits are being downloaded
+	StaticDeltaStatusDownloading = "DOWNLOADING"
+
 	// StaticDeltaStatusError represents there has been an error in the process
 	StaticDeltaStatusError = "ERROR"
+
+	// StaticDeltaStatusFailedPrereq skips the static delta and uses existing to_commit URL
+	StaticDeltaStatusFailedPrereq = "FAILEDPREREQ"
+
+	// StaticDeltaStatusForceGenerate is a feature flag override to force static delta generation
+	StaticDeltaStatusForceGenerate = "FORCE"
 
 	// StaticDeltaStatusGenerating represents static delta generation is in process
 	StaticDeltaStatusGenerating = "GENERATING"

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -105,17 +105,13 @@ var CleanUPDevices = &Flag{Name: "edge-management.cleanup_devices", EnvVar: "FEA
 // CleanUPOrphanCommits is a feature flag to use for cleanup orphan commits
 var CleanUPOrphanCommits = &Flag{Name: "edge-management.cleanup_orphan_commits", EnvVar: "FEATURE_CLEANUP_ORPHAN_COMMITS"}
 
+// STATIC DELTA FLAGS
+
 // SkipUpdateRepo is a feature flag to skip the process of download and re-upload of update repositories
 var SkipUpdateRepo = &Flag{Name: "edge-management.skip_update_repo", EnvVar: "FEATURE_SKIP_UPDATE_REPO"}
 
-// STATIC DELTA FLAGS
-
 // StaticDeltaDev toggles creation of static deltas
 var StaticDeltaDev = &Flag{Name: "edge-management.static_delta_dev", EnvVar: "FEATURE_STATIC_DELTA_DEV"}
-
-// StaticDeltaShortCircuit toggles creation of static deltas
-var StaticDeltaShortCircuit = &Flag{Name: "edge-management.static_delta_shortcircuit",
-	EnvVar: "FEATURE_STATIC_DELTA_SHORTCIRCUIT"}
 
 // StaticDeltaGenerate toggles creation of static deltas
 var StaticDeltaGenerate = &Flag{Name: "edge-management.static_delta_generate", EnvVar: "FEATURE_STATIC_DELTA_GENERATE"}


### PR DESCRIPTION
# Description
Add a "wait for ready" to the static delta process
Moved logic under a single dev feature flag
Removed some debug logging
Refactored status logic into a single switch

FIXES: <!-- THEEDGE-NNNN -->

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
