### PR TITLE
Log request boundaries with request_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+__debug_bin*
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
The build-in chi logger for start/end of requests does not put any context information, this fixes it.