### PR TITLE
devices-view: fixes devices-view when missing devices UUIDs

### DIFF
--- a/pkg/routes/devices.go
+++ b/pkg/routes/devices.go
@@ -548,13 +548,19 @@ func GetDevicesViewWithinDevices(w http.ResponseWriter, r *http.Request) {
 	if err := readRequestJSONBody(w, r, contextServices.Log, &devicesUUID); err != nil {
 		return
 	}
+	enforceEdgeGroups := utility.EnforceEdgeGroups(orgID)
+
 	if len(devicesUUID.DevicesUUID) == 0 {
-		respondWithAPIError(w, contextServices.Log, errors.NewBadRequest("Missing devicesUUID "))
+		respondWithJSONBody(
+			w,
+			contextServices.Log,
+			map[string]interface{}{"data": models.DeviceViewList{EnforceEdgeGroups: enforceEdgeGroups}, "count": 0},
+		)
 		return
 	}
 
 	tx := devicesFilters(r, db.DB).Where("image_id > 0").Where("devices.uuid IN (?)", devicesUUID.DevicesUUID)
-	enforceEdgeGroups := utility.EnforceEdgeGroups(orgID)
+
 	if feature.EdgeParityInventoryRbac.IsEnabled() && feature.EdgeParityInventoryGroupsEnabled.IsEnabled() && !enforceEdgeGroups {
 		inventoryRbacFilter, err := handleInventoryHostsRbac(w, r)
 		if err != nil {


### PR DESCRIPTION
# Description

When requesting devices-view with POST http command and when the list of requested UUIDs is empty return an empty list instead of an error. 

FIXES: https://issues.redhat.com/browse/THEEDGE-3692

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Tests update
- [ ] Refactor


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

