### PR TITLE
groups: introduce enforce edge groups for orgs

### DIFF
--- a/pkg/models/devicegroups_api.go
+++ b/pkg/models/devicegroups_api.go
@@ -59,3 +59,8 @@ type PostDeviceForDeviceGroupAPI struct {
 	Name string `json:"Name" example:"localhost"`                            // device name
 	UUID string `json:"UUID" example:"68485bb8-6427-40ad-8711-93b6a5b4deac"` // device uuid
 }
+
+// EnforceEdgeGroupsAPI is the result of /device-groups/enforce-edge-groups end point
+type EnforceEdgeGroupsAPI struct {
+	EnforceEdgeGroups bool `json:"enforce_edge_groups" example:"false"` // whether to enforce edge groups usage
+}

--- a/pkg/models/devices.go
+++ b/pkg/models/devices.go
@@ -40,8 +40,9 @@ type DeviceDetailsList struct {
 
 // DeviceViewList is the list of devices for a given account, formatted for the UI
 type DeviceViewList struct {
-	Total   int64        `json:"total"`
-	Devices []DeviceView `json:"devices"`
+	Total             int64        `json:"total"`
+	Devices           []DeviceView `json:"devices"`
+	EnforceEdgeGroups bool         `json:"enforce_edge_groups"` // Whether to enforce the edge groups usage
 }
 
 // DeviceView is the device information needed for the UI

--- a/pkg/models/devices_api.go
+++ b/pkg/models/devices_api.go
@@ -112,6 +112,13 @@ type DeviceViewAPI struct {
 
 // DeviceViewListAPI is the list of devices for a given account, formatted for the UI
 type DeviceViewListAPI struct {
-	Total   int64           `json:"total" example:"40"` // Total number of device
-	Devices []DeviceViewAPI `json:"devices"`            // List of Devices
+	Total             int64           `json:"total" example:"40"`  // Total number of device
+	Devices           []DeviceViewAPI `json:"devices"`             // List of Devices
+	EnforceEdgeGroups bool            `json:"enforce_edge_groups"` // Whether to enforce the edge groups usage
+}
+
+// DeviceViewListResponseAPI is the struct returned by the devices view endpoint
+type DeviceViewListResponseAPI struct {
+	Data  DeviceViewListAPI `json:"data"`               // The devices view data
+	Count int64             `json:"count" example:"40"` // The overall number of devices
 }

--- a/pkg/services/utility/groups.go
+++ b/pkg/services/utility/groups.go
@@ -1,0 +1,12 @@
+package utility
+
+import (
+	"github.com/Unleash/unleash-client-go/v3"
+	unleashContext "github.com/Unleash/unleash-client-go/v3/context"
+	feature "github.com/redhatinsights/edge-api/unleash/features"
+)
+
+// EnforceEdgeGroups returns if the organisation is enforced to use edge groups
+func EnforceEdgeGroups(orgID string) bool {
+	return feature.EnforceEdgeGroups.IsEnabled(unleash.WithContext(unleashContext.Context{UserId: orgID}))
+}

--- a/pkg/services/utility/groups_test.go
+++ b/pkg/services/utility/groups_test.go
@@ -1,0 +1,56 @@
+package utility_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/redhatinsights/edge-api/pkg/services/utility"
+	feature "github.com/redhatinsights/edge-api/unleash/features"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnforceEdgeGroups(t *testing.T) {
+	orgID := faker.UUIDHyphenated()
+
+	defer func() {
+		_ = os.Unsetenv(feature.EnforceEdgeGroups.EnvVar)
+	}()
+
+	testCases := []struct {
+		Name           string
+		EnvValue       string
+		OrgID          string
+		ExpectedOrg    string
+		ExpectedResult bool
+	}{
+		{
+			Name:           "should return true when feature flag is used",
+			EnvValue:       "true",
+			OrgID:          orgID,
+			ExpectedResult: true,
+		},
+		{
+			Name:           "should return false when feature flag is not used",
+			EnvValue:       "",
+			OrgID:          orgID,
+			ExpectedResult: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.EnvValue == "" {
+				err := os.Unsetenv(feature.EnforceEdgeGroups.EnvVar)
+				assert.NoError(t, err)
+			} else {
+				err := os.Setenv(feature.EnforceEdgeGroups.EnvVar, testCase.EnvValue)
+				assert.NoError(t, err)
+
+			}
+			assert.Equal(t, utility.EnforceEdgeGroups(testCase.OrgID), testCase.ExpectedResult)
+		})
+	}
+
+}


### PR DESCRIPTION
# Description
Despite the feature flag inventory-groups-enabled is on, we can force some orgs to use edge groups via configuration.
- Fixed devicesview api doc return type
- Updated features to accept unleash context
- Added the feature flag "enforce-edge-groups"
- Added the function that check whenther to enfoce-edge-groups for an organization.
- Added enforce_edge_groups to devicesview return data, so that the UI have not to make new request when working with devicesview.
- Added a new endpoint  "/device-groups/enforce-edge-groups" that return whether edge groups usage is enforced or not.
- Covered all the new functionality code with unit-tests.

FIXES: https://issues.redhat.com/browse/THEEDGE-3552

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

