### PR TITLE
migrate-groups: add auth-type to identity

### DIFF
--- a/cmd/migrategroups/migrategroups/migrategroups.go
+++ b/cmd/migrategroups/migrategroups/migrategroups.go
@@ -38,6 +38,9 @@ var DefaultMaxDataPageNumber = 100
 // DefaultIdentityType the default identity type used in header when requesting inventory groups end-point
 var DefaultIdentityType = "System"
 
+// AuthTypeBASIC the BASIC identity type used in header when requesting inventory groups end-point
+var AuthTypeBASIC = "basic-auth"
+
 // OrgsGroupsFilter the filter added to filter an organization groups (if the org_id is defined in the map as a key)
 var OrgsGroupsFilter = map[string][]interface{}{
 	"11789772": {"device_groups.name LIKE ?", "%-Store-%"},
@@ -63,6 +66,7 @@ func newInventoryGroupsOrgClient(orgID string) (inventorygroups.ClientInterface,
 	ident := identity.XRHID{Identity: identity.Identity{
 		OrgID:    orgID,
 		Type:     DefaultIdentityType,
+		AuthType: AuthTypeBASIC,
 		Internal: identity.Internal{OrgID: orgID},
 	}}
 	jsonIdent, err := json.Marshal(&ident)

--- a/cmd/migrategroups/migrategroups/migrategroups_test.go
+++ b/cmd/migrategroups/migrategroups/migrategroups_test.go
@@ -119,6 +119,7 @@ var _ = Describe("Migrate device groups", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(rhIndent.Identity.OrgID).To(Equal(orgID))
 					Expect(rhIndent.Identity.Type).To(Equal(migrategroups.DefaultIdentityType))
+					Expect(rhIndent.Identity.AuthType).To(Equal(migrategroups.AuthTypeBASIC))
 					return mockInventoryGroupClient
 				}
 


### PR DESCRIPTION
# Description
Add basic auth-type to identity for the groups migration script 

FIXES: https://issues.redhat.com/browse/THEEDGE-3555

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

