### PR TITLE
Improve console and migration logging

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -16,7 +16,7 @@ import (
 
 func handlePanic(errorOccurred *bool) {
 	if err := recover(); err != nil {
-		log.Error("Database automigrate failure")
+		log.Errorf("Database automigrate failure: %s", err)
 		l.FlushLogger()
 		os.Exit(1)
 	}
@@ -73,6 +73,11 @@ func main() {
 	// Automigration
 	errorOccurred := false
 	defer handlePanic(&errorOccurred)
+
+	var realDbName string
+	if result := db.DB.Raw("SELECT current_database()").Scan(&realDbName); result.Error == nil && realDbName == "postgres" {
+		log.Warning("Migration attempted on 'postgres' database")
+	}
 
 	// Delete indexes first, before models AutoMigrate
 	indexesToDelete := []struct {


### PR DESCRIPTION
This pull request introduces a new `plainFormatter` to make logs more human-readable. Compare how logs look like when you debug the system (without CloudWatch/Kibana)

Gist Commit 1 = before
Gist Commit 2 = after

https://gist.github.com/lzap/5d13da5e4ccc3184580cfd3f7c1e510e

Edit: Please merge https://github.com/RedHatInsights/edge-api/pull/2497 first there will be conflicts due to those mocks, I would rather rebase this one than the other.