### PR TITLE
golang: upgrade to go version 1.19.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-go@v4
         name: Set up Go 1.x
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - uses: actions/checkout@v4
         name: Checkout edge-api
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/setup-go@v4
         name: Set up Go 1.x
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - uses: actions/checkout@v4
         name: Checkout edge-api

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ arch: amd64   # Full VM on AWS or GCE
 dist: focal  # Ubuntu Focal 20.04
 services: docker
 language: go
-go: 1.18
+go: 1.19
 os: linux     # Linux OS
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################################
 # STEP 1: build executable edge-api binaries
 ############################################
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.9-13 AS edge-builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19.10-16 AS edge-builder
 WORKDIR $GOPATH/src/github.com/RedHatInsights/edge-api/
 COPY . .
 # Use go mod

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ BUILD_TAGS=-tags=fdo
 GOLANGCI_LINT_COMMON_OPTIONS=\
 			--enable=errcheck,gocritic,gofmt,goimports,gosec,gosimple,govet,ineffassign,revive,staticcheck,typecheck,unused,bodyclose \
 			--fix=false \
-			--go=1.18 \
+			--go=1.19 \
 			--max-same-issues=20 \
 			--print-issued-lines=true \
 			--print-linter-name=true \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Getting Started
 
 The **edge-api** project is an API server for fleet edge management capabilities. The API server will provide [Restful web services](https://www.redhat.com/en/topics/api/what-is-a-rest-api).
-This is a [Golang](https://golang.org/) project developed using Golang 1.18. *Make sure you have at least this version installed.*
+This is a [Golang](https://golang.org/) project developed using Golang 1.19. *Make sure you have at least this version installed.*
 
 ### Project Architecture
 

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -2,7 +2,7 @@
 
 set -exv
 
-export GOROOT="/opt/go/1.17.7" # Force Jenkins to use Go 1.17.7 since we don't have 1.18 yet
+export GOROOT="/opt/go/1.19.11"
 export PATH="${GOROOT}/bin:${PATH}"
 
 export PR_CHECK="false" # Only used when doing a PR check from Github.
@@ -53,7 +53,7 @@ done
 # Run coverage using same version of Go as the App
 podman run --user root --rm -i \
     -v $PWD:/usr/src:z \
-    registry.access.redhat.com/ubi8/go-toolset:1.18.4-8 \
+    registry.access.redhat.com/ubi8/go-toolset:1.19.10-16 \
     bash -c 'cd /usr/src && make coverage-no-fdo'
 
 # Generate sonarqube reports

--- a/go.mod
+++ b/go.mod
@@ -89,4 +89,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.18
+go 1.19

--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -850,7 +849,7 @@ var _ = Describe("Image Builder Client Test", func() {
 				}`
 
 				// create a new reader with that JSON
-				r := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+				r := io.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 
 				ImageBuilderHTTPClient = &MockClient{
 					MockDo: func(*http.Request) (*http.Response, error) {
@@ -889,7 +888,7 @@ var _ = Describe("Image Builder Client Test", func() {
 				}`
 
 				// create a new reader with that JSON
-				r := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+				r := io.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 
 				ImageBuilderHTTPClient = &MockClient{
 					MockDo: func(*http.Request) (*http.Response, error) {
@@ -923,7 +922,7 @@ var _ = Describe("Image Builder Client Test", func() {
 				jsonResponse := `{}`
 
 				// create a new reader with that JSON
-				r := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+				r := io.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 
 				ImageBuilderHTTPClient = &MockClient{
 					MockDo: func(*http.Request) (*http.Response, error) {
@@ -1060,7 +1059,7 @@ var _ = Describe("Image Builder Client Test", func() {
 				}`
 
 				// create a new reader with that JSON
-				r := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+				r := io.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 
 				ImageBuilderHTTPClient = &MockClient{
 					MockDo: func(*http.Request) (*http.Response, error) {

--- a/podman/Containerfile-dev
+++ b/podman/Containerfile-dev
@@ -1,7 +1,7 @@
 ############################################
 # STEP 1: build executable edge-api binaries
 ############################################
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.4-8
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19.10-16
 #WORKDIR $GOPATH/src/github.com/RedHatInsights/edge-api/
 COPY . .
 # Use go mod

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export GOROOT="/opt/go/1.17.7" # Force Jenkins to use Go 1.17.7 since we don't have 1.18 yet
+export GOROOT="/opt/go//1.19.11"
 export PATH="${GOROOT}/bin:${PATH}"
 
 export PR_CHECK="true" # Only used when doing a PR check from Github.
@@ -52,7 +52,7 @@ CONTAINER_NAME="edge-pr-check-$ghprbPullId"
 podman run --user root --rm --replace -i \
     --name $CONTAINER_NAME \
     -v $PWD:/usr/src:z \
-    registry.access.redhat.com/ubi8/go-toolset:1.18.4-8 \
+    registry.access.redhat.com/ubi8/go-toolset:1.19.10-16 \
     bash -c 'cd /usr/src && make coverage-no-fdo'
 
 # Generate sonarqube reports


### PR DESCRIPTION
# Description
Upgrade to go version 1.19
- Many dependencies latest versions require at least version 1.19
- Fix tests that use deprecated ioutils as golangci with version 1.19 is failing. 

FIXES: https://issues.redhat.com/browse/THEEDGE-3618

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
