### PR TITLE
Remove bearer from unleash auth

### DIFF
--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -16,7 +16,7 @@ import (
 
 	edgeunleash "github.com/redhatinsights/edge-api/unleash"
 
-	"github.com/Unleash/unleash-client-go/v3"
+	"github.com/Unleash/unleash-client-go/v4"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 	"time"
@@ -30,7 +29,7 @@ func initializeUnleash() {
 			unleash.WithUrl(cfg.UnleashURL),
 			unleash.WithRefreshInterval(5*time.Second),
 			unleash.WithMetricsInterval(5*time.Second),
-			unleash.WithCustomHeaders(http.Header{"Authorization": {fmt.Sprintf("Bearer %s", cfg.UnleashSecretName)}}),
+			unleash.WithCustomHeaders(http.Header{"Authorization": {cfg.FeatureFlagsAPIToken}}),
 		)
 		if err != nil {
 			log.WithField("Error", err).Error("Unleash client failed to initialize")

--- a/cmd/migrategroups/main.go
+++ b/cmd/migrategroups/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 	"time"
@@ -25,7 +24,7 @@ func initializeUnleash() {
 			unleash.WithUrl(cfg.UnleashURL),
 			unleash.WithRefreshInterval(5*time.Second),
 			unleash.WithMetricsInterval(5*time.Second),
-			unleash.WithCustomHeaders(http.Header{"Authorization": {fmt.Sprintf("Bearer %s", cfg.UnleashSecretName)}}),
+			unleash.WithCustomHeaders(http.Header{"Authorization": {cfg.FeatureFlagsAPIToken}}),
 		)
 		if err != nil {
 			log.WithField("Error", err).Error("Unleash client failed to initialize")

--- a/cmd/migrategroups/main.go
+++ b/cmd/migrategroups/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/redhatinsights/edge-api/pkg/db"
 	edgeunleash "github.com/redhatinsights/edge-api/unleash"
 
-	"github.com/Unleash/unleash-client-go/v3"
+	"github.com/Unleash/unleash-client-go/v4"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/cmd/migraterepos/main.go
+++ b/cmd/migraterepos/main.go
@@ -14,7 +14,7 @@ import (
 	edgeunleash "github.com/redhatinsights/edge-api/unleash"
 	feature "github.com/redhatinsights/edge-api/unleash/features"
 
-	"github.com/Unleash/unleash-client-go/v3"
+	"github.com/Unleash/unleash-client-go/v4"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/cmd/migraterepos/main.go
+++ b/cmd/migraterepos/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 	"time"
@@ -28,7 +27,7 @@ func initializeUnleash() {
 			unleash.WithUrl(cfg.UnleashURL),
 			unleash.WithRefreshInterval(5*time.Second),
 			unleash.WithMetricsInterval(5*time.Second),
-			unleash.WithCustomHeaders(http.Header{"Authorization": {fmt.Sprintf("Bearer %s", cfg.UnleashSecretName)}}),
+			unleash.WithCustomHeaders(http.Header{"Authorization": {cfg.FeatureFlagsAPIToken}}),
 		)
 		if err != nil {
 			log.WithField("Error", err).Error("Unleash client failed to initialize")

--- a/config/config.go
+++ b/config/config.go
@@ -57,12 +57,10 @@ type EdgeConfig struct {
 	Local                      bool                      `json:"local,omitempty"`
 	Dev                        bool                      `json:"dev,omitempty"`
 	UnleashURL                 string                    `json:"unleash_url,omitempty"`
-	UnleashSecretName          string                    `json:"unleash_secret_name,omitempty"`
 	FeatureFlagsEnvironment    string                    `json:"featureflags_environment,omitempty"`
 	FeatureFlagsURL            string                    `json:"featureflags_url,omitempty"`
 	FeatureFlagsAPIToken       string                    `json:"featureflags_api_token,omitempty"`
 	FeatureFlagsService        string                    `json:"featureflags_service,omitempty"`
-	FeatureFlagsBearerToken    string                    `json:"featureflags_bearer_token,omitempty"`
 	ContentSourcesURL          string                    `json:"content_sources_url,omitempty"`
 	TenantTranslatorHost       string                    `json:"tenant_translator_host,omitempty"`
 	TenantTranslatorPort       string                    `json:"tenant_translator_port,omitempty"`
@@ -189,17 +187,11 @@ func CreateEdgeAPIConfig() (*EdgeConfig, error) {
 			}
 
 			options.SetDefault("FeatureFlagsUrl", UnleashURL)
-
-			clientAccessToken := ""
-			if cfg.FeatureFlags.ClientAccessToken != nil {
-				clientAccessToken = *cfg.FeatureFlags.ClientAccessToken
-			}
-			options.SetDefault("FeatureFlagsBearerToken", clientAccessToken)
+			options.SetDefault("FeatureFlagsAPIToken", *cfg.FeatureFlags.ClientAccessToken)
 		}
 	} else {
 		options.SetDefault("FeatureFlagsUrl", os.Getenv("UNLEASH_URL"))
 		options.SetDefault("FeatureFlagsAPIToken", os.Getenv("UNLEASH_TOKEN"))
-		options.SetDefault("FeatureFlagsBearerToken", options.GetString("UNLEASH_TOKEN"))
 	}
 	options.SetDefault("FeatureFlagsService", os.Getenv("FEATURE_FLAGS_SERVICE"))
 
@@ -256,11 +248,9 @@ func CreateEdgeAPIConfig() (*EdgeConfig, error) {
 		Local:                      options.GetBool("Local"),
 		Dev:                        options.GetBool("Dev"),
 		UnleashURL:                 options.GetString("FeatureFlagsUrl"),
-		UnleashSecretName:          options.GetString("FeatureFlagsBearerToken"),
 		FeatureFlagsEnvironment:    options.GetString("FeatureFlagsEnvironment"),
 		FeatureFlagsURL:            options.GetString("FeatureFlagsUrl"),
 		FeatureFlagsAPIToken:       options.GetString("FeatureFlagsAPIToken"),
-		FeatureFlagsBearerToken:    options.GetString("FeatureFlagsBearerToken"),
 		FeatureFlagsService:        options.GetString("FeatureFlagsService"),
 		TenantTranslatorHost:       options.GetString("TenantTranslatorHost"),
 		ContentSourcesURL:          options.GetString("CONTENT_SOURCES_URL"),

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/redhatinsights/edge-api
 
 require (
-	github.com/Unleash/unleash-client-go/v3 v3.9.2
+	github.com/Unleash/unleash-client-go/v4 v4.1.0
 	github.com/aws/aws-sdk-go v1.50.22
 	github.com/bxcodec/faker/v3 v3.8.1
 	github.com/cavaliercoder/grab v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -721,8 +721,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/Unleash/unleash-client-go/v3 v3.9.2 h1:/Jl61G/kOx+1+MqPuMnC/JvJxdsf52ZDdJvCmXoA2ck=
-github.com/Unleash/unleash-client-go/v3 v3.9.2/go.mod h1:jAf7F2WWpfJbfn1n8bZ74p7hkAhijrqH4TpWoT7kWLc=
+github.com/Unleash/unleash-client-go/v4 v4.1.0 h1:+9ZMa4sb176nlPfZyWYlWHeY8bA3odhGdZa2V063nZA=
+github.com/Unleash/unleash-client-go/v4 v4.1.0/go.mod h1:jzGQjqMwJm2y+vaVLzq3IzZPvh5SRWco0MNIw2KK03I=
 github.com/actgardner/gogen-avro/v10 v10.1.0/go.mod h1:o+ybmVjEa27AAr35FRqU98DJu1fXES56uXniYFv4yDA=
 github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0RsT/ee8YIgGY/xpEQgQ=
 github.com/actgardner/gogen-avro/v9 v9.1.0/go.mod h1:nyTj6wPqDJoxM3qdnjcLv+EnMDSDFqE0qDpva2QRmKc=

--- a/main.go
+++ b/main.go
@@ -211,7 +211,7 @@ func main() {
 			unleash.WithUrl(cfg.UnleashURL),
 			unleash.WithRefreshInterval(5*time.Second),
 			unleash.WithMetricsInterval(5*time.Second),
-			unleash.WithCustomHeaders(http.Header{"Authorization": {fmt.Sprintf("Bearer %s", cfg.UnleashSecretName)}}),
+			unleash.WithCustomHeaders(http.Header{"Authorization": {cfg.FeatureFlagsAPIToken}}),
 		)
 		if err != nil {
 			log.WithField("Error", err).Error("Unleash client failed to initialize")

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/redhatinsights/edge-api/config"
 
-	"github.com/Unleash/unleash-client-go/v3"
+	"github.com/Unleash/unleash-client-go/v4"
 	"github.com/getsentry/sentry-go"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"

--- a/pkg/routes/main_test.go
+++ b/pkg/routes/main_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Unleash/unleash-client-go/v3"
+	"github.com/Unleash/unleash-client-go/v4"
 	"github.com/redhatinsights/edge-api/pkg/db"
 	"github.com/redhatinsights/edge-api/pkg/models"
 	"github.com/redhatinsights/edge-api/pkg/routes/common"

--- a/pkg/services/utility/groups.go
+++ b/pkg/services/utility/groups.go
@@ -1,8 +1,8 @@
 package utility
 
 import (
-	"github.com/Unleash/unleash-client-go/v3"
-	unleashContext "github.com/Unleash/unleash-client-go/v3/context"
+	"github.com/Unleash/unleash-client-go/v4"
+	unleashContext "github.com/Unleash/unleash-client-go/v4/context"
 	feature "github.com/redhatinsights/edge-api/unleash/features"
 )
 

--- a/unleash/edge_listener.go
+++ b/unleash/edge_listener.go
@@ -1,7 +1,7 @@
 package unleash // nolint:gofmt,goimports,revive
 
 import (
-	unleashclient "github.com/Unleash/unleash-client-go/v3"
+	unleashclient "github.com/Unleash/unleash-client-go/v4"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -7,8 +7,8 @@ package feature
 import (
 	"os"
 
-	"github.com/Unleash/unleash-client-go/v3"
-	unleashCTX "github.com/Unleash/unleash-client-go/v3/context"
+	"github.com/Unleash/unleash-client-go/v4"
+	unleashCTX "github.com/Unleash/unleash-client-go/v4/context"
 
 	"github.com/redhatinsights/edge-api/config"
 )

--- a/unleash/unleash_mock.go
+++ b/unleash/unleash_mock.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Unleash/unleash-client-go/v3/api"
+	"github.com/Unleash/unleash-client-go/v4/api"
 )
 
 // FakeUnleashServer is the server object


### PR DESCRIPTION
# Description

- Removes legacy Unleash Authentication Header
- Small Refactor
- Bumps Unleash client to v4

Closes: RHCLOUD-31428

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
