### PR TITLE
add imageset info to return

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 )
 
 require (
+	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -79,6 +80,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/swaggo/swag v1.16.2 // indirect
 	github.com/twmb/murmur3 v1.1.5 // indirect
 	go.mongodb.org/mongo-driver v1.11.3 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
@@ -88,6 +90,7 @@ require (
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
+	golang.org/x/tools v0.13.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -719,6 +719,8 @@ git.sr.ht/~sbinet/gg v0.3.1/go.mod h1:KGYtlADtqsqANL9ueOFkWymvzUvLMQllU5Ixo+8v3p
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
+github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
+github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -1234,6 +1236,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/swaggo/swag v1.16.2 h1:28Pp+8DkQoV+HLzLx8RGJZXNGKbFqnuvSbAAtoxiY04=
+github.com/swaggo/swag v1.16.2/go.mod h1:6YzXnDcpr0767iOejs318CwYkCQqyGer6BizOg03f+E=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/twmb/murmur3 v1.1.5 h1:i9OLS9fkuLzBXjt6dptlAEyk58fJsSTXbRg3SgVyqgk=
@@ -1677,6 +1681,7 @@ golang.org/x/tools v0.8.0/go.mod h1:JxBZ99ISMI5ViVkT1tr6tdNmXeTrcpVSD3vZ1RsRdN4=
 golang.org/x/tools v0.9.1/go.mod h1:owI94Op576fPu3cIGQeHs3joujW/2Oc6MtlxbF5dfNc=
 golang.org/x/tools v0.10.0/go.mod h1:UJwyiVBsOA2uwvK/e5OY3GTpDUJriEd+/YlqAwLPmyM=
 golang.org/x/tools v0.13.0 h1:Iey4qkscZuv0VvIt8E0neZjtPVQFSc870HQ448QgEmQ=
+golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -114,10 +114,11 @@ func (ur *UpdateTransaction) BeforeCreate(tx *gorm.DB) error {
 
 // InventoryGroupDevicesUpdateInfo is the inventory group update info
 type InventoryGroupDevicesUpdateInfo struct {
-	GroupUUID      string   `json:"group_uuid"`
-	UpdateValid    bool     `json:"update_valid"`
-	ImageSetID     uint     `json:"image_set_id"`
-	ImageSetsCount int      `json:"image_sets_count"`
-	DevicesCount   int      `json:"devices_count"`
-	DevicesUUIDS   []string `json:"update_devices_uuids"`
+	GroupUUID        string          `json:"group_uuid"`
+	UpdateValid      bool            `json:"update_valid"`
+	ImageSetID       uint            `json:"image_set_id"`
+	ImageSetsCount   int             `json:"image_sets_count"`
+	DevicesCount     int             `json:"devices_count"`
+	DevicesUUIDS     []string        `json:"update_devices_uuids"`
+	DevicesImageSets map[string]uint `json:"device_image_set_info"`
 }

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -1042,7 +1042,6 @@ func (s *UpdateService) InventoryGroupDevicesUpdateInfo(orgID string, inventoryG
 		inventoryGroupDevicesInfo.ImageSetID = deviceData.ImageSetID
 		if deviceData.DeviceUUID != "" {
 			devicesImageMap[deviceData.DeviceUUID] = deviceData.ImageSetID
-			inventoryGroupDevicesInfo.DevicesImageSets = devicesImageMap
 		}
 		if deviceData.UpdateAvailable && deviceData.DeviceUUID != "" {
 			inventoryGroupDevicesInfo.DevicesUUIDS = append(inventoryGroupDevicesInfo.DevicesUUIDS, deviceData.DeviceUUID)
@@ -1050,6 +1049,7 @@ func (s *UpdateService) InventoryGroupDevicesUpdateInfo(orgID string, inventoryG
 		}
 
 	}
+	inventoryGroupDevicesInfo.DevicesImageSets = devicesImageMap
 	inventoryGroupDevicesInfo.DevicesCount = len(inventoryGroupDevicesData)
 	inventoryGroupDevicesInfo.ImageSetsCount = len(imageSetIDSMap)
 	inventoryGroupDevicesInfo.GroupUUID = inventoryGroupUUID

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -1036,6 +1036,7 @@ func (s *UpdateService) InventoryGroupDevicesUpdateInfo(orgID string, inventoryG
 	var inventoryGroupDevicesInfo models.InventoryGroupDevicesUpdateInfo
 	var imageSetIDSMap = make(map[uint]bool)
 	var devicesImageMap = make(map[string]uint)
+
 	for _, deviceData := range inventoryGroupDevicesData {
 		imageSetIDSMap[deviceData.ImageSetID] = true
 		inventoryGroupDevicesInfo.ImageSetID = deviceData.ImageSetID
@@ -1045,7 +1046,9 @@ func (s *UpdateService) InventoryGroupDevicesUpdateInfo(orgID string, inventoryG
 		}
 		if deviceData.UpdateAvailable && deviceData.DeviceUUID != "" {
 			inventoryGroupDevicesInfo.DevicesUUIDS = append(inventoryGroupDevicesInfo.DevicesUUIDS, deviceData.DeviceUUID)
+
 		}
+
 	}
 	inventoryGroupDevicesInfo.DevicesCount = len(inventoryGroupDevicesData)
 	inventoryGroupDevicesInfo.ImageSetsCount = len(imageSetIDSMap)

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -1035,9 +1035,14 @@ func (s *UpdateService) InventoryGroupDevicesUpdateInfo(orgID string, inventoryG
 
 	var inventoryGroupDevicesInfo models.InventoryGroupDevicesUpdateInfo
 	var imageSetIDSMap = make(map[uint]bool)
+	var devicesImageMap = make(map[string]uint)
 	for _, deviceData := range inventoryGroupDevicesData {
 		imageSetIDSMap[deviceData.ImageSetID] = true
 		inventoryGroupDevicesInfo.ImageSetID = deviceData.ImageSetID
+		if deviceData.DeviceUUID != "" {
+			devicesImageMap[deviceData.DeviceUUID] = deviceData.ImageSetID
+			inventoryGroupDevicesInfo.DevicesImageSets = devicesImageMap
+		}
 		if deviceData.UpdateAvailable && deviceData.DeviceUUID != "" {
 			inventoryGroupDevicesInfo.DevicesUUIDS = append(inventoryGroupDevicesInfo.DevicesUUIDS, deviceData.DeviceUUID)
 		}

--- a/pkg/services/updates_test.go
+++ b/pkg/services/updates_test.go
@@ -1752,13 +1752,13 @@ var _ = Describe("UpdateService Basic functions", func() {
 
 			It("inventory group devices update should be valid", func() {
 				expectedDevicesUUID := []string{devices[0].UUID, devices[1].UUID, devices[2].UUID}
-				expectedDevicesImageSets := map[string]int{}
+				expectedDevicesImageSets := map[string]uint{}
 
-				for _, d := range devices {
-					for _, i := range images {
-						if i.ID == d.ImageID {
-							expectedDevicesImageSets = map[string]int{d.UUID: int(*i.ImageSetID)}
-							return
+				for _, device := range devices[:4] {
+					for _, image := range images {
+						if image.ID == device.ImageID {
+							expectedDevicesImageSets[device.UUID] = *image.ImageSetID
+							break
 						}
 					}
 				}
@@ -1771,7 +1771,11 @@ var _ = Describe("UpdateService Basic functions", func() {
 				Expect(inventoryGroupDevicesUpdateInfo.DevicesCount).To(Equal(4))
 				Expect(len(inventoryGroupDevicesUpdateInfo.DevicesUUIDS)).To(Equal(3))
 				Expect(inventoryGroupDevicesUpdateInfo.DevicesUUIDS).To(Equal(expectedDevicesUUID))
-				Expect(inventoryGroupDevicesUpdateInfo.DevicesImageSets).To(Equal(expectedDevicesImageSets))
+				Expect(len(inventoryGroupDevicesUpdateInfo.DevicesImageSets)).To(Equal(len(expectedDevicesImageSets)))
+				for device := range expectedDevicesImageSets {
+					Expect(inventoryGroupDevicesUpdateInfo.DevicesImageSets[device]).To(Equal(expectedDevicesImageSets[device]))
+				}
+
 			})
 
 			It("inventory group devices update should be invalid when no device update available", func() {

--- a/pkg/services/updates_test.go
+++ b/pkg/services/updates_test.go
@@ -1752,6 +1752,16 @@ var _ = Describe("UpdateService Basic functions", func() {
 
 			It("inventory group devices update should be valid", func() {
 				expectedDevicesUUID := []string{devices[0].UUID, devices[1].UUID, devices[2].UUID}
+				expectedDevicesImageSets := map[string]int{}
+
+				for _, d := range devices {
+					for _, i := range images {
+						if i.ID == d.ImageID {
+							expectedDevicesImageSets = map[string]int{d.UUID: int(*i.ImageSetID)}
+							return
+						}
+					}
+				}
 				inventoryGroupDevicesUpdateInfo, err := updateService.InventoryGroupDevicesUpdateInfo(orgID, groupUUID)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(inventoryGroupDevicesUpdateInfo.UpdateValid).To(BeTrue())
@@ -1761,6 +1771,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 				Expect(inventoryGroupDevicesUpdateInfo.DevicesCount).To(Equal(4))
 				Expect(len(inventoryGroupDevicesUpdateInfo.DevicesUUIDS)).To(Equal(3))
 				Expect(inventoryGroupDevicesUpdateInfo.DevicesUUIDS).To(Equal(expectedDevicesUUID))
+				Expect(inventoryGroupDevicesUpdateInfo.DevicesImageSets).To(Equal(expectedDevicesImageSets))
 			})
 
 			It("inventory group devices update should be invalid when no device update available", func() {
@@ -1774,6 +1785,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 				Expect(len(inventoryGroupDevicesUpdateInfo.DevicesUUIDS)).To(Equal(0))
 			})
 			It("inventory group devices update should be invalid when devices are from different images sets", func() {
+
 				inventoryGroupDevicesUpdateInfo, err := updateService.InventoryGroupDevicesUpdateInfo(orgID, groupUUID3)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(inventoryGroupDevicesUpdateInfo.UpdateValid).To(BeFalse())


### PR DESCRIPTION
# Description
Adding a hash with deviceUUID:imageSet to be able to enable/disable the bulk select 

FIXES:  THEEDGE-3703

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
