### PR TITLE
add improvements on subscription with activation key

### DIFF
--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -831,10 +831,7 @@ var _ = Describe("Image Builder Client Test", func() {
 	})
 
 	It("test compose installer with activation key", func() {
-		// enable feature flag
-		err := os.Setenv(feature.PassUserToImageBuilder.EnvVar, "true")
 		orgID := "234"
-		Expect(err).ToNot(HaveOccurred())
 		installer := models.Installer{Username: faker.Username(), SSHKey: faker.UUIDHyphenated()}
 		composeJobID := "compose-job-id-returned-from-image-builder"
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -845,6 +842,11 @@ var _ = Describe("Image Builder Client Test", func() {
 			err = json.Unmarshal(b, &req)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(req.Customizations.Subscription.ActivationKey).To(Equal("test-key"))
+			Expect(req.Customizations.Subscription.Organization).To(Equal(234))
+			Expect(req.Customizations.Subscription.RHC).To(Equal(true))
+			Expect(req.Customizations.Subscription.Insights).To(Equal(true))
+			Expect(req.Customizations.Subscription.BaseUrl).To(Equal(config.Get().SubscriptionBaseUrl))
+			Expect(req.Customizations.Subscription.ServerUrl).To(Equal(config.Get().SubscriptionBaseUrl))
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
@@ -862,7 +864,7 @@ var _ = Describe("Image Builder Client Test", func() {
 			Installer:     &installer,
 			ActivationKey: "test-key",
 		}
-		img, err = client.ComposeInstaller(img)
+		img, err := client.ComposeInstaller(img)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(img).ToNot(BeNil())
 		Expect(img.Installer.ComposeJobID).To(Equal(composeJobID))
@@ -870,10 +872,7 @@ var _ = Describe("Image Builder Client Test", func() {
 	})
 
 	It("test compose installer with no activation key", func() {
-		// enable feature flag
-		err := os.Setenv(feature.PassUserToImageBuilder.EnvVar, "true")
 		orgID := "234"
-		Expect(err).ToNot(HaveOccurred())
 		installer := models.Installer{Username: faker.Username(), SSHKey: faker.UUIDHyphenated()}
 		composeJobID := "compose-job-id-returned-from-image-builder"
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -900,7 +899,7 @@ var _ = Describe("Image Builder Client Test", func() {
 			Commit:       &models.Commit{Arch: "x86_64", Repo: &models.Repo{}},
 			Installer:    &installer,
 		}
-		img, err = client.ComposeInstaller(img)
+		img, err := client.ComposeInstaller(img)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(img).ToNot(BeNil())
 		Expect(img.Installer.ComposeJobID).To(Equal(composeJobID))

--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -842,7 +842,7 @@ var _ = Describe("Image Builder Client Test", func() {
 			err = json.Unmarshal(b, &req)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(req.Customizations.Subscription.ActivationKey).To(Equal("test-key"))
-			Expect(req.Customizations.Subscription.Organization).To(Equal(234))
+			Expect(req.Customizations.Subscription.Organization).To(Equal(orgID))
 			Expect(req.Customizations.Subscription.RHC).To(Equal(true))
 			Expect(req.Customizations.Subscription.Insights).To(Equal(true))
 			Expect(req.Customizations.Subscription.BaseUrl).To(Equal(config.Get().SubscriptionBaseUrl))

--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -841,7 +841,8 @@ var _ = Describe("Image Builder Client Test", func() {
 			var req ComposeRequest
 			err = json.Unmarshal(b, &req)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(req.Customizations.Subscription.ActivationKey).To(Equal("test-key"))
+Expect(req.Customizations.Subscription).ToNot(BeNil())                
+Expect(req.Customizations.Subscription.ActivationKey).To(Equal("test-key"))
 			Expect(req.Customizations.Subscription.Organization).To(Equal(orgID))
 			Expect(req.Customizations.Subscription.RHC).To(Equal(true))
 			Expect(req.Customizations.Subscription.Insights).To(Equal(true))

--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -846,7 +846,7 @@ var _ = Describe("Image Builder Client Test", func() {
 			Expect(req.Customizations.Subscription.RHC).To(Equal(true))
 			Expect(req.Customizations.Subscription.Insights).To(Equal(true))
 			Expect(req.Customizations.Subscription.BaseUrl).To(Equal(config.Get().SubscriptionBaseUrl))
-			Expect(req.Customizations.Subscription.ServerUrl).To(Equal(config.Get().SubscriptionBaseUrl))
+			Expect(req.Customizations.Subscription.ServerUrl).To(Equal(config.Get().SubscriptionServerURL))
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)

--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -53,14 +53,19 @@ var _ = Describe("Image Builder Client Test", func() {
 	conf := config.Get()
 	SUBSCRIPTION_BASE_URL := "SUBSCRIPTION_BASE_URL"
 	SUBSCRIPTION_SERVER_URL := "SUBSCRIPTION_SERVER_URL"
+
 	BeforeEach(func() {
+		err := os.Setenv(SUBSCRIPTION_BASE_URL, "http://base.url")
+		Expect(err).ToNot(HaveOccurred())
+		err = os.Setenv(SUBSCRIPTION_SERVER_URL, "http://server.url")
+		Expect(err).ToNot(HaveOccurred())
 		config.Init()
 		config.Get().Debug = true
 		dbName = fmt.Sprintf("%d-client.db", time.Now().UnixNano())
 		config.Get().Database.Name = dbName
 		db.InitDB()
 
-		err := db.DB.AutoMigrate(
+		err = db.DB.AutoMigrate(
 			&models.ImageSet{},
 			&models.Commit{},
 			&models.UpdateTransaction{},
@@ -76,10 +81,7 @@ var _ = Describe("Image Builder Client Test", func() {
 		client = InitClient(context.Background(), log.NewEntry(log.StandardLogger()))
 		// save the original image builder url
 		originalImageBuilderURL = conf.ImageBuilderConfig.URL
-		err = os.Setenv(SUBSCRIPTION_BASE_URL, "http://base.url")
-		Expect(err).ToNot(HaveOccurred())
-		err = os.Setenv(SUBSCRIPTION_SERVER_URL, "http://server.url")
-		Expect(err).ToNot(HaveOccurred())
+
 	})
 	AfterEach(func() {
 		os.Remove(dbName)


### PR DESCRIPTION
# Description

After hot fixes from last week, this PR will address some of comments we have open on subscription to image. 
It's create a new func that will create the subscription object to fill "req.customizations.subscription" if adequate and more tests to validate it.


FIXES: <!-- THEEDGE-NNNN -->

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
