### PR TITLE
devicesview: return empty list when no devices

### DIFF
--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -871,7 +871,7 @@ func ReturnDevicesView(storedDevices []models.Device, orgID string) ([]models.De
 	}
 
 	// build the return object
-	var returnDevices []models.DeviceView
+	returnDevices := make([]models.DeviceView, 0, len(storedDevices))
 	for _, device := range storedDevices {
 		var imageName string
 		deviceInfo := &neededDeviceInfo{}

--- a/pkg/services/devices_test.go
+++ b/pkg/services/devices_test.go
@@ -1322,6 +1322,18 @@ var _ = Describe("DfseviceService", func() {
 				Expect(devices).ToNot(BeNil())
 			})
 		})
+
+		When("devices are not returned from db", func() {
+			It("should return an empty list and not a nil value", func() {
+				unExistDeviceFilter := db.DB.Where("devices.uuid", faker.UUIDHyphenated())
+				devices, err := deviceService.GetDevicesView(100, 0, unExistDeviceFilter)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(devices).ToNot(BeNil())
+				Expect(devices.Total).To(Equal(int64(0)))
+				Expect(devices.Devices).ToNot(BeNil())
+				Expect(devices.Devices).To(BeEmpty())
+			})
+		})
 	})
 	Context("Get CommitID from Device Image", func() {
 		It("should return zero images", func() {


### PR DESCRIPTION
# Description
Return empty list in json [] when no devices where found. The root cause where in the ReturnDevicesView, now we are creating and allocating the devices slice (returnDevices), wich cause the devices slice to not be nil when no devices. The end-point is returning the following payload when no data
```json
 {"count":0,"data":{"total":0,"devices":[],"enforce_edge_groups":false}}
```
 FIXES: https://issues.redhat.com/browse/THEEDGE-3751

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

