### PR TITLE
image-builder: fixes users type passed to image-builder as slice

### DIFF
--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -70,7 +70,7 @@ type OSTree struct {
 type Customizations struct {
 	Packages            *[]string     `json:"packages"`
 	PayloadRepositories *[]Repository `json:"payload_repositories,omitempty"`
-	Users               *[]User       `json:"users,omitempty"`
+	Users               []User        `json:"users,omitempty"`
 	Subscription        *Subscription `json:"subscription,omitempty"`
 }
 
@@ -319,15 +319,15 @@ func (c *Client) ComposeInstaller(image *models.Image) (*models.Image, error) {
 		repoURL = image.Commit.Repo.URL
 		rhsm = false
 	}
-	var users []User
+	users := make([]User, 0)
 	if feature.PassUserToImageBuilder.IsEnabled() && image.Installer != nil && image.Installer.Username != "" && image.Installer.SSHKey != "" {
-		users = []User{{Name: image.Installer.Username, SSHKey: image.Installer.SSHKey}}
+		users = append(users, User{Name: image.Installer.Username, SSHKey: image.Installer.SSHKey})
 	}
 
 	req := &ComposeRequest{
 		Customizations: &Customizations{
 			Packages: &pkgs,
-			Users:    &users,
+			Users:    users,
 		},
 
 		Distribution: image.Distribution,

--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -724,10 +724,9 @@ var _ = Describe("Image Builder Client Test", func() {
 			var req ComposeRequest
 			err = json.Unmarshal(b, &req)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(req.Customizations.Users).ToNot(BeNil())
-			Expect(len(*req.Customizations.Users)).To(Equal(1))
-			Expect((*req.Customizations.Users)[0].Name).To(Equal(installer.Username))
-			Expect((*req.Customizations.Users)[0].SSHKey).To(Equal(installer.SSHKey))
+			Expect(len(req.Customizations.Users)).To(Equal(1))
+			Expect((req.Customizations.Users)[0].Name).To(Equal(installer.Username))
+			Expect((req.Customizations.Users)[0].SSHKey).To(Equal(installer.SSHKey))
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
@@ -767,7 +766,7 @@ var _ = Describe("Image Builder Client Test", func() {
 			err = json.Unmarshal(b, &req)
 			Expect(err).ToNot(HaveOccurred())
 			// when installer username or ssh-key are empty no user is passed to image-builder
-			Expect(req.Customizations.Users).To(BeNil())
+			Expect(len(req.Customizations.Users)).To(Equal(0))
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
@@ -806,7 +805,7 @@ var _ = Describe("Image Builder Client Test", func() {
 			err = json.Unmarshal(b, &req)
 			Expect(err).ToNot(HaveOccurred())
 			// when feature flag is disabled the user and ssh key should not not be passed to image builder
-			Expect(req.Customizations.Users).To(BeNil())
+			Expect(len(req.Customizations.Users)).To(Equal(0))
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)


### PR DESCRIPTION
# Description
image-builder was complaining that the users passed was nil and a list was expected.

FIXES: https://issues.redhat.com/browse/THEEDGE-3828

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

