### PR TITLE
image-builder: pass installer user and ssh-key to image-builder

### DIFF
--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -69,6 +69,7 @@ type OSTree struct {
 type Customizations struct {
 	Packages            *[]string     `json:"packages"`
 	PayloadRepositories *[]Repository `json:"payload_repositories,omitempty"`
+	Users               *[]User       `json:"users,omitempty"`
 }
 
 // Repository is the record of Third Party Repository
@@ -80,6 +81,12 @@ type Repository struct {
 	MetaLink   *string `json:"metalink,omitempty"`
 	MirrorList *string `json:"mirrorlist,omitempty"`
 	RHSM       bool    `json:"rhsm"`
+}
+
+// User is the username ad ssh key to inject in ISO kickstart for device login by default.
+type User struct {
+	Name   string `json:"name"`
+	SSHKey string `json:"ssh_key"`
 }
 
 // UploadRequest is the upload options accepted by Image Builder API
@@ -286,10 +293,14 @@ func (c *Client) ComposeInstaller(image *models.Image) (*models.Image, error) {
 		repoURL = image.Commit.Repo.URL
 		rhsm = false
 	}
-
+	var users []User
+	if image.Installer != nil && image.Installer.Username != "" && image.Installer.SSHKey != "" {
+		users = []User{{Name: image.Installer.Username, SSHKey: image.Installer.SSHKey}}
+	}
 	req := &ComposeRequest{
 		Customizations: &Customizations{
 			Packages: &pkgs,
+			Users:    &users,
 		},
 
 		Distribution: image.Distribution,


### PR DESCRIPTION
# Description
Pass installer user and ssh-key to image-builder when creating ISO artifact. 

FIXES: https://issues.redhat.com/browse/THEEDGE-3713

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

