### PR TITLE
inventory-client: remove staleness param from inventory query

### DIFF
--- a/pkg/clients/inventory/client.go
+++ b/pkg/clients/inventory/client.go
@@ -83,7 +83,7 @@ const (
 	// Fields represents field we get from inventory
 	Fields = "host_type,operating_system,greenboot_status,greenboot_fallback_detected,rpm_ostree_deployments,rhc_client_id,rhc_config_state"
 	// FilterParams represents params to retrieve data from inventory
-	FilterParams = "?staleness=fresh&filter[system_profile][host_type]=edge&fields[system_profile]=host_type,operating_system,greenboot_status,greenboot_fallback_detected,rpm_ostree_deployments,rhc_client_id,rhc_config_state"
+	FilterParams = "?filter[system_profile][host_type]=edge&fields[system_profile]=host_type,operating_system,greenboot_status,greenboot_fallback_detected,rpm_ostree_deployments,rhc_client_id,rhc_config_state"
 )
 
 // Params represents the struct of params to be sent

--- a/pkg/clients/inventory/client_suite_test.go
+++ b/pkg/clients/inventory/client_suite_test.go
@@ -1,0 +1,13 @@
+package inventory_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo" // nolint: revive
+	. "github.com/onsi/gomega" // nolint: revive
+)
+
+func TestInventoryClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Inventory Client Suite")
+}

--- a/pkg/clients/inventory/client_test.go
+++ b/pkg/clients/inventory/client_test.go
@@ -1,0 +1,64 @@
+package inventory_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/clients/inventory"
+
+	"github.com/bxcodec/faker/v3"
+	. "github.com/onsi/ginkgo" // nolint: revive
+	. "github.com/onsi/gomega" // nolint: revive
+	log "github.com/sirupsen/logrus"
+)
+
+var _ = Describe("Inventory Client Tests", func() {
+	var client inventory.ClientInterface
+	var originalInventoryURL string
+	conf := config.Get()
+	BeforeEach(func() {
+		client = inventory.InitClient(context.Background(), log.NewEntry(log.StandardLogger()))
+		originalInventoryURL = conf.InventoryConfig.URL
+	})
+	AfterEach(func() {
+		conf.ImageBuilderConfig.URL = originalInventoryURL
+	})
+	It("should init client", func() {
+		Expect(client).ToNot(BeNil())
+	})
+	Context("ReturnDevicesByID", func() {
+
+		It("should return inventory hosts by id successfully", func() {
+			deviceUUID := faker.UUIDHyphenated()
+			expectedParams := map[string]string{
+				"filter[system_profile][host_type]": "edge",
+				"fields[system_profile]": "host_type,operating_system,greenboot_status," +
+					"greenboot_fallback_detected,rpm_ostree_deployments,rhc_client_id,rhc_config_state",
+				"hostname_or_id": deviceUUID,
+			}
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				urlQueryValues := r.URL.Query()
+				for key, value := range expectedParams {
+					Expect(value).To(Equal(urlQueryValues.Get(key)))
+				}
+				w.WriteHeader(http.StatusOK)
+				response := inventory.Response{Total: 1, Count: 1, Result: []inventory.Device{{ID: deviceUUID}}}
+				err := json.NewEncoder(w).Encode(&response)
+				Expect(err).ToNot(HaveOccurred())
+			}))
+			defer ts.Close()
+			config.Get().InventoryConfig.URL = ts.URL
+			result, err := client.ReturnDevicesByID(deviceUUID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Total).To(Equal(1))
+			Expect(result.Count).To(Equal(1))
+			Expect(len(result.Result)).To(Equal(1))
+			Expect(result.Result[0].ID).To(Equal(deviceUUID))
+		})
+	})
+})


### PR DESCRIPTION
# Description
With staleness=fresh param, some hosts may be not found, removing this param has been tested to found this hosts again. 

FIXES: https://issues.redhat.com/browse/THEEDGE-3763

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

