### PR TITLE
fix: don't depend on unleash-proxy

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -456,8 +456,6 @@ objects:
     - replicas: 3
       partitions: 3
       topicName: platform.notifications.ingress
-    dependencies:
-    - unleash-proxy
     optionalDependencies:
     - host-inventory
     - playbook-dispatcher


### PR DESCRIPTION
# Description

Unleash proxy is deprecated and unused anyway IIUC.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor