### PR TITLE
rhel: upgrade to ubi9

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -53,7 +53,7 @@ done
 # Run coverage using same version of Go as the App
 podman run --user root --rm -i \
     -v $PWD:/usr/src:z \
-    registry.access.redhat.com/ubi8/go-toolset:1.20.10-3 \
+    registry.access.redhat.com/ubi9/go-toolset:1.20 \
     bash -c 'cd /usr/src && make coverage-no-fdo'
 
 # Generate sonarqube reports

--- a/podman/Containerfile-dev
+++ b/podman/Containerfile-dev
@@ -1,7 +1,7 @@
 ############################################
 # STEP 1: build executable edge-api binaries
 ############################################
-FROM registry.access.redhat.com/ubi8/go-toolset:1.20.10-3
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20
 #WORKDIR $GOPATH/src/github.com/RedHatInsights/edge-api/
 COPY . .
 # Use go mod
@@ -54,7 +54,7 @@ RUN go build -o /usr/local/bin/edge-api-cleanup cmd/cleanup/main.go
 #    coreutils-single glibc-minimal-langpack \
 #    pykickstart mtools xorriso genisoimage \
 #    syslinux isomd5sum file ostree \
-#    --releasever 8 --setopt \
+#    --releasever 9 --setopt \
 #    install_weak_deps=false --nodocs -y; \
 #    yum --installroot /mnt/rootfs clean all
 #RUN rm -rf /var/cache/* /var/log/dnf* /var/log/yum.*
@@ -64,7 +64,7 @@ RUN go build -o /usr/local/bin/edge-api-cleanup cmd/cleanup/main.go
 ####################################
 #FROM scratch
 #LABEL maintainer="Red Hat, Inc."
-#LABEL com.redhat.component="ubi8-micro-container"
+#LABEL com.redhat.component="ubi9-micro-container"
 
 # label for EULA
 #LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -48,7 +48,7 @@ CONTAINER_NAME="edge-pr-check-$ghprbPullId"
 podman run --user root --rm --replace -i \
     --name $CONTAINER_NAME \
     -v $PWD:/usr/src:z \
-    registry.access.redhat.com/ubi8/go-toolset:1.20.10-3 \
+    registry.access.redhat.com/ubi9/go-toolset:1.20 \
     bash -c 'cd /usr/src && make coverage-no-fdo'
 
 # Generate sonarqube reports


### PR DESCRIPTION
# Description
upgrade container to ubi9, will always stick to latest version of ubi9/go-toolset:1.20

For compatibility install compat-openssl11 for fdo compilation (to remove when fdo-data container is upgraded to ubi9)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

