### PR TITLE
fix: defer log flush in main functions

### DIFF
--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -51,41 +51,31 @@ func initConfiguration() {
 	initializeUnleash()
 }
 
-func flushLogAndExit(err error) {
-	// flush logger before app exit
-	logger.FlushLogger()
-	if err != nil {
-		os.Exit(2)
-	}
-	os.Exit(0)
-}
-
 func main() {
 	initConfiguration()
+	defer logger.FlushLogger()
 
 	client := files.GetNewS3Client()
 
-	var mainErr error
-
 	if err := deleteimages.DeleteAllImages(db.DB); err != nil &&
 		err != deleteimages.ErrDeleteImagesCleanUpNotAvailable {
-		mainErr = err
+		os.Exit(2)
 	}
 
 	if err := cleanupimages.CleanUpAllImages(client); err != nil &&
 		err != cleanupimages.ErrImagesCleanUPNotAvailable {
-		mainErr = err
+		os.Exit(2)
 	}
 
 	if err := cleanupdevices.CleanupAllDevices(client, db.DB); err != nil &&
 		err != cleanupdevices.ErrCleanupDevicesNotAvailable {
-		mainErr = err
+		os.Exit(2)
 	}
 
 	if err := cleanuporphancommits.CleanupAllOrphanCommits(client, db.DB); err != nil &&
 		err != cleanuporphancommits.ErrCleanupOrphanCommitsNotAvailable {
-		mainErr = err
+		os.Exit(2)
 	}
 
-	flushLogAndExit(mainErr)
+	os.Exit(0)
 }

--- a/cmd/migraterepos/main.go
+++ b/cmd/migraterepos/main.go
@@ -48,41 +48,30 @@ func initConfiguration() {
 	initializeUnleash()
 }
 
-func cleanupAndExit(err error) {
-	// flush logger before app exit
-	logger.FlushLogger()
-	if err != nil {
-		os.Exit(2)
-	}
-	os.Exit(0)
-}
-
 func main() {
 
 	initConfiguration()
+	defer logger.FlushLogger()
+
 	// wait for 5 seconds, for the unleash client to refresh
 	time.Sleep(5 * time.Second)
 
 	if feature.MigrateCustomRepositories.IsEnabled() {
 		log.Info("custom repositories migration started")
 		if _, err := repairrepos.RepairUrls(); err != nil {
-			cleanupAndExit(err)
-			return
+			os.Exit(2)
 		}
 
 		if err := repairrepos.RepairDuplicateImagesReposURLS(); err != nil {
-			cleanupAndExit(err)
-			return
+			os.Exit(2)
 		}
 
 		if err := repairrepos.RepairDuplicates(); err != nil {
-			cleanupAndExit(err)
-			return
+			os.Exit(2)
 		}
 
 		if err := migraterepos.MigrateAllCustomRepositories(); err != nil {
-			cleanupAndExit(err)
-			return
+			os.Exit(2)
 		}
 	} else {
 		log.Info("custom repositories migration feature is disabled")
@@ -91,10 +80,9 @@ func main() {
 	if feature.PostMigrateDeleteCustomRepositories.IsEnabled() {
 		log.Info("post migrate delete custom repositories start")
 		if _, err := postmigraterepos.PostMigrateDeleteCustomRepo(); err != nil {
-			cleanupAndExit(err)
-			return
+			os.Exit(2)
 		}
 	}
 
-	cleanupAndExit(nil)
+	os.Exit(0)
 }

--- a/pkg/services/images_iso/main.go
+++ b/pkg/services/images_iso/main.go
@@ -134,6 +134,7 @@ func initConsumer(ctx context.Context) error {
 func main() {
 	ctx := context.Background()
 	logger.InitLogger(os.Stdout)
+	defer logger.FlushLogger()
 	edgeAPIServices := dependencies.Init(ctx)
 	ctx = dependencies.ContextWithServices(ctx, edgeAPIServices)
 	mslog := log.WithFields(log.Fields{"app": "edge", "service": "images"})
@@ -144,6 +145,5 @@ func main() {
 		mslog.WithField("error", err.Error()).Error("Error when initializing consumer")
 		exitCode = 1
 	}
-	logger.FlushLogger()
 	os.Exit(exitCode)
 }


### PR DESCRIPTION
This pull request fixes the issue with log flushing in the main functions of the `cleanup`, `migraterepos`, and `images_iso` packages. Previously, the log was not being flushed properly, which could lead to incomplete or missing log entries. This PR adds the necessary code to ensure that the log is flushed before the application exits.

_Generated by AI._