### PR TITLE
Update database paths to use /tmp directory

### DIFF
--- a/cmd/cleanup/cleanupdevices/cleanupdevices_suite_test.go
+++ b/cmd/cleanup/cleanupdevices/cleanupdevices_suite_test.go
@@ -24,7 +24,7 @@ func TestMigrate(t *testing.T) {
 func setupTestDB() string {
 	config.Init()
 	config.Get().Debug = true
-	dbName := fmt.Sprintf("%d-cleanupdevices.db", time.Now().UnixNano())
+	dbName := fmt.Sprintf("/tmp/%d-cleanupdevices.db", time.Now().UnixNano())
 	config.Get().Database.Name = dbName
 	db.InitDB()
 	err := db.DB.AutoMigrate(

--- a/cmd/cleanup/cleanupimages/cleanupimages_suite_test.go
+++ b/cmd/cleanup/cleanupimages/cleanupimages_suite_test.go
@@ -24,7 +24,7 @@ func TestMigrate(t *testing.T) {
 func setupTestDB() string {
 	config.Init()
 	config.Get().Debug = true
-	dbName := fmt.Sprintf("%d-cleanupimages.db", time.Now().UnixNano())
+	dbName := fmt.Sprintf("/tmp/%d-cleanupimages.db", time.Now().UnixNano())
 	config.Get().Database.Name = dbName
 	db.InitDB()
 	err := db.DB.AutoMigrate(

--- a/cmd/cleanup/cleanuporphancommits/cleanuporphancommits_suite_test.go
+++ b/cmd/cleanup/cleanuporphancommits/cleanuporphancommits_suite_test.go
@@ -24,7 +24,7 @@ func TestCleanupOrphanCommits(t *testing.T) {
 func setupTestDB() string {
 	config.Init()
 	config.Get().Debug = true
-	dbName := fmt.Sprintf("%d-cleanuporphancommits.db", time.Now().UnixNano())
+	dbName := fmt.Sprintf("/tmp/%d-cleanuporphancommits.db", time.Now().UnixNano())
 	config.Get().Database.Name = dbName
 	db.InitDB()
 	err := db.DB.AutoMigrate(

--- a/cmd/cleanup/deleteimages/deleteimages_suite_test.go
+++ b/cmd/cleanup/deleteimages/deleteimages_suite_test.go
@@ -24,7 +24,7 @@ func TestMigrate(t *testing.T) {
 func setupTestDB() string {
 	config.Init()
 	config.Get().Debug = true
-	dbName := fmt.Sprintf("%d-cleanupimages.db", time.Now().UnixNano())
+	dbName := fmt.Sprintf("/tmp/%d-cleanupimages.db", time.Now().UnixNano())
 	config.Get().Database.Name = dbName
 	db.InitDB()
 	err := db.DB.AutoMigrate(

--- a/cmd/migrategroups/migrategroups/migrategroups_suite_test.go
+++ b/cmd/migrategroups/migrategroups/migrategroups_suite_test.go
@@ -23,7 +23,7 @@ func TestMigrate(t *testing.T) {
 
 func setupTestDB() string {
 	config.Init()
-	dbName := fmt.Sprintf("%d-migrategroups.db", time.Now().UnixNano())
+	dbName := fmt.Sprintf("/tmp/%d-migrategroups.db", time.Now().UnixNano())
 	config.Get().Database.Name = dbName
 	db.InitDB()
 	if err := db.DB.AutoMigrate(

--- a/cmd/migraterepos/migraterepos/migraterepos_suite_test.go
+++ b/cmd/migraterepos/migraterepos/migraterepos_suite_test.go
@@ -23,7 +23,7 @@ func TestMigrate(t *testing.T) {
 
 func setupTestDB() string {
 	config.Init()
-	dbName := fmt.Sprintf("%d-migraterepos.db", time.Now().UnixNano())
+	dbName := fmt.Sprintf("/tmp/%d-migraterepos.db", time.Now().UnixNano())
 	config.Get().Database.Name = dbName
 	db.InitDB()
 	if err := db.DB.AutoMigrate(

--- a/cmd/migraterepos/postmigraterepos/postmigraterepos_suite_test.go
+++ b/cmd/migraterepos/postmigraterepos/postmigraterepos_suite_test.go
@@ -23,7 +23,7 @@ func TestPostMigrate(t *testing.T) {
 
 func setupTestDB() string {
 	config.Init()
-	dbName := fmt.Sprintf("%d-migraterepos.db", time.Now().UnixNano())
+	dbName := fmt.Sprintf("/tmp/%d-migraterepos.db", time.Now().UnixNano())
 	config.Get().Database.Name = dbName
 	db.InitDB()
 	if err := db.DB.AutoMigrate(

--- a/cmd/migraterepos/repairrepos/repairrepos_suite_test.go
+++ b/cmd/migraterepos/repairrepos/repairrepos_suite_test.go
@@ -24,7 +24,7 @@ func TestMigrate(t *testing.T) {
 func setupTestDB() string {
 	config.Init()
 	config.Get().Debug = true
-	dbName := fmt.Sprintf("%d-repairrepos.db", time.Now().UnixNano())
+	dbName := fmt.Sprintf("/tmp/%d-repairrepos.db", time.Now().UnixNano())
 	config.Get().Database.Name = dbName
 	db.InitDB()
 	err := db.DB.AutoMigrate(

--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Image Builder Client Test", func() {
 		Expect(err).ToNot(HaveOccurred())
 		config.Init()
 		config.Get().Debug = true
-		dbName = fmt.Sprintf("%d-client.db", time.Now().UnixNano())
+		dbName = fmt.Sprintf("/tmp/%d-client.db", time.Now().UnixNano())
 		config.Get().Database.Name = dbName
 		db.InitDB()
 

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Db", func() {
 
 		BeforeEach(func() {
 			dbTimeCreation := time.Now().UnixNano()
-			dbName = fmt.Sprintf("%d-dbtest.db", dbTimeCreation)
+			dbName = fmt.Sprintf("/tmp/%d-dbtest.db", dbTimeCreation)
 			originalDBName = config.Get().Database.Name
 			config.Get().Database.Name = dbName
 		})

--- a/pkg/db/main_test.go
+++ b/pkg/db/main_test.go
@@ -25,7 +25,7 @@ var dbName string
 
 func setupTestDB() {
 	dbTimeCreation := time.Now().UnixNano()
-	dbName = fmt.Sprintf("%d-services.db", dbTimeCreation)
+	dbName = fmt.Sprintf("/tmp/%d-services.db", dbTimeCreation)
 	config.Get().Database.Name = dbName
 	InitDB()
 }

--- a/pkg/models/main_test.go
+++ b/pkg/models/main_test.go
@@ -26,7 +26,7 @@ var dbName string
 
 func setUp() {
 	dbTimeCreation := time.Now().UnixNano()
-	dbName = fmt.Sprintf("%d-models.db", dbTimeCreation)
+	dbName = fmt.Sprintf("/tmp/%d-models.db", dbTimeCreation)
 	config.Get().Database.Name = dbName
 	db.InitDB()
 

--- a/pkg/routes/common/filters_test.go
+++ b/pkg/routes/common/filters_test.go
@@ -26,7 +26,7 @@ func setUp() {
 	config.Init()
 	config.Get().Debug = true
 	time := time.Now().UnixNano()
-	dbName = fmt.Sprintf("%d-routes-common.db", time)
+	dbName = fmt.Sprintf("/tmp/%d-routes-common.db", time)
 	config.Get().Database.Name = dbName
 	db.InitDB()
 	db.DB.AutoMigrate(&models.Image{})

--- a/pkg/routes/main_test.go
+++ b/pkg/routes/main_test.go
@@ -57,7 +57,7 @@ var dbName string
 func setUp() {
 	config.Init()
 	config.Get().Debug = true
-	dbName = fmt.Sprintf("%d-routes.db", time.Now().UnixNano())
+	dbName = fmt.Sprintf("/tmp/%d-routes.db", time.Now().UnixNano())
 	config.Get().Database.Name = dbName
 	db.InitDB()
 	err := db.DB.AutoMigrate(

--- a/pkg/services/main_test.go
+++ b/pkg/services/main_test.go
@@ -28,7 +28,7 @@ func setupTestDB() {
 	config.Init()
 	config.Get().Debug = true
 	time := time.Now().UnixNano()
-	dbName = fmt.Sprintf("%d-services.db", time)
+	dbName = fmt.Sprintf("/tmp/%d-services.db", time)
 	config.Get().Database.Name = dbName
 	db.InitDB()
 	err := db.DB.AutoMigrate(

--- a/pkg/services/update/update_suite_test.go
+++ b/pkg/services/update/update_suite_test.go
@@ -29,7 +29,7 @@ var dbName string
 func setUp() {
 	config.Init()
 	time := time.Now().UnixNano()
-	dbName = fmt.Sprintf("%d-models.db", time)
+	dbName = fmt.Sprintf("/tmp/%d-models.db", time)
 	config.Get().Database.Name = dbName
 	db.InitDB()
 	err := db.DB.AutoMigrate(


### PR DESCRIPTION
This pull request updates the database paths in the code to use the /tmp directory. This ensures that the test databases are created in the /tmp directory instead of the current directory.

Hardcoding is lame, but it will do.
