### PR TITLE
move to cicd-tools for pr_check.sh

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -16,8 +16,7 @@ export IQE_CJI_TIMEOUT="30m"  # This is the time to wait for smoke test to compl
 
 # Install bonfire repo/initialize
 WORKSPACE=${WORKSPACE:-$PWD}
-BONFIRE_REPO_BRANCH='bonfire-hotfix'
-CICD_URL="https://raw.githubusercontent.com/RedHatInsights/bonfire/${BONFIRE_REPO_BRANCH}/cicd"
+CICD_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main"
 curl -s $CICD_URL/bootstrap.sh > ${WORKSPACE}/cicd_bootstrap.sh && source ${WORKSPACE}/cicd_bootstrap.sh
 
 # env vars for bonfire


### PR DESCRIPTION
# Description
This PR sets the CICD tools repository that replaced the old bonfire scripts tools to host helper functions for pr_check.sh

FIXES: the workaround to connect to CRCD instead of Ephemeral

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
