### PR TITLE
go-toolset: always use gotoolset latest minor version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################################
 # STEP 1: build executable edge-api binaries
 ############################################
-FROM registry.access.redhat.com/ubi8/go-toolset:1.20.10-3 AS edge-builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.20 AS edge-builder
 WORKDIR $GOPATH/src/github.com/RedHatInsights/edge-api/
 COPY . .
 # Use go mod

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -53,7 +53,7 @@ done
 # Run coverage using same version of Go as the App
 podman run --user root --rm -i \
     -v $PWD:/usr/src:z \
-    registry.access.redhat.com/ubi8/go-toolset:1.20.10-3 \
+    registry.access.redhat.com/ubi8/go-toolset:1.20 \
     bash -c 'cd /usr/src && make coverage-no-fdo'
 
 # Generate sonarqube reports

--- a/podman/Containerfile-dev
+++ b/podman/Containerfile-dev
@@ -1,7 +1,7 @@
 ############################################
 # STEP 1: build executable edge-api binaries
 ############################################
-FROM registry.access.redhat.com/ubi8/go-toolset:1.20.10-3
+FROM registry.access.redhat.com/ubi8/go-toolset:1.20
 #WORKDIR $GOPATH/src/github.com/RedHatInsights/edge-api/
 COPY . .
 # Use go mod

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -48,7 +48,7 @@ CONTAINER_NAME="edge-pr-check-$ghprbPullId"
 podman run --user root --rm --replace -i \
     --name $CONTAINER_NAME \
     -v $PWD:/usr/src:z \
-    registry.access.redhat.com/ubi8/go-toolset:1.20.10-3 \
+    registry.access.redhat.com/ubi8/go-toolset:1.20 \
     bash -c 'cd /usr/src && make coverage-no-fdo'
 
 # Generate sonarqube reports


### PR DESCRIPTION
# Description

This will allow to always have the latest updated go-toolset while using the same go-toolset minor version.


## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor
- [X] Toolset

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

