### PR TITLE
Theedge 3711 add activation key on kickstart

### DIFF
--- a/templates/templateKickstart.ks
+++ b/templates/templateKickstart.ks
@@ -64,7 +64,7 @@ echo POST-USER
 USER_NAME={{.Username}}
 useradd -m -G wheel $USER_NAME
 USER_HOME=$(getent passwd $USER_NAME | awk -F: '{print $6}')
-
+RHC_ACTIVATION_KEY = {{.activationKey}}
 mkdir -p ${USER_HOME}/.ssh
 chown ${USER_NAME}:${USER_NAME} ${USER_HOME}/.ssh
 chmod 0700 ${USER_HOME}/.ssh


### PR DESCRIPTION
# Description
Include object of activation key on kickstart

FIXES: <THEEDGE-3711>

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
