### PR TITLE
device-group-view: add enforce-edge-groups

### DIFF
--- a/pkg/routes/devicegroups.go
+++ b/pkg/routes/devicegroups.go
@@ -385,6 +385,11 @@ func GetDeviceGroupDetailsByID(w http.ResponseWriter, r *http.Request) {
 // @Router       /device-groups/{ID}/view [get]
 func GetDeviceGroupDetailsByIDView(w http.ResponseWriter, r *http.Request) {
 	ctxServices := dependencies.ServicesFromContext(r.Context())
+	orgID := readOrgID(w, r, ctxServices.Log)
+	if orgID == "" {
+		return
+	}
+
 	deviceGroup := getContextDeviceGroup(w, r)
 	if deviceGroup == nil {
 		return
@@ -392,6 +397,7 @@ func GetDeviceGroupDetailsByIDView(w http.ResponseWriter, r *http.Request) {
 
 	var deviceGroupDetails models.DeviceGroupDetailsView
 	deviceGroupDetails.DeviceGroup = deviceGroup
+	deviceGroupDetails.DeviceDetails.EnforceEdgeGroups = utility.EnforceEdgeGroups(orgID)
 	if int(len(deviceGroup.Devices)) == 0 {
 		respondWithJSONBody(w, ctxServices.Log, &deviceGroupDetails)
 		return


### PR DESCRIPTION
# Description
when an org is enforced to use edge-groups the edge groups was not displayed inventory group was displayed instead. this fix this behavior.

FIXES: https://issues.redhat.com/browse/THEEDGE-3552


## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

