### PR TITLE
rbac: fixes rbac with empty resources

### DIFF
--- a/pkg/clients/rbac/client.go
+++ b/pkg/clients/rbac/client.go
@@ -199,6 +199,13 @@ func (c *Client) GetInventoryGroupsAccess(acl AccessList, resource ResourceType,
 		// check if the resource with accessType has access to the current access item
 		if ac.Application() == string(ApplicationInventory) && ResourceMatch(ResourceType(ac.Resource()), resource) && AccessMatch(AccessType(ac.AccessType()), accessType) {
 			allowedAccess = true
+			if len(ac.ResourceDefinitions) == 0 {
+				// we should have global access to the resource in the context of this access type
+				// reset the values
+				globalUnGroupedHosts = false
+				overallGroupIDS = nil
+				break
+			}
 			for _, resourceDef := range ac.ResourceDefinitions {
 				// validate if the resource definition is correct and get all access groups from the resource definition value
 				accessGroups, err := c.getAssessGroupsFromResourceDefinition(resourceDef)

--- a/pkg/clients/rbac/client_test.go
+++ b/pkg/clients/rbac/client_test.go
@@ -255,6 +255,72 @@ var _ = Describe("Rbac Client", func() {
 			Expect(overallGroupIDS).To(Equal(expectedGroups))
 		})
 
+		It("it should allowed access when resources is empty", func() {
+			acl := rbac.AccessList{
+				rbac.Access{
+					ResourceDefinitions: []rbac.ResourceDefinition{},
+					Permission:          "inventory:hosts:read",
+				},
+			}
+			allowedAccess, overallGroupIDS, hostsWithNoGroupsAssigned, err := client.GetInventoryGroupsAccess(acl, rbac.ResourceTypeHOSTS, rbac.AccessTypeRead)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(allowedAccess).To(BeTrue())
+			Expect(hostsWithNoGroupsAssigned).To(BeFalse())
+			Expect(len(overallGroupIDS)).To(Equal(0))
+		})
+
+		It("it should allowed access when resources is empty any where in the list 1", func() {
+			acl := rbac.AccessList{
+				rbac.Access{
+					ResourceDefinitions: []rbac.ResourceDefinition{
+						{
+							Filter: rbac.ResourceDefinitionFilter{
+								Key:       "group.id",
+								Operation: "in",
+								Value:     []*string{nil},
+							},
+						},
+					},
+					Permission: "inventory:hosts:read",
+				},
+				rbac.Access{
+					ResourceDefinitions: []rbac.ResourceDefinition{},
+					Permission:          "inventory:hosts:read",
+				},
+			}
+			allowedAccess, overallGroupIDS, hostsWithNoGroupsAssigned, err := client.GetInventoryGroupsAccess(acl, rbac.ResourceTypeHOSTS, rbac.AccessTypeRead)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(allowedAccess).To(BeTrue())
+			Expect(hostsWithNoGroupsAssigned).To(BeFalse())
+			Expect(len(overallGroupIDS)).To(Equal(0))
+		})
+
+		It("it should allowed access when resources is empty any where in the list 2", func() {
+			acl := rbac.AccessList{
+				rbac.Access{
+					ResourceDefinitions: []rbac.ResourceDefinition{},
+					Permission:          "inventory:hosts:read",
+				},
+				rbac.Access{
+					ResourceDefinitions: []rbac.ResourceDefinition{
+						{
+							Filter: rbac.ResourceDefinitionFilter{
+								Key:       "group.id",
+								Operation: "in",
+								Value:     []*string{nil},
+							},
+						},
+					},
+					Permission: "inventory:hosts:read",
+				},
+			}
+			allowedAccess, overallGroupIDS, hostsWithNoGroupsAssigned, err := client.GetInventoryGroupsAccess(acl, rbac.ResourceTypeHOSTS, rbac.AccessTypeRead)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(allowedAccess).To(BeTrue())
+			Expect(hostsWithNoGroupsAssigned).To(BeFalse())
+			Expect(len(overallGroupIDS)).To(Equal(0))
+		})
+
 		It("it should not be allowed access when no resources matches", func() {
 			acl := rbac.AccessList{
 				rbac.Access{

--- a/pkg/routes/devices_test.go
+++ b/pkg/routes/devices_test.go
@@ -1355,6 +1355,25 @@ func TestDevicesViewInventoryHostsRbac(t *testing.T) {
 	}{
 		// GET http method
 		{
+			Name:       "should return all the devices",
+			HTTPMethod: "GET",
+			RbacACL: rbac.AccessList{
+				rbac.Access{
+					ResourceDefinitions: []rbac.ResourceDefinition{},
+					Permission:          "inventory:hosts:read",
+				},
+			},
+			UseIdentity:                     true,
+			UseIdentityType:                 common.IdentityTypeUser,
+			ClientCallExpected:              true,
+			ClientAccessCallExpected:        true,
+			ResultAllowedAccess:             true,
+			ResultGroupsID:                  []string{},
+			ResultHostsWithNoGroupsAssigned: false,
+			ExpectedHTTPStatus:              http.StatusOK,
+			ExpectedDevices:                 devices,
+		},
+		{
 			Name:       "should return the devices device from groups in ACL",
 			HTTPMethod: "GET",
 			RbacACL: rbac.AccessList{


### PR DESCRIPTION
# Description
When empty access resources is found, this should force global access to the resource in the context of access type.

FIXES: https://issues.redhat.com/browse/THEEDGE-3816

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor


# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

