### PR TITLE
updates: implement inventoryGroupDevicesInfo

### DIFF
--- a/pkg/dependencies/main.go
+++ b/pkg/dependencies/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/redhatinsights/edge-api/logger"
+	"github.com/redhatinsights/edge-api/pkg/clients/inventorygroups"
 	"github.com/redhatinsights/edge-api/pkg/clients/rbac"
 	"github.com/redhatinsights/edge-api/pkg/clients/repositories"
 	kafkacommon "github.com/redhatinsights/edge-api/pkg/common/kafka"
@@ -31,6 +32,7 @@ type EdgeAPIServices struct {
 	FilesService            services.FilesService
 	ProducerService         kafkacommon.ProducerServiceInterface
 	ConsumerService         kafkacommon.ConsumerServiceInterface
+	InventoryGroupsService  inventorygroups.ClientInterface
 	RepositoriesService     repositories.ClientInterface
 	RbacService             rbac.ClientInterface
 	Log                     *log.Entry
@@ -59,6 +61,7 @@ func Init(ctx context.Context) *EdgeAPIServices {
 		FilesService:            services.NewFilesService(log),
 		ProducerService:         kafkacommon.NewProducerService(),
 		ConsumerService:         kafkacommon.NewConsumerService(ctx, log),
+		InventoryGroupsService:  inventorygroups.InitClient(ctx, log),
 		RepositoriesService:     repositories.InitClient(ctx, log),
 		RbacService:             rbac.InitClient(ctx, log),
 		Log:                     log,

--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -111,3 +111,13 @@ func (ur *UpdateTransaction) BeforeCreate(tx *gorm.DB) error {
 
 	return nil
 }
+
+// InventoryGroupDevicesUpdateInfo is the inventory group update info
+type InventoryGroupDevicesUpdateInfo struct {
+	GroupUUID      string   `json:"group_uuid"`
+	UpdateValid    bool     `json:"update_valid"`
+	ImageSetID     uint     `json:"image_set_id"`
+	ImageSetsCount int      `json:"image_sets_count"`
+	DevicesCount   int      `json:"devices_count"`
+	DevicesUUIDS   []string `json:"update_devices_uuids"`
+}

--- a/pkg/models/updates_api.go
+++ b/pkg/models/updates_api.go
@@ -85,3 +85,13 @@ type RecipientNotificationAPI struct {
 	IgnoreUserPreferences bool     `json:"ignore_user_preferences" example:"false"` // notification recipient to ignore user preferences
 	Users                 []string `json:"users" example:"user-id"`                 // notification recipient users
 } // @name RecipientNotification
+
+// InventoryGroupDevicesUpdateInfoResponseAPI is the inventory group update info
+type InventoryGroupDevicesUpdateInfoResponseAPI struct {
+	GroupUUID      string   `json:"group_uuid" example:"b579a578-1a6f-48d5-8a45-21f2a656a5d4"`                                                // the inventory group id
+	UpdateValid    bool     `json:"update_valid" example:"true"`                                                                              // whether the inventory group devices update is valid
+	ImageSetID     uint     `json:"image_set_id" example:"1024" `                                                                             // the image set id common to all inventory group devices
+	ImageSetsCount int      `json:"image_sets_count" example:"1"`                                                                             // how much image set ids the inventory group devices belongs to
+	DevicesCount   int      `json:"devices_count" example:"25"`                                                                               // the overall count of all devices that belongs to inventory group
+	DevicesUUID    []string `json:"update_devices_uuids" example:"b579a578-1a6f-48d5-8a45-21f2a656a5d4,1abb288d-6d88-4e2d-bdeb-fcc536be58ec"` // the list of devices uuids that belongs to inventory group that are available to update
+}

--- a/pkg/services/mock_services/updates.go
+++ b/pkg/services/mock_services/updates.go
@@ -123,6 +123,21 @@ func (mr *MockUpdateServiceInterfaceMockRecorder) GetUpdateTransactionsForDevice
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdateTransactionsForDevice", reflect.TypeOf((*MockUpdateServiceInterface)(nil).GetUpdateTransactionsForDevice), device)
 }
 
+// InventoryGroupDevicesUpdateInfo mocks base method.
+func (m *MockUpdateServiceInterface) InventoryGroupDevicesUpdateInfo(orgID, inventoryGroupUUID string) (*models.InventoryGroupDevicesUpdateInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InventoryGroupDevicesUpdateInfo", orgID, inventoryGroupUUID)
+	ret0, _ := ret[0].(*models.InventoryGroupDevicesUpdateInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InventoryGroupDevicesUpdateInfo indicates an expected call of InventoryGroupDevicesUpdateInfo.
+func (mr *MockUpdateServiceInterfaceMockRecorder) InventoryGroupDevicesUpdateInfo(orgID, inventoryGroupUUID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InventoryGroupDevicesUpdateInfo", reflect.TypeOf((*MockUpdateServiceInterface)(nil).InventoryGroupDevicesUpdateInfo), orgID, inventoryGroupUUID)
+}
+
 // ProcessPlaybookDispatcherRunEvent mocks base method.
 func (m *MockUpdateServiceInterface) ProcessPlaybookDispatcherRunEvent(message []byte) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
# Description
In the context of inventory group details view we want to update devices of an inventory group. But before that we to need to retrieve validation data and the device uuids related to this group.

FIXES: https://issues.redhat.com/browse/THEEDGE-3539

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

