### PR TITLE
add subsctiption manager id to be stored on device information; if no…

### DIFF
--- a/pkg/clients/inventory/client.go
+++ b/pkg/clients/inventory/client.go
@@ -48,14 +48,15 @@ type Response struct {
 
 // Device represents the struct of a Device on Inventory API
 type Device struct {
-	ID              string        `json:"id"`
-	DisplayName     string        `json:"display_name"`
-	LastSeen        string        `json:"updated"`
-	UpdateAvailable bool          `json:"update_available"`
-	Ostree          SystemProfile `json:"system_profile"`
-	Account         string        `json:"account"`
-	OrgID           string        `json:"org_id"`
-	Groups          []Group       `json:"groups"`
+	ID                    string        `json:"id"`
+	DisplayName           string        `json:"display_name"`
+	LastSeen              string        `json:"updated"`
+	UpdateAvailable       bool          `json:"update_available"`
+	Ostree                SystemProfile `json:"system_profile"`
+	Account               string        `json:"account"`
+	OrgID                 string        `json:"org_id"`
+	Groups                []Group       `json:"groups"`
+	SubscriptionManagerId string        `json:"subscription_manager_id"`
 }
 
 type Group struct {

--- a/pkg/models/devices.go
+++ b/pkg/models/devices.go
@@ -87,21 +87,22 @@ const (
 // THEEDGE-1921 created 2 temporary indexes to address production issue
 type Device struct {
 	Model
-	UUID              string               `gorm:"index" json:"UUID"`
-	AvailableHash     string               `json:"AvailableHash,omitempty"`
-	RHCClientID       string               `json:"RHCClientID"`
-	Connected         bool                 `gorm:"default:true" json:"Connected"`
-	Name              string               `json:"Name"`
-	LastSeen          EdgeAPITime          `json:"LastSeen"`
-	CurrentHash       string               `json:"CurrentHash,omitempty"`
-	Account           string               `gorm:"index" json:"Account"`
-	OrgID             string               `json:"org_id" gorm:"index;<-:create"`
-	ImageID           uint                 `json:"ImageID" gorm:"index"`
-	UpdateAvailable   bool                 `json:"UpdateAvailable"`
-	DevicesGroups     []DeviceGroup        `faker:"-" gorm:"many2many:device_groups_devices;save_association:false" json:"DevicesGroups"`
-	UpdateTransaction *[]UpdateTransaction `faker:"-" gorm:"many2many:updatetransaction_devices;" json:"UpdateTransaction"`
-	GroupName         string               `json:"group_name"` // the inventory group name
-	GroupUUID         string               `json:"group_uuid"` // the inventory group id
+	UUID                  string               `gorm:"index" json:"UUID"`
+	AvailableHash         string               `json:"AvailableHash,omitempty"`
+	RHCClientID           string               `json:"RHCClientID"`
+	Connected             bool                 `gorm:"default:true" json:"Connected"`
+	Name                  string               `json:"Name"`
+	LastSeen              EdgeAPITime          `json:"LastSeen"`
+	CurrentHash           string               `json:"CurrentHash,omitempty"`
+	Account               string               `gorm:"index" json:"Account"`
+	OrgID                 string               `json:"org_id" gorm:"index;<-:create"`
+	ImageID               uint                 `json:"ImageID" gorm:"index"`
+	UpdateAvailable       bool                 `json:"UpdateAvailable"`
+	DevicesGroups         []DeviceGroup        `faker:"-" gorm:"many2many:device_groups_devices;save_association:false" json:"DevicesGroups"`
+	UpdateTransaction     *[]UpdateTransaction `faker:"-" gorm:"many2many:updatetransaction_devices;" json:"UpdateTransaction"`
+	GroupName             string               `json:"group_name"` // the inventory group name
+	GroupUUID             string               `json:"group_uuid"` // the inventory group id
+	SubscriptionManagerId string               `json:"SubscriptionManagerId"`
 }
 
 // BeforeCreate method is called before creating devices, it make sure org_id is not empty

--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -77,13 +77,14 @@ type systemProfile struct {
 }
 
 type host struct {
-	ID            string                  `json:"id"`
-	Name          string                  `json:"display_name"`
-	OrgID         string                  `json:"org_id"`
-	InsightsID    string                  `json:"insights_id"`
-	Updated       models.EdgeAPITime      `json:"updated"`
-	SystemProfile systemProfile           `json:"system_profile"`
-	Groups        []PlatformInsightsGroup `json:"groups"`
+	ID                    string                  `json:"id"`
+	Name                  string                  `json:"display_name"`
+	OrgID                 string                  `json:"org_id"`
+	InsightsID            string                  `json:"insights_id"`
+	Updated               models.EdgeAPITime      `json:"updated"`
+	SystemProfile         systemProfile           `json:"system_profile"`
+	Groups                []PlatformInsightsGroup `json:"groups"`
+	SubscriptionManagerId string                  `json:subscription_manager_id,omitempty`
 }
 
 type PlatformInsightsGroup struct {
@@ -181,8 +182,9 @@ func (s *DeviceService) GetDeviceDetails(device inventory.Device, deviceUpdateIm
 		ulog.Info("Could not find device on the devices table yet - returning just the data from inventory")
 		// if err != nil then databaseDevice is nil pointer
 		databaseDevice = &models.Device{
-			UUID:        device.ID,
-			RHCClientID: device.Ostree.RHCClientID,
+			UUID:                  device.ID,
+			RHCClientID:           device.Ostree.RHCClientID,
+			SubscriptionManagerId: device.SubscriptionManagerId,
 		}
 	}
 	details := &models.DeviceDetails{
@@ -545,13 +547,14 @@ func (s *DeviceService) GetDevices(params *inventory.Params) (*models.DeviceDeta
 
 		dd.Device = models.EdgeDevice{
 			Device: &models.Device{
-				Model:             models.Model{ID: dbDeviceID},
-				UUID:              device.ID,
-				RHCClientID:       device.Ostree.RHCClientID,
-				Name:              device.DisplayName,
-				OrgID:             device.OrgID,
-				DevicesGroups:     storeDevice.DevicesGroups,
-				UpdateTransaction: storeDevice.UpdateTransaction,
+				Model:                 models.Model{ID: dbDeviceID},
+				UUID:                  device.ID,
+				RHCClientID:           device.Ostree.RHCClientID,
+				Name:                  device.DisplayName,
+				OrgID:                 device.OrgID,
+				DevicesGroups:         storeDevice.DevicesGroups,
+				UpdateTransaction:     storeDevice.UpdateTransaction,
+				SubscriptionManagerId: device.SubscriptionManagerId,
 			},
 			OrgID:      device.OrgID,
 			DeviceName: device.DisplayName,
@@ -705,13 +708,14 @@ func (s *DeviceService) ProcessPlatformInventoryUpdatedEvent(message []byte) err
 		if _, ok := err.(*DeviceNotFoundError); ok {
 			// create a new device if it does not exist.
 			var newDevice = models.Device{
-				UUID:        deviceUUID,
-				RHCClientID: eventData.Host.SystemProfile.RHCClientID,
-				OrgID:       deviceOrgID,
-				Name:        deviceName,
-				LastSeen:    eventData.Host.Updated,
-				GroupName:   deviceGroupName,
-				GroupUUID:   deviceGroupUUID,
+				UUID:                  deviceUUID,
+				RHCClientID:           eventData.Host.SystemProfile.RHCClientID,
+				OrgID:                 deviceOrgID,
+				Name:                  deviceName,
+				LastSeen:              eventData.Host.Updated,
+				GroupName:             deviceGroupName,
+				GroupUUID:             deviceGroupUUID,
+				SubscriptionManagerId: eventData.Host.SubscriptionManagerId,
 			}
 			if result := db.DB.Create(&newDevice); result.Error != nil {
 				s.log.WithFields(log.Fields{"host_id": deviceUUID, "error": result.Error.Error()}).Error("Error creating device")
@@ -730,6 +734,9 @@ func (s *DeviceService) ProcessPlatformInventoryUpdatedEvent(message []byte) err
 	// update rhc client id if undefined
 	if eventData.Host.SystemProfile.RHCClientID != "" && device.RHCClientID != eventData.Host.SystemProfile.RHCClientID {
 		device.RHCClientID = eventData.Host.SystemProfile.RHCClientID
+	}
+	if eventData.Host.SubscriptionManagerId != "" && device.SubscriptionManagerId != eventData.Host.SubscriptionManagerId {
+		device.SubscriptionManagerId = eventData.Host.SubscriptionManagerId
 	}
 	// always update device name and last seen datetime
 	device.LastSeen = eventData.Host.Updated
@@ -1044,14 +1051,16 @@ func (s *DeviceService) platformInventoryCreateEventHelper(e PlatformInsightsCre
 		deviceGroupName = e.Host.Groups[0].Name
 		deviceGroupUUID = e.Host.Groups[0].ID
 	}
+
 	var newDevice = models.Device{
-		UUID:        e.Host.ID,
-		RHCClientID: e.Host.SystemProfile.RHCClientID,
-		OrgID:       e.Host.OrgID,
-		Name:        e.Host.Name,
-		LastSeen:    e.Host.Updated,
-		GroupName:   deviceGroupName,
-		GroupUUID:   deviceGroupUUID,
+		UUID:                  e.Host.ID,
+		RHCClientID:           e.Host.SystemProfile.RHCClientID,
+		OrgID:                 e.Host.OrgID,
+		Name:                  e.Host.Name,
+		LastSeen:              e.Host.Updated,
+		GroupName:             deviceGroupName,
+		GroupUUID:             deviceGroupUUID,
+		SubscriptionManagerId: e.Host.SubscriptionManagerId,
 	}
 
 	// We should not create a new device if UUID already exists
@@ -1274,11 +1283,12 @@ func (s *DeviceService) SyncInventoryWithDevices(orgID string) {
 						RHCClientID:          inDevice.Ostree.RHCClientID,
 					}
 					iHost := host{
-						ID:            inDevice.ID,
-						Name:          inDevice.DisplayName,
-						OrgID:         inDevice.OrgID,
-						Updated:       models.EdgeAPITime{Time: time.Now(), Valid: true},
-						SystemProfile: profile,
+						ID:                    inDevice.ID,
+						Name:                  inDevice.DisplayName,
+						OrgID:                 inDevice.OrgID,
+						Updated:               models.EdgeAPITime{Time: time.Now(), Valid: true},
+						SystemProfile:         profile,
+						SubscriptionManagerId: inDevice.SubscriptionManagerId,
 					}
 					createEvent := PlatformInsightsCreateUpdateEventPayload{
 						Type: InventoryEventTypeCreated,

--- a/pkg/services/devices_test.go
+++ b/pkg/services/devices_test.go
@@ -632,6 +632,52 @@ var _ = Describe("DfseviceService", func() {
 			Expect(len(total)).To(Equal(1))
 		})
 	})
+
+	Context("ProcessPlatformInventoryCreateEvent with Subscription Manager ID", func() {
+
+		commit := models.Commit{OrgID: orgID, OSTreeCommit: faker.UUIDHyphenated()}
+		result := db.DB.Create(&commit)
+		Expect(result.Error).To(BeNil())
+		image := models.Image{OrgID: orgID, CommitID: commit.ID, Status: models.ImageStatusSuccess}
+		result = db.DB.Create(&image)
+		Expect(result.Error).To(BeNil())
+		var message []byte
+		var err error
+		var event services.PlatformInsightsCreateUpdateEventPayload
+		BeforeEach(func() {
+
+			event.Type = services.InventoryEventTypeCreated
+			event.Host.SystemProfile.HostType = services.InventoryHostTypeEdge
+			event.Host.ID = faker.UUIDHyphenated()
+			event.Host.OrgID = orgID
+			event.Host.Name = faker.UUIDHyphenated()
+			event.Host.Updated = models.EdgeAPITime(sql.NullTime{Time: time.Now().UTC(), Valid: true})
+			event.Host.SystemProfile.RpmOSTreeDeployments = []services.RpmOSTreeDeployment{{Booted: true, Checksum: commit.OSTreeCommit}}
+			event.Host.SubscriptionManagerId = faker.UUIDHyphenated()
+			event.Host.SystemProfile.RHCClientID = faker.UUIDHyphenated()
+
+			event.Host.Groups = []services.PlatformInsightsGroup{{ID: faker.UUIDHyphenated(), Name: faker.Name()}}
+			message, err = json.Marshal(event)
+			Expect(err).To(BeNil())
+		})
+		It("should create devices when no record is found", func() {
+			err = deviceService.ProcessPlatformInventoryCreateEvent(message)
+			Expect(err).To(BeNil())
+			var savedDevice models.Device
+			result := db.DB.Where(models.Device{UUID: event.Host.ID, OrgID: event.Host.OrgID}).First(&savedDevice).Unscoped()
+			Expect(result.Error).To(BeNil())
+			Expect(savedDevice.UUID).To(Equal(event.Host.ID))
+			Expect(savedDevice.OrgID).To(Equal(orgID))
+			Expect(savedDevice.ImageID).To(Equal(image.ID))
+			Expect(savedDevice.LastSeen.Time).To(Equal(event.Host.Updated.Time))
+			Expect(savedDevice.Name).To(Equal(event.Host.Name))
+			Expect(savedDevice.RHCClientID).To(Equal(event.Host.SystemProfile.RHCClientID))
+			Expect(savedDevice.SubscriptionManagerId).To(Equal(event.Host.SubscriptionManagerId))
+			Expect(savedDevice.GroupUUID).To(Equal(event.Host.Groups[0].ID))
+			Expect(savedDevice.GroupName).To(Equal(event.Host.Groups[0].Name))
+		})
+	})
+
 	Context("ProcessPlatformInventoryUpdatedEvent", func() {
 		commit := models.Commit{OrgID: orgID, OSTreeCommit: faker.UUIDHyphenated()}
 		result := db.DB.Create(&commit)
@@ -708,6 +754,48 @@ var _ = Describe("DfseviceService", func() {
 			Expect(savedDevice.ImageID).To(Equal(image.ID))
 			Expect(savedDevice.UpdateAvailable).To(Equal(false))
 			Expect(savedDevice.RHCClientID).To(Equal(event.Host.SystemProfile.RHCClientID))
+			Expect(savedDevice.LastSeen.Time).To(Equal(event.Host.Updated.Time))
+			Expect(savedDevice.Name).To(Equal(event.Host.Name))
+			Expect(savedDevice.GroupUUID).To(Equal(event.Host.Groups[0].ID))
+			Expect(savedDevice.GroupName).To(Equal(event.Host.Groups[0].Name))
+		})
+
+		It("should update device subscription manager id when device already exists", func() {
+			// Creating a devices needs to have org_id because of BeforeCreate method applied to Devices model
+			device := models.Device{
+				UUID:            faker.UUIDHyphenated(),
+				UpdateAvailable: true,
+				OrgID:           orgID,
+			}
+			res := db.DB.Create(&device)
+			Expect(res.Error).To(BeNil())
+
+			event := new(services.PlatformInsightsCreateUpdateEventPayload)
+			event.Type = services.InventoryEventTypeUpdated
+			event.Host.ID = device.UUID
+			event.Host.InsightsID = faker.UUIDHyphenated()
+			event.Host.OrgID = orgID
+			event.Host.Name = faker.UUIDHyphenated()
+			event.Host.Updated = models.EdgeAPITime(sql.NullTime{Time: time.Now().UTC(), Valid: true})
+			event.Host.SystemProfile.HostType = services.InventoryHostTypeEdge
+			event.Host.SystemProfile.RpmOSTreeDeployments = []services.RpmOSTreeDeployment{{Booted: true, Checksum: commit.OSTreeCommit}}
+			event.Host.SystemProfile.RHCClientID = faker.UUIDHyphenated()
+			event.Host.SubscriptionManagerId = faker.UUIDHyphenated()
+			event.Host.Groups = []services.PlatformInsightsGroup{{ID: faker.UUIDHyphenated(), Name: faker.Name()}}
+			message, err := json.Marshal(event)
+			Expect(err).To(BeNil())
+
+			err = deviceService.ProcessPlatformInventoryUpdatedEvent(message)
+			Expect(err).To(BeNil())
+
+			var savedDevice models.Device
+			res = db.DB.Where("uuid = ?", device.UUID).First(&savedDevice)
+			Expect(res.Error).To(BeNil())
+			Expect(savedDevice.OrgID).To(Equal(orgID))
+			Expect(savedDevice.ImageID).To(Equal(image.ID))
+			Expect(savedDevice.UpdateAvailable).To(Equal(false))
+			Expect(savedDevice.RHCClientID).To(Equal(event.Host.SystemProfile.RHCClientID))
+			Expect(savedDevice.SubscriptionManagerId).To(Equal(event.Host.SubscriptionManagerId))
 			Expect(savedDevice.LastSeen.Time).To(Equal(event.Host.Updated.Time))
 			Expect(savedDevice.Name).To(Equal(event.Host.Name))
 			Expect(savedDevice.GroupUUID).To(Equal(event.Host.Groups[0].ID))

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -1137,8 +1137,11 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 					return nil, result.Error
 				}
 			}
-
-			if device.Ostree.RHCClientID == "" {
+			connectorId := device.Ostree.RHCClientID
+			if connectorId == "" {
+				connectorId = device.SubscriptionManagerId
+			}
+			if connectorId == "" {
 				s.log.WithFields(log.Fields{
 					"deviceUUID": device.ID,
 				}).Info("Device is disconnected")
@@ -1149,7 +1152,8 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 				}
 				continue
 			}
-			updateDevice.RHCClientID = device.Ostree.RHCClientID
+
+			updateDevice.RHCClientID = connectorId
 			updateDevice.AvailableHash = update.Commit.OSTreeCommit
 
 			// update the device orgID if undefined


### PR DESCRIPTION
… rhc present, send the subscription manager value

# Description
 If device doesnt present rhc_client_id we'll send the subscription_manager_id to update execution.
Once the device is registered, the subscription_manager_id can also be used for playbook dispatcher call

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
