### PR TITLE
device-groups: fixes device-group rename

### DIFF
--- a/pkg/routes/devicegroups.go
+++ b/pkg/routes/devicegroups.go
@@ -514,7 +514,7 @@ func UpdateDeviceGroup(w http.ResponseWriter, r *http.Request) {
 			case *services.DeviceGroupAlreadyExists:
 				apiError = errors.NewBadRequest(err.Error())
 			default:
-				apiError := errors.NewInternalServerError()
+				apiError = errors.NewInternalServerError()
 				apiError.SetTitle("failed updating device group")
 			}
 			respondWithAPIError(w, ctxServices.Log, apiError)

--- a/pkg/services/devicegroups.go
+++ b/pkg/services/devicegroups.go
@@ -341,7 +341,7 @@ func (s *DeviceGroupsService) UpdateDeviceGroup(deviceGroup *models.DeviceGroup,
 		}
 	}
 
-	result := db.DB.Save(&groupDetails)
+	result := db.DB.Omit("Devices").Save(&groupDetails)
 	if result.Error != nil {
 		return result.Error
 	}


### PR DESCRIPTION
# Description
The fix concern two major problems when group has devices and the device are in the model, when we try to save to db, gorm try to add the devices to group again, but they already exists and the error is raised, when this unknown error is raised, we were creating a new apiError variable, but we return the global apiError that is nil, and a panic is raised.

This PR fixes both problem by:

1. Fixing apiError assignment to the global apiError
2. Omiting devices when updating deviceGroup covered by unit-tests

FIXES: https://issues.redhat.com/browse/THEEDGE-3812

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

