### PR TITLE
device-update: implement deviceUpdateImagesFilters

### DIFF
--- a/pkg/models/updates.go
+++ b/pkg/models/updates.go
@@ -122,3 +122,15 @@ type InventoryGroupDevicesUpdateInfo struct {
 	DevicesUUIDS     []string        `json:"update_devices_uuids"`
 	DevicesImageSets map[string]uint `json:"device_image_set_info"`
 }
+
+// DeviceUpdateImagesFilters is the device image
+type DeviceUpdateImagesFilters struct {
+	Limit              int
+	Offset             int
+	Version            int
+	Release            string
+	Created            string
+	AdditionalPackages *int
+	AllPackages        *int
+	SystemsRunning     *int
+}

--- a/pkg/services/devices_test.go
+++ b/pkg/services/devices_test.go
@@ -138,7 +138,7 @@ var _ = Describe("DfseviceService", func() {
 			It("should return error and no updates available - for all updates", func() {
 				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(inventory.Response{}, errors.New("error on inventory api"))
 
-				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false, 10, 0)
+				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
 				Expect(updatesAvailable).To(BeNil())
 				Expect(countUpdatesAvailable).To(Equal(int64(0)))
@@ -146,7 +146,7 @@ var _ = Describe("DfseviceService", func() {
 			It("should return error and no updates available - for latest update", func() {
 				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(inventory.Response{}, errors.New("error on inventory api"))
 
-				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, true, 10, 0)
+				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, true, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
 				Expect(updatesAvailable).To(BeNil())
 				Expect(countUpdatesAvailable).To(Equal(int64(0)))
@@ -161,7 +161,7 @@ var _ = Describe("DfseviceService", func() {
 					Inventory: mockInventoryClient,
 				}
 
-				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false, 10, 0)
+				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
 				Expect(updatesAvailable).To(BeNil())
 				Expect(countUpdatesAvailable).To(Equal(int64(0)))
@@ -174,7 +174,7 @@ var _ = Describe("DfseviceService", func() {
 					Inventory: mockInventoryClient,
 				}
 
-				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, true, 10, 0)
+				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, true, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
 				Expect(updatesAvailable).To(BeNil())
 				Expect(countUpdatesAvailable).To(Equal(int64(0)))
@@ -200,7 +200,7 @@ var _ = Describe("DfseviceService", func() {
 					Inventory: mockInventoryClient,
 				}
 
-				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false, 10, 0)
+				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
 				Expect(updatesAvailable).To(BeNil())
 				Expect(countUpdatesAvailable).To(Equal(int64(0)))
@@ -224,7 +224,7 @@ var _ = Describe("DfseviceService", func() {
 					Inventory: mockInventoryClient,
 				}
 
-				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, true, 10, 0)
+				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, true, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
 				Expect(updatesAvailable).To(BeNil())
 				Expect(countUpdatesAvailable).To(Equal(int64(0)))
@@ -260,7 +260,7 @@ var _ = Describe("DfseviceService", func() {
 					},
 				}).WithImageSetID(imageSet.ID).Create()
 
-				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false, 10, 0)
+				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 
 				Expect(err).To(BeNil())
 				Expect(updatesAvailable).To(HaveLen(1))
@@ -308,7 +308,7 @@ var _ = Describe("DfseviceService", func() {
 					},
 				}).WithImageSetID(imageSet.ID).WithVersion(3).Create()
 
-				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, true, 10, 0)
+				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, true, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 
 				Expect(err).To(BeNil())
 				Expect(updatesAvailable).To(HaveLen(1))
@@ -346,7 +346,7 @@ var _ = Describe("DfseviceService", func() {
 
 				seeder.Images().WithOstreeCommit(checksum).Create()
 
-				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false, 10, 0)
+				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 				Expect(err).To(BeNil())
 				Expect(updatesAvailable).To(BeNil())
 				Expect(countUpdatesAvailable).To(Equal(int64(0)))
@@ -367,7 +367,7 @@ var _ = Describe("DfseviceService", func() {
 				}}
 				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
 
-				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false, 10, 0)
+				updatesAvailable, countUpdatesAvailable, err := deviceService.GetUpdateAvailableForDeviceByUUID(uuid, false, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 				Expect(err).ToNot(BeNil())
 				Expect(err).To(MatchError(new(services.DeviceNotFoundError)))
 				Expect(updatesAvailable).To(BeNil())
@@ -485,7 +485,7 @@ var _ = Describe("DfseviceService", func() {
 				mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(newImage, nil)
 				mockImageService.EXPECT().GetRollbackImage(gomock.Eq(newImage)).Return(oldImage, nil)
 
-				imageInfo, err := deviceService.GetDeviceImageInfoByUUID(uuid, 10, 0)
+				imageInfo, err := deviceService.GetDeviceImageInfoByUUID(uuid, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 				Expect(err).To(BeNil())
 				Expect(oldImage.Commit.OSTreeCommit).To(Equal(imageInfo.Rollback.Commit.OSTreeCommit))
 				Expect(newImage.Commit.OSTreeCommit).To(Equal(imageInfo.Image.Commit.OSTreeCommit))
@@ -510,7 +510,7 @@ var _ = Describe("DfseviceService", func() {
 				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Eq(uuid)).Return(resp, nil)
 				mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(nil, errors.New("Not found"))
 
-				_, err := deviceService.GetDeviceImageInfoByUUID(uuid, 10, 0)
+				_, err := deviceService.GetDeviceImageInfoByUUID(uuid, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 				Expect(err).To(MatchError(new(services.ImageNotFoundError)))
 			})
 		})
@@ -914,7 +914,7 @@ var _ = Describe("DfseviceService", func() {
 				}
 				mockInventoryClient.EXPECT().ReturnDevicesByID(gomock.Any()).Return(resp, nil)
 
-				deviceDetails, err := deviceService.GetDeviceDetailsByUUID(deviceWithImage.UUID, 10, 0)
+				deviceDetails, err := deviceService.GetDeviceDetailsByUUID(deviceWithImage.UUID, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 				Expect(err).To(BeNil())
 				Expect(deviceDetails).ToNot(BeNil())
 				Expect(deviceDetails.Device.ID).To(Equal(deviceWithImage.ID))
@@ -1419,6 +1419,230 @@ var _ = Describe("DfseviceService", func() {
 		})
 	})
 
+	Context("DeviceUpdateImagesFilters", func() {
+		var orgID string
+		var device models.Device
+		var inventoryDevice inventory.Device
+		var currentDeviceChecksum string
+		var imageSet models.ImageSet
+		var imageV1 models.Image
+		var imageV2 models.Image
+		var imageV3 models.Image
+		var devicesV2 []models.Device
+		var devicesV3 []models.Device
+
+		var intPointer = func(value int) *int { return &value }
+
+		BeforeEach(func() {
+			// do setup data only once for all tests
+			if orgID == "" {
+				orgID = faker.UUIDHyphenated()
+				currentDeviceChecksum = faker.UUIDHyphenated()
+				imageSet = models.ImageSet{OrgID: orgID, Name: faker.Name()}
+				err := db.DB.Create(&imageSet).Error
+				Expect(err).ToNot(HaveOccurred())
+				imageV1 = models.Image{
+					OrgID: orgID, ImageSetID: &imageSet.ID, Name: imageSet.Name, Version: 1, Distribution: "rhel-8.6",
+					Status: models.ImageStatusSuccess,
+					Commit: &models.Commit{OrgID: orgID, OSTreeCommit: currentDeviceChecksum},
+					// set creation time as 2 days ago
+					Model: models.Model{CreatedAt: models.EdgeAPITime{Time: time.Now().Add(-time.Hour * 48), Valid: true}},
+				}
+				imageV2 = models.Image{
+					OrgID: orgID, ImageSetID: &imageSet.ID, Name: imageSet.Name, Version: 2, Distribution: "rhel-8.7",
+					Status: models.ImageStatusSuccess,
+					Commit: &models.Commit{OrgID: orgID, OSTreeCommit: faker.UUIDHyphenated(), InstalledPackages: []models.InstalledPackage{
+						{Name: "git"},
+						{Name: "mc"},
+						{Name: "glibc"},
+						{Name: "ModemManager"},
+						{Name: "ModemManager-glib"},
+					}},
+					CustomPackages: []models.Package{
+						{Name: "git"},
+						{Name: "mc"},
+					},
+					// set creation time as 1 day ago
+					Model: models.Model{CreatedAt: models.EdgeAPITime{Time: time.Now().Add(-time.Hour * 24), Valid: true}},
+				}
+				imageV3 = models.Image{
+					OrgID: orgID, ImageSetID: &imageSet.ID, Name: imageSet.Name, Version: 3, Distribution: "rhel-8.8",
+					Status: models.ImageStatusSuccess,
+					Commit: &models.Commit{OrgID: orgID, OSTreeCommit: faker.UUIDHyphenated(), InstalledPackages: []models.InstalledPackage{
+						{Name: "git"},
+						{Name: "mc"},
+						{Name: "vim"},
+						{Name: "glibc"},
+						{Name: "ModemManager"},
+						{Name: "ModemManager-glib"},
+						{Name: "libnmc"},
+						{Name: "NetworkManager-libnm"},
+					}},
+					CustomPackages: []models.Package{
+						{Name: "git"},
+						{Name: "mc"},
+						{Name: "vim"},
+					},
+				}
+				images := []*models.Image{&imageV1, &imageV2, &imageV3}
+				err = db.DB.Create(&images).Error
+				Expect(err).ToNot(HaveOccurred())
+
+				device = models.Device{OrgID: orgID, UUID: faker.UUIDHyphenated(), ImageID: imageV1.ID}
+				err = db.DB.Create(&device).Error
+				Expect(err).ToNot(HaveOccurred())
+				inventoryDevice = inventory.Device{
+					ID: device.UUID, Ostree: inventory.SystemProfile{
+						RHCClientID: faker.UUIDHyphenated(),
+						RpmOstreeDeployments: []inventory.OSTree{
+							{Checksum: currentDeviceChecksum, Booted: true},
+						},
+					},
+					OrgID: orgID,
+				}
+				devicesV2 = []models.Device{
+					{OrgID: orgID, UUID: faker.UUIDHyphenated(), ImageID: imageV2.ID},
+					{OrgID: orgID, UUID: faker.UUIDHyphenated(), ImageID: imageV2.ID},
+					{OrgID: orgID, UUID: faker.UUIDHyphenated(), ImageID: imageV2.ID},
+				}
+				err = db.DB.Create(&devicesV2).Error
+				Expect(err).ToNot(HaveOccurred())
+				devicesV3 = []models.Device{
+					{OrgID: orgID, UUID: faker.UUIDHyphenated(), ImageID: imageV3.ID},
+					{OrgID: orgID, UUID: faker.UUIDHyphenated(), ImageID: imageV3.ID},
+				}
+				err = db.DB.Create(&devicesV3).Error
+				Expect(err).ToNot(HaveOccurred())
+
+			}
+		})
+
+		It("should return all device update images", func() {
+			updateImagesInfo, overallUpdateAvailable, err := deviceService.GetUpdateAvailableForDevice(
+				inventoryDevice, false, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(overallUpdateAvailable).To(Equal(int64(2)))
+			Expect(len(updateImagesInfo)).To(Equal(2))
+			Expect([]uint{updateImagesInfo[0].Image.ID, updateImagesInfo[1].Image.ID}).To(Equal([]uint{imageV3.ID, imageV2.ID}))
+		})
+
+		It("should return device update image with limit filter", func() {
+			updateImagesInfo, overallUpdateAvailable, err := deviceService.GetUpdateAvailableForDevice(
+				inventoryDevice, false, models.DeviceUpdateImagesFilters{Limit: 1, Offset: 0},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(overallUpdateAvailable).To(Equal(int64(2)))
+			Expect(len(updateImagesInfo)).To(Equal(1))
+			Expect(updateImagesInfo[0].Image.ID).To(Equal(imageV3.ID))
+		})
+
+		It("should return device update image with limit and offset filter", func() {
+			updateImagesInfo, overallUpdateAvailable, err := deviceService.GetUpdateAvailableForDevice(
+				inventoryDevice, false, models.DeviceUpdateImagesFilters{Limit: 1, Offset: 1},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(overallUpdateAvailable).To(Equal(int64(2)))
+			Expect(len(updateImagesInfo)).To(Equal(1))
+			Expect(updateImagesInfo[0].Image.ID).To(Equal(imageV2.ID))
+		})
+
+		It("should return device update image with version filter", func() {
+			updateImagesInfo, overallUpdateAvailable, err := deviceService.GetUpdateAvailableForDevice(
+				inventoryDevice, false, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0, Version: 2},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(overallUpdateAvailable).To(Equal(int64(2)))
+			Expect(len(updateImagesInfo)).To(Equal(1))
+			Expect(updateImagesInfo[0].Image.Version).To(Equal(imageV2.Version))
+			Expect(updateImagesInfo[0].Image.ID).To(Equal(imageV2.ID))
+		})
+
+		It("should return device update image with release filter", func() {
+			updateImagesInfo, overallUpdateAvailable, err := deviceService.GetUpdateAvailableForDevice(
+				inventoryDevice, false, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0, Release: "8.7"},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(overallUpdateAvailable).To(Equal(int64(2)))
+			Expect(len(updateImagesInfo)).To(Equal(1))
+			Expect(updateImagesInfo[0].Image.Distribution).To(Equal(imageV2.Distribution))
+			Expect(updateImagesInfo[0].Image.ID).To(Equal(imageV2.ID))
+		})
+
+		It("should return device update image with created filter", func() {
+			yesterdayDate := time.Now().Add(-time.Hour * 24).Format(common.LayoutISO)
+			updateImagesInfo, overallUpdateAvailable, err := deviceService.GetUpdateAvailableForDevice(
+				inventoryDevice, false, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0, Created: yesterdayDate},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(overallUpdateAvailable).To(Equal(int64(2)))
+			Expect(len(updateImagesInfo)).To(Equal(1))
+			Expect(updateImagesInfo[0].Image.ID).To(Equal(imageV2.ID))
+		})
+
+		It("should return error when created filter value is not valid", func() {
+			_, _, err := deviceService.GetUpdateAvailableForDevice(
+				inventoryDevice, false, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0, Created: "AAAA"},
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(new(services.ParsingISODateError)))
+		})
+
+		It("should return device update image with additionalPackages filter", func() {
+			updateImagesInfo, overallUpdateAvailable, err := deviceService.GetUpdateAvailableForDevice(
+				inventoryDevice, false, models.DeviceUpdateImagesFilters{
+					Limit: 10, Offset: 0, AdditionalPackages: intPointer(len(imageV2.CustomPackages)),
+				},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(overallUpdateAvailable).To(Equal(int64(2)))
+			Expect(len(updateImagesInfo)).To(Equal(1))
+			Expect(updateImagesInfo[0].Image.ID).To(Equal(imageV2.ID))
+		})
+
+		It("should return device update image with allPackages filter", func() {
+			updateImagesInfo, overallUpdateAvailable, err := deviceService.GetUpdateAvailableForDevice(
+				inventoryDevice, false, models.DeviceUpdateImagesFilters{
+					Limit: 10, Offset: 0, AllPackages: intPointer(len(imageV3.Commit.InstalledPackages)),
+				},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(overallUpdateAvailable).To(Equal(int64(2)))
+			Expect(len(updateImagesInfo)).To(Equal(1))
+			Expect(updateImagesInfo[0].Image.ID).To(Equal(imageV3.ID))
+		})
+
+		It("should return device update image with systemsRunning filter", func() {
+			updateImagesInfo, overallUpdateAvailable, err := deviceService.GetUpdateAvailableForDevice(
+				inventoryDevice, false, models.DeviceUpdateImagesFilters{
+					Limit: 10, Offset: 0, SystemsRunning: intPointer(len(devicesV2)),
+				},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(overallUpdateAvailable).To(Equal(int64(2)))
+			Expect(len(updateImagesInfo)).To(Equal(1))
+			Expect(updateImagesInfo[0].Image.ID).To(Equal(imageV2.ID))
+		})
+
+		It("should return device update image with all filters", func() {
+			updateImagesInfo, overallUpdateAvailable, err := deviceService.GetUpdateAvailableForDevice(
+				inventoryDevice, false, models.DeviceUpdateImagesFilters{
+					Limit:              10,
+					Offset:             0,
+					Version:            imageV2.Version,
+					Release:            imageV2.Distribution,
+					AdditionalPackages: intPointer(len(imageV2.CustomPackages)),
+					AllPackages:        intPointer(len(imageV2.Commit.InstalledPackages)),
+					SystemsRunning:     intPointer(len(devicesV2)),
+				},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(overallUpdateAvailable).To(Equal(int64(2)))
+			Expect(len(updateImagesInfo)).To(Equal(1))
+			Expect(updateImagesInfo[0].Image.ID).To(Equal(imageV2.ID))
+		})
+	})
+
 	Context("Get Device Image Info", func() {
 		It("should return full image info", func() {
 			checksum := "fake-checksum"
@@ -1447,12 +1671,12 @@ var _ = Describe("DfseviceService", func() {
 
 			mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(newImage, nil)
 			mockImageService.EXPECT().GetRollbackImage(gomock.Eq(newImage)).Return(oldImage, nil)
-			imageInfoUpd, countUpdateAvailable, err := deviceService.GetUpdateAvailableForDevice(resp.Result[0], false, 10, 0)
+			imageInfoUpd, countUpdateAvailable, err := deviceService.GetUpdateAvailableForDevice(resp.Result[0], false, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 			Expect(err).To(BeNil())
 			Expect(imageInfoUpd).ToNot(BeNil())
 			Expect(countUpdateAvailable).To(Equal(int64(1)))
 
-			imageInfo, err := deviceService.GetDeviceImageInfo(resp.Result[0], 10, 0)
+			imageInfo, err := deviceService.GetDeviceImageInfo(resp.Result[0], models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 			Expect(err).To(BeNil())
 			Expect(imageInfo.Image).ToNot(BeNil())
 			Expect(imageInfo.Rollback).ToNot(BeNil())
@@ -1462,6 +1686,7 @@ var _ = Describe("DfseviceService", func() {
 			Expect(imageInfo.Image.TotalDevicesWithImage).To(Equal(int64(1)))
 
 		})
+
 		It("should return no packages", func() {
 			checksum := "fake-checksum-2"
 			resp := inventory.Response{Total: 1, Count: 1, Result: []inventory.Device{
@@ -1479,7 +1704,7 @@ var _ = Describe("DfseviceService", func() {
 
 			mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(image, nil)
 
-			imageInfo, err := deviceService.GetDeviceImageInfo(resp.Result[0], 10, 0)
+			imageInfo, err := deviceService.GetDeviceImageInfo(resp.Result[0], models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 			Expect(err).To(BeNil())
 			Expect(imageInfo.Image).ToNot(BeNil())
 			Expect(imageInfo.Rollback).To(BeNil())
@@ -1571,7 +1796,7 @@ var _ = Describe("DfseviceService", func() {
 				err = db.DB.Create(&device).Error
 				Expect(err).ToNot(HaveOccurred())
 
-				imageInfo, err := deviceService.GetDeviceImageInfo(inventoryDevice, 10, 0)
+				imageInfo, err := deviceService.GetDeviceImageInfo(inventoryDevice, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(imageInfo.Image).ToNot(BeNil())
 				Expect(imageInfo.Image.ID).To(Equal(image.ID))
@@ -1635,7 +1860,7 @@ var _ = Describe("DfseviceService", func() {
 				err = db.DB.Create(&device).Error
 				Expect(err).ToNot(HaveOccurred())
 
-				imageInfo, err := deviceService.GetDeviceImageInfo(inventoryDevice, 10, 0)
+				imageInfo, err := deviceService.GetDeviceImageInfo(inventoryDevice, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(imageInfo.Image).ToNot(BeNil())
 				Expect(imageInfo.Image.ID).To(Equal(image.ID))
@@ -1705,7 +1930,7 @@ var _ = Describe("DfseviceService", func() {
 				mockImageService.EXPECT().GetImageByOSTreeCommitHash(checksum).Return(image, nil)
 				mockImageService.EXPECT().GetRollbackImage(image).Return(nil, expectedError)
 
-				_, err = deviceService.GetDeviceImageInfo(inventoryDevice, 10, 0)
+				_, err = deviceService.GetDeviceImageInfo(inventoryDevice, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(Equal(expectedError))
 			})
@@ -1798,7 +2023,7 @@ var _ = Describe("DfseviceService", func() {
 		It("should return first result", func() {
 			mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(oldImage, nil)
 
-			imageInfo, err := deviceService.GetDeviceImageInfoByUUID(uuid, 1, 0)
+			imageInfo, err := deviceService.GetDeviceImageInfoByUUID(uuid, models.DeviceUpdateImagesFilters{Limit: 1, Offset: 0})
 
 			Expect(err).To(BeNil())
 			Expect(len((*imageInfo.UpdatesAvailable))).To(Equal(1))
@@ -1808,7 +2033,7 @@ var _ = Describe("DfseviceService", func() {
 		It("should return last result", func() {
 			mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(oldImage, nil)
 
-			imageInfo, err := deviceService.GetDeviceImageInfoByUUID(uuid, 1, 1)
+			imageInfo, err := deviceService.GetDeviceImageInfoByUUID(uuid, models.DeviceUpdateImagesFilters{Limit: 1, Offset: 1})
 			Expect(err).To(BeNil())
 			Expect(len((*imageInfo.UpdatesAvailable))).To(Equal(1))
 			Expect(newImage.Version).To(Equal((*imageInfo.UpdatesAvailable)[0].Image.Version))
@@ -1816,14 +2041,14 @@ var _ = Describe("DfseviceService", func() {
 		It("should return all result", func() {
 			mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(oldImage, nil)
 
-			imageInfo, err := deviceService.GetDeviceImageInfoByUUID(uuid, 10, 0)
+			imageInfo, err := deviceService.GetDeviceImageInfoByUUID(uuid, models.DeviceUpdateImagesFilters{Limit: 10, Offset: 0})
 			Expect(err).To(BeNil())
 			Expect(len((*imageInfo.UpdatesAvailable))).To(Equal(2))
 		})
 		It("should return last result", func() {
 			mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(oldImage, nil)
 
-			imageInfo, err := deviceService.GetDeviceImageInfoByUUID(uuid, -1, 1)
+			imageInfo, err := deviceService.GetDeviceImageInfoByUUID(uuid, models.DeviceUpdateImagesFilters{Limit: -1, Offset: 1})
 			Expect(err).To(BeNil())
 			fmt.Printf("\n *imageInfo.UpdatesAvailable %v\n", *imageInfo.UpdatesAvailable)
 			Expect(len((*imageInfo.UpdatesAvailable))).To(Equal(1))
@@ -1831,7 +2056,7 @@ var _ = Describe("DfseviceService", func() {
 		It("should return last result", func() {
 			mockImageService.EXPECT().GetImageByOSTreeCommitHash(gomock.Eq(checksum)).Return(oldImage, nil)
 
-			imageInfo, err := deviceService.GetDeviceImageInfoByUUID(uuid, -1, 0)
+			imageInfo, err := deviceService.GetDeviceImageInfoByUUID(uuid, models.DeviceUpdateImagesFilters{Limit: -1, Offset: 0})
 			Expect(err).To(BeNil())
 			fmt.Printf("\n *imageInfo.UpdatesAvailable %v\n", *imageInfo.UpdatesAvailable)
 			Expect(len((*imageInfo.UpdatesAvailable))).To(Equal(2))

--- a/pkg/services/errors.go
+++ b/pkg/services/errors.go
@@ -53,6 +53,7 @@ const SomeDevicesDoesNotExistsMsg = "image-set not found for all devices"
 const KafkaAllBrokersDownMsg = "Cannot connect to any Kafka brokers"
 const DBCommitErrorMsg = "Error searching for ImageSet of Device Images"
 const KafkaProducerInstanceUndefinedMsg = "kafka producer instance is undefined"
+const ParsingISODateErrorMsg = "error occurred while parsing string for ISO date"
 
 // DeviceNotFoundError indicates the device was not found
 type DeviceNotFoundError struct{}
@@ -410,4 +411,11 @@ type ImageCommitNotFound struct{}
 
 func (e *ImageCommitNotFound) Error() string {
 	return ImageCommitNotFoundMsg
+}
+
+// ParsingISODateError occurs when parsing a string for iso date fails
+type ParsingISODateError struct{}
+
+func (e *ParsingISODateError) Error() string {
+	return ParsingISODateErrorMsg
 }

--- a/pkg/services/mock_services/devices.go
+++ b/pkg/services/mock_services/devices.go
@@ -5,52 +5,38 @@
 package mock_services
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	inventory "github.com/redhatinsights/edge-api/pkg/clients/inventory"
 	models "github.com/redhatinsights/edge-api/pkg/models"
 	gorm "gorm.io/gorm"
-	reflect "reflect"
 )
 
-// MockDeviceServiceInterface is a mock of DeviceServiceInterface interface
+// MockDeviceServiceInterface is a mock of DeviceServiceInterface interface.
 type MockDeviceServiceInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockDeviceServiceInterfaceMockRecorder
 }
 
-// MockDeviceServiceInterfaceMockRecorder is the mock recorder for MockDeviceServiceInterface
+// MockDeviceServiceInterfaceMockRecorder is the mock recorder for MockDeviceServiceInterface.
 type MockDeviceServiceInterfaceMockRecorder struct {
 	mock *MockDeviceServiceInterface
 }
 
-// NewMockDeviceServiceInterface creates a new mock instance
+// NewMockDeviceServiceInterface creates a new mock instance.
 func NewMockDeviceServiceInterface(ctrl *gomock.Controller) *MockDeviceServiceInterface {
 	mock := &MockDeviceServiceInterface{ctrl: ctrl}
 	mock.recorder = &MockDeviceServiceInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDeviceServiceInterface) EXPECT() *MockDeviceServiceInterfaceMockRecorder {
 	return m.recorder
 }
 
-// GetDevices mocks base method
-func (m *MockDeviceServiceInterface) GetDevices(params *inventory.Params) (*models.DeviceDetailsList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDevices", params)
-	ret0, _ := ret[0].(*models.DeviceDetailsList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDevices indicates an expected call of GetDevices
-func (mr *MockDeviceServiceInterfaceMockRecorder) GetDevices(params interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDevices", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDevices), params)
-}
-
-// GetDeviceByID mocks base method
+// GetDeviceByID mocks base method.
 func (m *MockDeviceServiceInterface) GetDeviceByID(deviceID uint) (*models.Device, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDeviceByID", deviceID)
@@ -59,43 +45,13 @@ func (m *MockDeviceServiceInterface) GetDeviceByID(deviceID uint) (*models.Devic
 	return ret0, ret1
 }
 
-// GetDeviceByID indicates an expected call of GetDeviceByID
+// GetDeviceByID indicates an expected call of GetDeviceByID.
 func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceByID(deviceID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceByID", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceByID), deviceID)
 }
 
-// GetDevicesView mocks base method
-func (m *MockDeviceServiceInterface) GetDevicesView(limit, offset int, tx *gorm.DB) (*models.DeviceViewList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDevicesView", limit, offset, tx)
-	ret0, _ := ret[0].(*models.DeviceViewList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDevicesView indicates an expected call of GetDevicesView
-func (mr *MockDeviceServiceInterfaceMockRecorder) GetDevicesView(limit, offset, tx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDevicesView", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDevicesView), limit, offset, tx)
-}
-
-// GetDevicesCount mocks base method
-func (m *MockDeviceServiceInterface) GetDevicesCount(tx *gorm.DB) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDevicesCount", tx)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDevicesCount indicates an expected call of GetDevicesCount
-func (mr *MockDeviceServiceInterfaceMockRecorder) GetDevicesCount(tx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDevicesCount", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDevicesCount), tx)
-}
-
-// GetDeviceByUUID mocks base method
+// GetDeviceByUUID mocks base method.
 func (m *MockDeviceServiceInterface) GetDeviceByUUID(deviceUUID string) (*models.Device, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDeviceByUUID", deviceUUID)
@@ -104,59 +60,146 @@ func (m *MockDeviceServiceInterface) GetDeviceByUUID(deviceUUID string) (*models
 	return ret0, ret1
 }
 
-// GetDeviceByUUID indicates an expected call of GetDeviceByUUID
+// GetDeviceByUUID indicates an expected call of GetDeviceByUUID.
 func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceByUUID(deviceUUID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceByUUID", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceByUUID), deviceUUID)
 }
 
-// GetDeviceDetailsByUUID mocks base method
-func (m *MockDeviceServiceInterface) GetDeviceDetailsByUUID(deviceUUID string, imagesLimit, imagesOffSet int) (*models.DeviceDetails, error) {
+// GetDeviceDetails mocks base method.
+func (m *MockDeviceServiceInterface) GetDeviceDetails(device inventory.Device, deviceUpdateImagesFilters models.DeviceUpdateImagesFilters) (*models.DeviceDetails, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeviceDetailsByUUID", deviceUUID, imagesLimit, imagesOffSet)
+	ret := m.ctrl.Call(m, "GetDeviceDetails", device, deviceUpdateImagesFilters)
 	ret0, _ := ret[0].(*models.DeviceDetails)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetDeviceDetailsByUUID indicates an expected call of GetDeviceDetailsByUUID
-func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceDetailsByUUID(deviceUUID, imagesLimit, imagesOffSet interface{}) *gomock.Call {
+// GetDeviceDetails indicates an expected call of GetDeviceDetails.
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceDetails(device, deviceUpdateImagesFilters interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceDetailsByUUID", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceDetailsByUUID), deviceUUID, imagesLimit, imagesOffSet)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceDetails", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceDetails), device, deviceUpdateImagesFilters)
 }
 
-// GetUpdateAvailableForDeviceByUUID mocks base method
-func (m *MockDeviceServiceInterface) GetUpdateAvailableForDeviceByUUID(deviceUUID string, latest bool, imagesLimit, imagesOffSet int) ([]models.ImageUpdateAvailable, int64, error) {
+// GetDeviceDetailsByUUID mocks base method.
+func (m *MockDeviceServiceInterface) GetDeviceDetailsByUUID(deviceUUID string, deviceUpdateImagesFilters models.DeviceUpdateImagesFilters) (*models.DeviceDetails, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUpdateAvailableForDeviceByUUID", deviceUUID, latest, imagesLimit, imagesOffSet)
-	ret0, _ := ret[0].([]models.ImageUpdateAvailable)
-	ret1, _ := ret[1].(int64)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret := m.ctrl.Call(m, "GetDeviceDetailsByUUID", deviceUUID, deviceUpdateImagesFilters)
+	ret0, _ := ret[0].(*models.DeviceDetails)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// GetUpdateAvailableForDeviceByUUID indicates an expected call of GetUpdateAvailableForDeviceByUUID
-func (mr *MockDeviceServiceInterfaceMockRecorder) GetUpdateAvailableForDeviceByUUID(deviceUUID, latest, imagesLimit, imagesOffSet interface{}) *gomock.Call {
+// GetDeviceDetailsByUUID indicates an expected call of GetDeviceDetailsByUUID.
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceDetailsByUUID(deviceUUID, deviceUpdateImagesFilters interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdateAvailableForDeviceByUUID", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetUpdateAvailableForDeviceByUUID), deviceUUID, latest, imagesLimit, imagesOffSet)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceDetailsByUUID", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceDetailsByUUID), deviceUUID, deviceUpdateImagesFilters)
 }
 
-// GetDeviceImageInfoByUUID mocks base method
-func (m *MockDeviceServiceInterface) GetDeviceImageInfoByUUID(deviceUUID string, imagesLimit, imagesOffSet int) (*models.ImageInfo, error) {
+// GetDeviceImageInfo mocks base method.
+func (m *MockDeviceServiceInterface) GetDeviceImageInfo(device inventory.Device, deviceUpdateImagesFilters models.DeviceUpdateImagesFilters) (*models.ImageInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeviceImageInfoByUUID", deviceUUID, imagesLimit, imagesOffSet)
+	ret := m.ctrl.Call(m, "GetDeviceImageInfo", device, deviceUpdateImagesFilters)
 	ret0, _ := ret[0].(*models.ImageInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetDeviceImageInfoByUUID indicates an expected call of GetDeviceImageInfoByUUID
-func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceImageInfoByUUID(deviceUUID, imagesLimit, imagesOffSet interface{}) *gomock.Call {
+// GetDeviceImageInfo indicates an expected call of GetDeviceImageInfo.
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceImageInfo(device, deviceUpdateImagesFilters interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceImageInfoByUUID", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceImageInfoByUUID), deviceUUID, imagesLimit, imagesOffSet)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceImageInfo", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceImageInfo), device, deviceUpdateImagesFilters)
 }
 
-// GetLatestCommitFromDevices mocks base method
+// GetDeviceImageInfoByUUID mocks base method.
+func (m *MockDeviceServiceInterface) GetDeviceImageInfoByUUID(deviceUUID string, deviceUpdateImagesFilters models.DeviceUpdateImagesFilters) (*models.ImageInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeviceImageInfoByUUID", deviceUUID, deviceUpdateImagesFilters)
+	ret0, _ := ret[0].(*models.ImageInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeviceImageInfoByUUID indicates an expected call of GetDeviceImageInfoByUUID.
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceImageInfoByUUID(deviceUUID, deviceUpdateImagesFilters interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceImageInfoByUUID", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceImageInfoByUUID), deviceUUID, deviceUpdateImagesFilters)
+}
+
+// GetDeviceLastBootedDeployment mocks base method.
+func (m *MockDeviceServiceInterface) GetDeviceLastBootedDeployment(device inventory.Device) *inventory.OSTree {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeviceLastBootedDeployment", device)
+	ret0, _ := ret[0].(*inventory.OSTree)
+	return ret0
+}
+
+// GetDeviceLastBootedDeployment indicates an expected call of GetDeviceLastBootedDeployment.
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceLastBootedDeployment(device interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceLastBootedDeployment", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceLastBootedDeployment), device)
+}
+
+// GetDeviceLastDeployment mocks base method.
+func (m *MockDeviceServiceInterface) GetDeviceLastDeployment(device inventory.Device) *inventory.OSTree {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeviceLastDeployment", device)
+	ret0, _ := ret[0].(*inventory.OSTree)
+	return ret0
+}
+
+// GetDeviceLastDeployment indicates an expected call of GetDeviceLastDeployment.
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceLastDeployment(device interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceLastDeployment", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceLastDeployment), device)
+}
+
+// GetDevices mocks base method.
+func (m *MockDeviceServiceInterface) GetDevices(params *inventory.Params) (*models.DeviceDetailsList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDevices", params)
+	ret0, _ := ret[0].(*models.DeviceDetailsList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDevices indicates an expected call of GetDevices.
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetDevices(params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDevices", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDevices), params)
+}
+
+// GetDevicesCount mocks base method.
+func (m *MockDeviceServiceInterface) GetDevicesCount(tx *gorm.DB) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDevicesCount", tx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDevicesCount indicates an expected call of GetDevicesCount.
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetDevicesCount(tx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDevicesCount", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDevicesCount), tx)
+}
+
+// GetDevicesView mocks base method.
+func (m *MockDeviceServiceInterface) GetDevicesView(limit, offset int, tx *gorm.DB) (*models.DeviceViewList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDevicesView", limit, offset, tx)
+	ret0, _ := ret[0].(*models.DeviceViewList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDevicesView indicates an expected call of GetDevicesView.
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetDevicesView(limit, offset, tx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDevicesView", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDevicesView), limit, offset, tx)
+}
+
+// GetLatestCommitFromDevices mocks base method.
 func (m *MockDeviceServiceInterface) GetLatestCommitFromDevices(orgID string, devicesUUID []string) (uint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLatestCommitFromDevices", orgID, devicesUUID)
@@ -165,87 +208,45 @@ func (m *MockDeviceServiceInterface) GetLatestCommitFromDevices(orgID string, de
 	return ret0, ret1
 }
 
-// GetLatestCommitFromDevices indicates an expected call of GetLatestCommitFromDevices
+// GetLatestCommitFromDevices indicates an expected call of GetLatestCommitFromDevices.
 func (mr *MockDeviceServiceInterfaceMockRecorder) GetLatestCommitFromDevices(orgID, devicesUUID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestCommitFromDevices", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetLatestCommitFromDevices), orgID, devicesUUID)
 }
 
-// GetDeviceDetails mocks base method
-func (m *MockDeviceServiceInterface) GetDeviceDetails(device inventory.Device, imagesLimit, imagesOffSet int) (*models.DeviceDetails, error) {
+// GetUpdateAvailableForDevice mocks base method.
+func (m *MockDeviceServiceInterface) GetUpdateAvailableForDevice(device inventory.Device, latest bool, deviceUpdateImagesFilters models.DeviceUpdateImagesFilters) ([]models.ImageUpdateAvailable, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeviceDetails", device, imagesLimit, imagesOffSet)
-	ret0, _ := ret[0].(*models.DeviceDetails)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDeviceDetails indicates an expected call of GetDeviceDetails
-func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceDetails(device, imagesLimit, imagesOffSet interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceDetails", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceDetails), device, imagesLimit, imagesOffSet)
-}
-
-// GetUpdateAvailableForDevice mocks base method
-func (m *MockDeviceServiceInterface) GetUpdateAvailableForDevice(device inventory.Device, latest bool, imagesLimit, imagesOffSet int) ([]models.ImageUpdateAvailable, int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUpdateAvailableForDevice", device, latest, imagesLimit, imagesOffSet)
+	ret := m.ctrl.Call(m, "GetUpdateAvailableForDevice", device, latest, deviceUpdateImagesFilters)
 	ret0, _ := ret[0].([]models.ImageUpdateAvailable)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// GetUpdateAvailableForDevice indicates an expected call of GetUpdateAvailableForDevice
-func (mr *MockDeviceServiceInterfaceMockRecorder) GetUpdateAvailableForDevice(device, latest, imagesLimit, imagesOffSet interface{}) *gomock.Call {
+// GetUpdateAvailableForDevice indicates an expected call of GetUpdateAvailableForDevice.
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetUpdateAvailableForDevice(device, latest, deviceUpdateImagesFilters interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdateAvailableForDevice", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetUpdateAvailableForDevice), device, latest, imagesLimit, imagesOffSet)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdateAvailableForDevice", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetUpdateAvailableForDevice), device, latest, deviceUpdateImagesFilters)
 }
 
-// GetDeviceImageInfo mocks base method
-func (m *MockDeviceServiceInterface) GetDeviceImageInfo(device inventory.Device, imagesLimit, imagesOffSet int) (*models.ImageInfo, error) {
+// GetUpdateAvailableForDeviceByUUID mocks base method.
+func (m *MockDeviceServiceInterface) GetUpdateAvailableForDeviceByUUID(deviceUUID string, latest bool, deviceUpdateImagesFilters models.DeviceUpdateImagesFilters) ([]models.ImageUpdateAvailable, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeviceImageInfo", device, imagesLimit, imagesOffSet)
-	ret0, _ := ret[0].(*models.ImageInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "GetUpdateAvailableForDeviceByUUID", deviceUUID, latest, deviceUpdateImagesFilters)
+	ret0, _ := ret[0].([]models.ImageUpdateAvailable)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
-// GetDeviceImageInfo indicates an expected call of GetDeviceImageInfo
-func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceImageInfo(device, imagesLimit, imagesOffSet interface{}) *gomock.Call {
+// GetUpdateAvailableForDeviceByUUID indicates an expected call of GetUpdateAvailableForDeviceByUUID.
+func (mr *MockDeviceServiceInterfaceMockRecorder) GetUpdateAvailableForDeviceByUUID(deviceUUID, latest, deviceUpdateImagesFilters interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceImageInfo", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceImageInfo), device, imagesLimit, imagesOffSet)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdateAvailableForDeviceByUUID", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetUpdateAvailableForDeviceByUUID), deviceUUID, latest, deviceUpdateImagesFilters)
 }
 
-// GetDeviceLastDeployment mocks base method
-func (m *MockDeviceServiceInterface) GetDeviceLastDeployment(device inventory.Device) *inventory.OSTree {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeviceLastDeployment", device)
-	ret0, _ := ret[0].(*inventory.OSTree)
-	return ret0
-}
-
-// GetDeviceLastDeployment indicates an expected call of GetDeviceLastDeployment
-func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceLastDeployment(device interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceLastDeployment", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceLastDeployment), device)
-}
-
-// GetDeviceLastBootedDeployment mocks base method
-func (m *MockDeviceServiceInterface) GetDeviceLastBootedDeployment(device inventory.Device) *inventory.OSTree {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeviceLastBootedDeployment", device)
-	ret0, _ := ret[0].(*inventory.OSTree)
-	return ret0
-}
-
-// GetDeviceLastBootedDeployment indicates an expected call of GetDeviceLastBootedDeployment
-func (mr *MockDeviceServiceInterfaceMockRecorder) GetDeviceLastBootedDeployment(device interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceLastBootedDeployment", reflect.TypeOf((*MockDeviceServiceInterface)(nil).GetDeviceLastBootedDeployment), device)
-}
-
-// ProcessPlatformInventoryCreateEvent mocks base method
+// ProcessPlatformInventoryCreateEvent mocks base method.
 func (m *MockDeviceServiceInterface) ProcessPlatformInventoryCreateEvent(message []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessPlatformInventoryCreateEvent", message)
@@ -253,27 +254,13 @@ func (m *MockDeviceServiceInterface) ProcessPlatformInventoryCreateEvent(message
 	return ret0
 }
 
-// ProcessPlatformInventoryCreateEvent indicates an expected call of ProcessPlatformInventoryCreateEvent
+// ProcessPlatformInventoryCreateEvent indicates an expected call of ProcessPlatformInventoryCreateEvent.
 func (mr *MockDeviceServiceInterfaceMockRecorder) ProcessPlatformInventoryCreateEvent(message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessPlatformInventoryCreateEvent", reflect.TypeOf((*MockDeviceServiceInterface)(nil).ProcessPlatformInventoryCreateEvent), message)
 }
 
-// ProcessPlatformInventoryUpdatedEvent mocks base method
-func (m *MockDeviceServiceInterface) ProcessPlatformInventoryUpdatedEvent(message []byte) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessPlatformInventoryUpdatedEvent", message)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ProcessPlatformInventoryUpdatedEvent indicates an expected call of ProcessPlatformInventoryUpdatedEvent
-func (mr *MockDeviceServiceInterfaceMockRecorder) ProcessPlatformInventoryUpdatedEvent(message interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessPlatformInventoryUpdatedEvent", reflect.TypeOf((*MockDeviceServiceInterface)(nil).ProcessPlatformInventoryUpdatedEvent), message)
-}
-
-// ProcessPlatformInventoryDeleteEvent mocks base method
+// ProcessPlatformInventoryDeleteEvent mocks base method.
 func (m *MockDeviceServiceInterface) ProcessPlatformInventoryDeleteEvent(message []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessPlatformInventoryDeleteEvent", message)
@@ -281,31 +268,45 @@ func (m *MockDeviceServiceInterface) ProcessPlatformInventoryDeleteEvent(message
 	return ret0
 }
 
-// ProcessPlatformInventoryDeleteEvent indicates an expected call of ProcessPlatformInventoryDeleteEvent
+// ProcessPlatformInventoryDeleteEvent indicates an expected call of ProcessPlatformInventoryDeleteEvent.
 func (mr *MockDeviceServiceInterfaceMockRecorder) ProcessPlatformInventoryDeleteEvent(message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessPlatformInventoryDeleteEvent", reflect.TypeOf((*MockDeviceServiceInterface)(nil).ProcessPlatformInventoryDeleteEvent), message)
 }
 
-// SyncDevicesWithInventory mocks base method
+// ProcessPlatformInventoryUpdatedEvent mocks base method.
+func (m *MockDeviceServiceInterface) ProcessPlatformInventoryUpdatedEvent(message []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProcessPlatformInventoryUpdatedEvent", message)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ProcessPlatformInventoryUpdatedEvent indicates an expected call of ProcessPlatformInventoryUpdatedEvent.
+func (mr *MockDeviceServiceInterfaceMockRecorder) ProcessPlatformInventoryUpdatedEvent(message interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessPlatformInventoryUpdatedEvent", reflect.TypeOf((*MockDeviceServiceInterface)(nil).ProcessPlatformInventoryUpdatedEvent), message)
+}
+
+// SyncDevicesWithInventory mocks base method.
 func (m *MockDeviceServiceInterface) SyncDevicesWithInventory(orgID string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SyncDevicesWithInventory", orgID)
 }
 
-// SyncDevicesWithInventory indicates an expected call of SyncDevicesWithInventory
+// SyncDevicesWithInventory indicates an expected call of SyncDevicesWithInventory.
 func (mr *MockDeviceServiceInterfaceMockRecorder) SyncDevicesWithInventory(orgID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncDevicesWithInventory", reflect.TypeOf((*MockDeviceServiceInterface)(nil).SyncDevicesWithInventory), orgID)
 }
 
-// SyncInventoryWithDevices mocks base method
+// SyncInventoryWithDevices mocks base method.
 func (m *MockDeviceServiceInterface) SyncInventoryWithDevices(orgID string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SyncInventoryWithDevices", orgID)
 }
 
-// SyncInventoryWithDevices indicates an expected call of SyncInventoryWithDevices
+// SyncInventoryWithDevices indicates an expected call of SyncInventoryWithDevices.
 func (mr *MockDeviceServiceInterfaceMockRecorder) SyncInventoryWithDevices(orgID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncInventoryWithDevices", reflect.TypeOf((*MockDeviceServiceInterface)(nil).SyncInventoryWithDevices), orgID)


### PR DESCRIPTION
# Description
Implement deviceUpdateImagesFilters to allow to filter images for device update. The issue raised when the user click on update for a device, on the device update view there is a filter that allow to filter update target images, the request was sent to backend, but as the backend feature was not implement, as the filter feature was not implemented, the same result was returned. 

FIXES: https://issues.redhat.com/browse/THEEDGE-3795

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor


# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

