### PR TITLE
fix empty Principal when using service account

### DIFF
--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -287,12 +287,18 @@ func (s *UpdateService) CreateUpdate(id uint) (*models.UpdateTransaction, error)
 	for _, device := range update.Devices {
 		device := device // this will prevent implicit memory aliasing in the loop
 		// Create new &DispatcherPayload{}
+		principal := identity.User.Username
+		if len(identity.User.Username) == 0 {
+			// FIXME: identity.ServiceAccount.Username when middleware identity v2.0 is prod, until then use update.OrgId
+			principal = update.OrgID
+		}
+
 		payloadDispatcher := playbookdispatcher.DispatcherPayload{
 			Recipient:    device.RHCClientID,
 			PlaybookURL:  playbookURL,
 			OrgID:        update.OrgID,
 			PlaybookName: "Edge-management",
-			Principal:    identity.User.Username,
+			Principal:    principal,
 		}
 		s.log.WithField("playbook_dispatcher", payloadDispatcher).Debug("Calling playbook dispatcher")
 		exc, err := s.PlaybookClient.ExecuteDispatcher(payloadDispatcher)


### PR DESCRIPTION
# Description
Replaces empty Principal element with OrgID when API request uses service token instead of user/pass.
Playbook Dispatcher errors with required Principal field being empty instead of len > 0

FIXES: THEEDGE-3907

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
