### PR TITLE
Log Gorm through logrus

### DIFF
--- a/logger/gorm_logger.go
+++ b/logger/gorm_logger.go
@@ -1,0 +1,73 @@
+package logger
+
+import (
+	"context"
+	"time"
+
+	"github.com/redhatinsights/platform-go-middlewares/request_id"
+	"github.com/sirupsen/logrus"
+	glogger "gorm.io/gorm/logger"
+)
+
+// GormLogger is a custom logger for GORM
+type GormLogger struct {
+	logger *logrus.Logger
+}
+
+// NewGormLogger creates a new instance of GormLogger
+func NewGormLogger(logger *logrus.Logger) *GormLogger {
+	return &GormLogger{
+		logger: logger,
+	}
+}
+
+// LogMode sets the log mode for GORM
+func (l *GormLogger) LogMode(_ glogger.LogLevel) glogger.Interface {
+	return l
+}
+
+// Info logs an info message
+func (l *GormLogger) Info(ctx context.Context, msg string, data ...interface{}) {
+	rid := request_id.GetReqID(ctx)
+	l.logger.WithFields(logrus.Fields{
+		"request_id": rid,
+	}).Debugf(msg, data...)
+}
+
+// Warn logs a warning message
+func (l *GormLogger) Warn(ctx context.Context, msg string, data ...interface{}) {
+	rid := request_id.GetReqID(ctx)
+	l.logger.WithFields(logrus.Fields{
+		"request_id": rid,
+	}).Warnf(msg, data...)
+}
+
+// Error logs an error message
+func (l *GormLogger) Error(ctx context.Context, msg string, data ...interface{}) {
+	rid := request_id.GetReqID(ctx)
+	l.logger.WithFields(logrus.Fields{
+		"request_id": rid,
+	}).Errorf(msg, data...)
+}
+
+// Trace logs a SQL query
+func (l *GormLogger) Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error) {
+	rid := request_id.GetReqID(ctx)
+	elapsed := time.Since(begin)
+	sql, rows := fc()
+	if err != nil {
+		l.logger.WithContext(ctx).WithError(err).WithFields(logrus.Fields{
+			"latency_ms": elapsed.Milliseconds(),
+			"rows":       rows,
+			"sql":        sql,
+			"request_id": rid,
+		}).Error("SQL failed")
+	} else {
+		l.logger.WithContext(ctx).WithFields(logrus.Fields{
+			"latency_ms": elapsed.Milliseconds(),
+			"rows":       rows,
+			"sql":        sql,
+			"request_id": rid,
+		}).Debug("SQL query")
+	}
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -24,6 +24,12 @@ var logLevel log.Level
 // hook is an instance of cloudwatch.hook
 var hook *lc.Hook
 
+func prettyfier(f *runtime.Frame) (string, string) {
+	s := strings.Split(f.Function, ".")
+	funcName := s[len(s)-1]
+	return funcName, fmt.Sprintf("%s:%d", path.Base(f.File), f.Line)
+}
+
 // InitLogger initializes the API logger
 func InitLogger(writer io.Writer) {
 
@@ -52,11 +58,7 @@ func InitLogger(writer io.Writer) {
 			FieldMap: log.FieldMap{
 				log.FieldKeyTime: "@timestamp",
 			},
-			CallerPrettyfier: func(f *runtime.Frame) (string, string) {
-				s := strings.Split(f.Function, ".")
-				funcName := s[len(s)-1]
-				return funcName, fmt.Sprintf("%s:%d", path.Base(f.File), f.Line)
-			},
+			CallerPrettyfier: prettyfier,
 		})
 	}
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -3,6 +3,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 
 	edgelogger "github.com/redhatinsights/edge-api/logger"
@@ -44,7 +45,9 @@ func CreateDB() (*gorm.DB, error) {
 			Logger: logger.Default.LogMode(logger.Silent),
 		})
 	} else {
-		newDB, err = gorm.Open(dia, &gorm.Config{})
+		newDB, err = gorm.Open(dia, &gorm.Config{
+			Logger: edgelogger.NewGormLogger(log.StandardLogger()),
+		})
 	}
 
 	if err != nil {
@@ -98,9 +101,19 @@ func AccountOrOrgTx(account string, orgID string, tx *gorm.DB, table string) *go
 	return tx.Where(sqlText, account, orgID)
 }
 
+// DBX returns a gorm db query with context
+func DBx(ctx context.Context) *gorm.DB {
+	return DB.WithContext(ctx)
+}
+
 // Org returns a gorm db query with orgID filter
 func Org(orgID string, table string) *gorm.DB {
 	return OrgDB(orgID, DB, table)
+}
+
+// Orgx returns a gorm db query with orgID filter with context
+func Orgx(ctx context.Context, orgID string, table string) *gorm.DB {
+	return Org(orgID, table).WithContext(ctx)
 }
 
 // OrgDB returns a gorm db with orgID filter from a known gorm db query
@@ -123,4 +136,9 @@ func OrgDB(orgID string, gormDB *gorm.DB, table string) *gorm.DB {
 	)
 
 	return gormDB.Where(sqlText, orgID)
+}
+
+// OrgDBx returns a gorm db with orgID filter from a known gorm db query with context
+func OrgDBx(ctx context.Context, orgID string, gormDB *gorm.DB, table string) *gorm.DB {
+	return OrgDB(orgID, gormDB, table).WithContext(ctx)
 }

--- a/pkg/routes/updates.go
+++ b/pkg/routes/updates.go
@@ -358,7 +358,7 @@ func AddUpdate(w http.ResponseWriter, r *http.Request) {
 			ctxServices.UpdateService.CreateUpdateAsync(update.ID)
 		}
 	}
-	if result := db.DB.Omit("Devices.*").Save(upd); result.Error != nil {
+	if result := db.DBx(r.Context()).Omit("Devices.*").Save(upd); result.Error != nil {
 		ctxServices.Log.WithFields(log.Fields{
 			"error": result.Error.Error(),
 		}).Error("Error saving update")


### PR DESCRIPTION
This pull request adds logging for Gorm using logrus. It includes a new GormLogger struct and a new function `prettyfier` in the logger package. The `InitLogger` function in the logger package is also updated to use the new GormLogger.

I created helper functions because `db.DB.WithContext(r.Context())` feels quite long. I am adding it at just few places tho, it is not realistic to add it everywhere. Only when we will debugging a bug on stage, we can add the context through the code path.

Query logs now contain latency, so we can easily pull long SQL queries on stage.

I will do a followup and create a prometheus metric for that to see how slow SQL queries really are in all envs.