### PR TITLE
device: fixes create image when account is missing.

### DIFF
--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -151,7 +151,7 @@ type CreateImageRequest struct {
 	Image *models.Image
 }
 
-// GetImageWithIdentity pre-populates the image with Account, OrgID, requestID and also returns an identity header
+// GetImageWithIdentity pre-populates the image with OrgID, requestID and also returns an identity header
 // This is used by every image endpoint, so it reduces copy/paste risk
 func GetImageWithIdentity(w http.ResponseWriter, r *http.Request) (*models.Image, identity.XRHID, error) {
 	ctxServices := dependencies.ServicesFromContext(r.Context())
@@ -170,13 +170,6 @@ func GetImageWithIdentity(w http.ResponseWriter, r *http.Request) (*models.Image
 		return image, ident, err
 	}
 
-	image.Account, err = common.GetAccount(r)
-	if err != nil {
-		ctxServices.Log.WithField("error", err.Error()).Error("Failed retrieving account from request")
-		respondWithAPIError(w, ctxServices.Log, errors.NewBadRequest(err.Error()))
-
-		return image, ident, err
-	}
 	image.OrgID, err = common.GetOrgID(r)
 	if err != nil {
 		ctxServices.Log.WithField("error", err.Error()).Error("Failed retrieving org_id from request")
@@ -872,7 +865,7 @@ func ResumeCreateImage(w http.ResponseWriter, r *http.Request) {
 		resumeLog.Info("Resuming image build")
 
 		// recreate a stripped down identity header
-		strippedIdentity := `{ "identity": {"account_number": ` + image.Account + `, "type": "User", "internal": {"org_id": ` + image.OrgID + `, }, }, }`
+		strippedIdentity := `{ "identity": {"org_id": ` + image.OrgID + `, "type": "User", "internal": {"org_id": ` + image.OrgID + `, }, }, }`
 		resumeLog.WithField("identity_text", strippedIdentity).Debug("Creating a new stripped identity")
 		base64Identity := base64.StdEncoding.EncodeToString([]byte(strippedIdentity))
 		resumeLog.WithField("identity_base64", base64Identity).Debug("Using a base64encoded stripped identity")

--- a/pkg/routes/images_test.go
+++ b/pkg/routes/images_test.go
@@ -1802,7 +1802,6 @@ var _ = Describe("Images Route Integration Tests", func() {
 				composeImage.Commit.OSTreeRef = "rhel/9/x86_64/edge"
 				composeImage.Commit.OSTreeParentRef = "rhel/9/x86_64/edge"
 				composeImage.OrgID = common.DefaultOrgID
-				composeImage.Account = common.DefaultAccount
 				composeImage.ImageSetID = &imageSet.ID
 
 				var body bytes.Buffer


### PR DESCRIPTION
# Description

When using token authentication account maybe missing from identity, that cause image creating return error "cannot find account number". Note: that we rely only on orgID that should not be empty.

FIXES: https://issues.redhat.com/browse/THEEDGE-3881

## Type of change

What is it?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo

