### PR TITLE
fix Unresponsive status on update and duplicate Inventory

### DIFF
--- a/templates/templateKickstart.ks
+++ b/templates/templateKickstart.ks
@@ -112,28 +112,6 @@ fi
 %end
 
 
-%post --log=/var/log/anaconda/insights-on-reboot-unit-install.log --interpreter=/usr/bin/bash --erroronfail
-echo POST-INSIGHTS-CLIENT-OVERRIDE
-
-INSIGHTS_CLIENT_OVERRIDE_DIR=/etc/systemd/system/insights-client.service.d
-INSIGHTS_CLIENT_OVERRIDE_FILE=$INSIGHTS_CLIENT_OVERRIDE_DIR/override.conf
-
-if [ ! -f $INSIGHTS_CLIENT_OVERRIDE_FILE ]; then
-    mkdir -p $INSIGHTS_CLIENT_OVERRIDE_DIR
-    cat > $INSIGHTS_CLIENT_OVERRIDE_FILE << EOF 
-[Unit]
-Requisite=greenboot-healthcheck.service
-After=network-online.target greenboot-healthcheck.service
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-    systemctl enable insights-client.service
-fi
-
-%end
-
 #FIX THE RHCD_T semanage
 %post --log=/var/log/anaconda/permissive-rhcd_t.log
 /usr/sbin/semanage permissive --add rhcd_t


### PR DESCRIPTION
# Description
Fixes a condition where:
* a system can be displayed in both Conventional and Immutable tabs of consoledot Inventory.
* a system can be marked as Unresponsive when attempting an update

FIXES: THEEDGE-3896 and THEEDGE-3897

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
