### PR TITLE
image-builder: add feature flag to pass user to image-builder

### DIFF
--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -320,7 +320,7 @@ func (c *Client) ComposeInstaller(image *models.Image) (*models.Image, error) {
 		rhsm = false
 	}
 	var users []User
-	if image.Installer != nil && image.Installer.Username != "" && image.Installer.SSHKey != "" {
+	if feature.PassUserToImageBuilder.IsEnabled() && image.Installer != nil && image.Installer.Username != "" && image.Installer.SSHKey != "" {
 		users = []User{{Name: image.Installer.Username, SSHKey: image.Installer.SSHKey}}
 	}
 

--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/redhatinsights/edge-api/pkg/db"
 	"github.com/redhatinsights/edge-api/pkg/models"
+	feature "github.com/redhatinsights/edge-api/unleash/features"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/redhatinsights/edge-api/config"
@@ -77,6 +78,9 @@ var _ = Describe("Image Builder Client Test", func() {
 		os.Remove(dbName)
 		// restore the original image builder url
 		conf.ImageBuilderConfig.URL = originalImageBuilderURL
+		// disable passing user to image builder feature flag
+		err := os.Unsetenv(feature.PassUserToImageBuilder.EnvVar)
+		Expect(err).ToNot(HaveOccurred())
 	})
 	It("should init client", func() {
 		Expect(client).ToNot(BeNil())
@@ -708,6 +712,9 @@ var _ = Describe("Image Builder Client Test", func() {
 	})
 
 	It("test compose installer with username and ssh-key", func() {
+		// enable feature flag
+		err := os.Setenv(feature.PassUserToImageBuilder.EnvVar, "true")
+		Expect(err).ToNot(HaveOccurred())
 		installer := models.Installer{Username: faker.Username(), SSHKey: faker.UUIDHyphenated()}
 		composeJobID := "compose-job-id-returned-from-image-builder"
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -738,7 +745,7 @@ var _ = Describe("Image Builder Client Test", func() {
 			Commit:       &models.Commit{Arch: "x86_64", Repo: &models.Repo{}},
 			Installer:    &installer,
 		}
-		img, err := client.ComposeInstaller(img)
+		img, err = client.ComposeInstaller(img)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(img).ToNot(BeNil())
 		Expect(img.Installer.ComposeJobID).To(Equal(composeJobID))
@@ -746,6 +753,9 @@ var _ = Describe("Image Builder Client Test", func() {
 	})
 
 	It("test compose installer without username and ssh-key", func() {
+		// enable feature flag
+		err := os.Setenv(feature.PassUserToImageBuilder.EnvVar, "true")
+		Expect(err).ToNot(HaveOccurred())
 		// install has no username and ssh-key
 		installer := models.Installer{}
 		composeJobID := "compose-job-id-returned-from-image-builder"
@@ -775,7 +785,46 @@ var _ = Describe("Image Builder Client Test", func() {
 			Commit:       &models.Commit{Arch: "x86_64", Repo: &models.Repo{}},
 			Installer:    &installer,
 		}
-		img, err := client.ComposeInstaller(img)
+		img, err = client.ComposeInstaller(img)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(img).ToNot(BeNil())
+		Expect(img.Installer.ComposeJobID).To(Equal(composeJobID))
+		Expect(img.Commit.ExternalURL).To(BeFalse())
+	})
+
+	It("test compose installer should not pass username and ssh-key when feature flag is disabled", func() {
+		// ensure feature flag disabled
+		err := os.Unsetenv(feature.PassUserToImageBuilder.EnvVar)
+		Expect(err).ToNot(HaveOccurred())
+		installer := models.Installer{Username: faker.Username(), SSHKey: faker.UUIDHyphenated()}
+		composeJobID := "compose-job-id-returned-from-image-builder"
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, err := io.ReadAll(r.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(b).ToNot(BeNil())
+			var req ComposeRequest
+			err = json.Unmarshal(b, &req)
+			Expect(err).ToNot(HaveOccurred())
+			// when feature flag is disabled the user and ssh key should not not be passed to image builder
+			Expect(req.Customizations.Users).To(BeNil())
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			payload := fmt.Sprintf(`{"id": "%s"}`, composeJobID)
+			_, err = fmt.Fprintln(w, payload)
+			Expect(err).ToNot(HaveOccurred())
+		}))
+		defer ts.Close()
+		config.Get().ImageBuilderConfig.URL = ts.URL
+
+		pkgs := []models.Package{{Name: "vim"}, {Name: "ansible"}}
+		img := &models.Image{
+			Distribution: "rhel-8",
+			Packages:     pkgs,
+			Commit:       &models.Commit{Arch: "x86_64", Repo: &models.Repo{}},
+			Installer:    &installer,
+		}
+		img, err = client.ComposeInstaller(img)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(img).ToNot(BeNil())
 		Expect(img.Installer.ComposeJobID).To(Equal(composeJobID))

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -122,6 +122,9 @@ var HideCreateGroup = &Flag{Name: "edge-management.hide-create-group", EnvVar: "
 // SkipInjectKickstartToISO toggles INJECTING kickstart to iso file
 var SkipInjectKickstartToISO = &Flag{Name: "edge-management.skip-inject-kickstart-to-iso", EnvVar: "FEATURE_SKIP_INJECT_KICKSTART_TO_ISO"}
 
+// PassUserToImageBuilder toggles passing user to image builder
+var PassUserToImageBuilder = &Flag{Name: "edge-management.pass-user-to-image-builder", EnvVar: "FEATURE_PASS_USER_TO_IMAGE_BUILDER"}
+
 // EdgeParityGroupsMigration toggles edge parity groups migration
 var EdgeParityGroupsMigration = &Flag{Name: "edgeParity.groups-migration", EnvVar: "FEATURE_EDGE_PARITY_GROUPS_MIGRATION"}
 


### PR DESCRIPTION
# Description
When passing user and sskey to image builder the os installer is behaving differently and request some data to setup.

FIXES: https://issues.redhat.com/browse/THEEDGE-3828

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

