### PR TITLE
Add simple job scheduler

### DIFF
--- a/internal/middleware/prometheus.go
+++ b/internal/middleware/prometheus.go
@@ -1,0 +1,71 @@
+package middleware
+
+// Chi routes aware middleware, taken from https://github.com/766b/chi-prometheus
+// License: Apache 2.0
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var buckets = []float64{100, 200, 500, 750, 1000, 2000, 5000}
+
+const (
+	metricNameHTTPRequestTotal    = "edge_http_request_total"
+	metricNameHTTPRequestDuration = "edge_http_request_duration_ms"
+)
+
+// Middleware is a handler that exposes prometheus metrics for the number of requests,
+// the latency and the response size, partitioned by status code, method and HTTP path.
+type Middleware struct {
+	reqs    *prometheus.CounterVec
+	latency *prometheus.HistogramVec
+}
+
+// NewPatternMiddleware returns a new prometheus Middleware handler that groups requests by the chi routing pattern.
+// EX: /users/{firstName} instead of /users/bob
+func NewPatternMiddleware() func(next http.Handler) http.Handler {
+	var m Middleware
+	m.reqs = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        metricNameHTTPRequestTotal,
+			Help:        "HTTP requests count partitioned by numeric status code, text status code, method and HTTP path (chi route)",
+			ConstLabels: prometheus.Labels{"service": "edge-api"},
+		},
+		[]string{"code", "status_code", "method", "path"},
+	)
+	prometheus.MustRegister(m.reqs)
+
+	m.latency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:        metricNameHTTPRequestDuration,
+		Help:        "Request duration partitioned by numeric status code, text status code, method and HTTP path (chi route)",
+		ConstLabels: prometheus.Labels{"service": "edge-api"},
+		Buckets:     buckets,
+	},
+		[]string{"code", "status_code", "method", "path"},
+	)
+	prometheus.MustRegister(m.latency)
+	return m.patternHandler
+}
+
+func (c Middleware) patternHandler(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+		next.ServeHTTP(ww, r)
+
+		rctx := chi.RouteContext(r.Context())
+		routePattern := strings.Join(rctx.RoutePatterns, "")
+		routePattern = strings.ReplaceAll(routePattern, "/*/", "/")
+
+		c.reqs.WithLabelValues(strconv.Itoa(ww.Status()), http.StatusText(ww.Status()), r.Method, routePattern).Inc()
+		c.latency.WithLabelValues(strconv.Itoa(ww.Status()), http.StatusText(ww.Status()), r.Method, routePattern).Observe(float64(time.Since(start).Nanoseconds()) / 1000000)
+	}
+	return http.HandlerFunc(fn)
+}

--- a/pkg/jobs/dummy.go
+++ b/pkg/jobs/dummy.go
@@ -1,0 +1,37 @@
+package jobs
+
+import "context"
+
+// Dummy worker is useful for unit tests - it immediately processes the job, there is no queue
+// or background goroutines.
+type DummyWorker struct {
+	hs map[JobType]JobHandler
+}
+
+func NewDummyWorker() *DummyWorker {
+	return &DummyWorker{
+		hs: make(map[JobType]JobHandler),
+	}
+}
+
+func (w *DummyWorker) RegisterHandlers(jtype JobType, handler, _ JobHandler) {
+	w.hs[jtype] = handler
+}
+
+func (w *DummyWorker) Enqueue(ctx context.Context, job *Job) error {
+	if h, ok := w.hs[job.Type]; ok {
+		h(ctx, job)
+	}
+
+	return nil
+}
+
+func (w *DummyWorker) Start(_ context.Context) {
+}
+
+func (w *DummyWorker) Stop(_ context.Context) {
+}
+
+func (w *DummyWorker) Stats(_ context.Context) (Stats, error) {
+	return Stats{}, nil
+}

--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -1,0 +1,123 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
+	"github.com/sirupsen/logrus"
+)
+
+func init() {
+	// makes UUID generation faster
+	uuid.EnableRandPool()
+}
+
+// JobType represents a "channel" for jobs. Each channel must have exactly one handler.
+type JobType string
+
+// JobHandler is a function that processes a job. Does not return error, the function must
+// handle all errors internally. Panics will cause the job to be retried and failure handler
+// will be called.
+type JobHandler func(ctx context.Context, job *Job)
+
+// Job represents a single job. It is a message that is sent to a worker.
+// Job arguments are serialized so do not store pointers - workers must not share any
+// memory with the caller.
+type Job struct {
+	// Random UUID for logging and tracing. It is generated randomly by Enqueue function when blank.
+	ID uuid.UUID
+
+	// Job type or "queue"
+	Type JobType
+
+	// Red Hat platform identity encoded with base64
+	Identity string
+
+	// Red Hat platform request id
+	CorrelationID string
+
+	// Job arguments
+	Args any
+}
+
+var ErrJobNotFound = errors.New("job not found")
+var ErrHandlerNotFound = errors.New("handler not registered")
+
+// JobEnqueuer sends Job messages into worker queue.
+type JobEnqueuer interface {
+	// Enqueue delivers a job to one of the backend workers.
+	Enqueue(context.Context, *Job) error
+}
+
+// JobWorker receives and handles Job messages.
+type JobWorker interface {
+	JobEnqueuer
+
+	// RegisterHandler registers an event listener for a particular type with an associated handler. The first handler
+	// is for business logic, the second handler is for error handling. The second handler is called when job is processing
+	// for too long, on graceful shutdown, panic or SIGINT.
+	RegisterHandlers(JobType, JobHandler, JobHandler)
+
+	// Start starts one or more goroutines to dispatch incoming jobs.
+	Start(ctx context.Context)
+
+	// Stop let's background workers to finish all jobs and terminates them. It blocks until workers are done.
+	Stop(ctx context.Context)
+
+	// Stats returns statistics. Not all implementations supports stats, some may return zero values.
+	Stats(ctx context.Context) (Stats, error)
+}
+
+func (jt JobType) String() string {
+	return string(jt)
+}
+
+// Stats provides monitoring statistics.
+type Stats struct {
+	// Number of jobs currently in the queue.
+	Enqueued int64
+
+	// Number of jobs currently being processed.
+	Active int64
+}
+
+type jobKeyID int
+
+const (
+	jobIDCtxKey jobKeyID = iota
+)
+
+// JobID returns job id or an empty string when not set.
+func JobID(ctx context.Context) string {
+	value := ctx.Value(jobIDCtxKey)
+	if value == nil {
+		return ""
+	}
+	return value.(string)
+}
+
+// WithJobID returns context copy with trace id value.
+func WithJobID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, jobIDCtxKey, id)
+}
+
+func initJobContext(origCtx context.Context, job *Job) (context.Context, logrus.FieldLogger) {
+	ctx := WithJobID(origCtx, job.ID.String())
+
+	id, err := identity.DecodeIdentity(job.Identity)
+	if err != nil {
+		logrus.WithContext(ctx).WithError(err).Warn("Error decoding identity")
+		id = identity.XRHID{}
+	}
+
+	return ctx, logrus.WithContext(ctx).WithFields(
+		logrus.Fields{
+			"job_id":         job.ID,
+			"job_type":       job.Type,
+			"org_id":         id.Identity.OrgID,
+			"correlation_id": job.CorrelationID,
+		},
+	)
+}

--- a/pkg/jobs/memory.go
+++ b/pkg/jobs/memory.go
@@ -1,0 +1,246 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redhatinsights/edge-api/pkg/metrics"
+	"github.com/sirupsen/logrus"
+)
+
+type Config struct {
+	QueueSize int
+	Workers   int
+	Timeout   time.Duration
+	IntSignal os.Signal
+}
+
+type MemoryWorker struct {
+	cfg Config
+	hs  map[JobType]JobHandler
+	fhs map[JobType]JobHandler
+	q   chan *Job
+	oc  *sync.Once
+	wg  sync.WaitGroup
+	cf  []context.CancelFunc
+	cfm sync.Mutex
+	sen atomic.Int64
+	sac atomic.Int64
+	sig os.Signal
+}
+
+func NewMemoryClientWithConfig(config Config) *MemoryWorker {
+	return &MemoryWorker{
+		cfg: config,
+		hs:  make(map[JobType]JobHandler),
+		fhs: make(map[JobType]JobHandler),
+		q:   make(chan *Job, config.QueueSize),
+		oc:  &sync.Once{},
+		wg:  sync.WaitGroup{},
+		cf:  make([]context.CancelFunc, 0, config.Workers+1),
+		sig: config.IntSignal,
+	}
+}
+
+func NewMemoryClient() *MemoryWorker {
+	return NewMemoryClientWithConfig(Config{
+		QueueSize: 10,
+		Workers:   10,
+		Timeout:   4 * time.Hour,
+		IntSignal: os.Interrupt,
+	})
+}
+
+// RegisterHandlers registers job handlers for a specific job type.
+func (w *MemoryWorker) RegisterHandlers(jtype JobType, handler, failureHandler JobHandler) {
+	w.hs[jtype] = handler
+	w.fhs[jtype] = failureHandler
+}
+
+// Enqueue sends a job to the worker queue.
+func (w *MemoryWorker) Enqueue(ctx context.Context, job *Job) error {
+	if job == nil {
+		return fmt.Errorf("unable to enqueue job: %w", ErrJobNotFound)
+	}
+
+	_, logger := initJobContext(ctx, job)
+
+	logger.WithField("job_args", job.Args).Infof("Enqueuing job %s of type %s", job.ID, job.Type)
+
+	if job.ID == uuid.Nil {
+		job.ID = uuid.New()
+	}
+
+	w.q <- job
+	w.sen.Add(1)
+	metrics.JobEnqueuedCount.WithLabelValues(string(job.Type)).Inc()
+	return nil
+}
+
+// Starts managed goroutines to process jobs from the queue. Additionally, start
+// goroutine to handle interrupt signal if provided. This method does not block.
+// Worker must be gracefully stopped via Stop().
+func (w *MemoryWorker) Start(ctx context.Context) {
+	w.cfm.Lock()
+	defer w.cfm.Unlock()
+
+	logrus.WithContext(ctx).Infof("Starting %d job workers", w.cfg.Workers)
+	for i := 0; i < w.cfg.Workers; i++ {
+		uid := uuid.New()
+		w.wg.Add(1)
+		logrus.WithContext(ctx).Infof("Started worker with uuid %s", uid)
+		gctx, cf := context.WithCancel(ctx)
+		w.cf = append(w.cf, cf)
+		go w.dequeueLoop(gctx, uid)
+	}
+
+	// Handle interrupt signal
+	if w.sig != nil {
+		intC := make(chan os.Signal, 1)
+		signal.Notify(intC, w.sig)
+
+		ctxInt, cfInt := context.WithCancel(ctx)
+		w.cf = append(w.cf, cfInt)
+		go func() {
+			select {
+			case <-intC:
+				logrus.WithContext(ctx).Debugf("Interrupt detected, sending cancel to all workers")
+				w.cancelAll()
+			case <-ctxInt.Done():
+				logrus.WithContext(ctx).Debugf("Stopping interrupt signal goroutine")
+				return
+			}
+		}()
+	}
+}
+
+// Stops processing of all free goroutines, queue is discarded but all active jobs are left
+// to finish. It blocks until all workers are done which may be terminated by kubernetes.
+func (w *MemoryWorker) Stop(ctx context.Context) {
+	w.oc.Do(func() {
+		w.cfm.Lock()
+		defer w.cfm.Unlock()
+
+		// Print some stats before we start the procedure
+		s, err := w.Stats(ctx)
+		if err != nil {
+			logrus.WithContext(ctx).Errorf("Error getting stats: %v", err)
+		}
+		logrus.WithContext(ctx).Infof("Stopping jobs, %d active jobs, %d queued jobs (waiting started)", s.Active, s.Enqueued)
+
+		// Stop all idle workers by closing the queue
+		close(w.q)
+
+		w.cancelAll()
+
+		// Wait for active workers to finish
+		w.wg.Wait()
+		logrus.WithContext(ctx).Info("All goroutines stopped")
+	})
+}
+
+// Stop all running workers
+func (w *MemoryWorker) cancelAll() {
+	for _, cf := range w.cf {
+		cf()
+	}
+}
+
+func (w *MemoryWorker) dequeueLoop(ctx context.Context, wid uuid.UUID) {
+	defer w.wg.Done()
+
+	// Handle also stats updates, in extreme case when all workers are busy, stats
+	// will not be updated for a while. Not
+	statsTick := time.NewTicker(1 * time.Second)
+	defer statsTick.Stop()
+
+	for {
+		select {
+		case job := <-w.q:
+			if job == nil {
+				logrus.WithContext(ctx).Debug("Stopping worker goroutine (closed channel)")
+				return
+			}
+
+			w.sen.Add(-1)
+			w.processJob(ctx, job, wid)
+		case <-statsTick.C:
+			s, _ := w.Stats(ctx)
+			metrics.JobActiveSize.Set(float64(s.Active))
+			metrics.JobQueueSize.Set(float64(s.Enqueued))
+		case <-ctx.Done():
+			logrus.WithContext(ctx).Debug("Stopping worker goroutine (context done)")
+			return
+		}
+	}
+}
+
+func (w *MemoryWorker) processJob(ctx context.Context, job *Job, wid uuid.UUID) {
+	if job == nil {
+		logrus.WithContext(ctx).Error(ErrJobNotFound)
+		return
+	}
+	w.sac.Add(1)
+	defer w.sac.Add(-1)
+
+	ctx, logger := initJobContext(ctx, job)
+	logger = logger.WithFields(logrus.Fields{
+		"worker_id": wid,
+		"job_args":  job.Args,
+	})
+
+	if h, ok := w.hs[job.Type]; ok {
+		ctx, cFunc := context.WithTimeout(ctx, w.cfg.Timeout)
+		defer cFunc()
+
+		if fh, ok := w.fhs[job.Type]; ok {
+			defer func() {
+				// call failure handler if job panics or context is cancelled/expired
+				call := false
+				if r := recover(); r != nil {
+					logger.Warningf("Job %s of type %s panic: %s, calling interrupt handler", job.ID, job.Type, r)
+					call = true
+					metrics.JobProcessedCount.WithLabelValues(string(job.Type), "panicked").Inc()
+				} else if ctx.Err() != nil {
+					logger.Warningf("Job %s of type %s was cancelled: %s, calling interrupt handler", job.ID, job.Type, ctx.Err().Error())
+					call = true
+					if ctx.Err() == context.DeadlineExceeded {
+						metrics.JobProcessedCount.WithLabelValues(string(job.Type), "timeouted").Inc()
+					} else {
+						metrics.JobProcessedCount.WithLabelValues(string(job.Type), "cancelled").Inc()
+					}
+				}
+
+				if call {
+					start := time.Now()
+					fh(ctx, job)
+					elapsed := time.Since(start)
+					logger.Infof("Failure handler %s of type %s completed in %s seconds", job.ID, job.Type, elapsed.Seconds())
+				}
+			}()
+		}
+
+		logger.Infof("Processing job %s of type %s", job.ID, job.Type)
+		start := time.Now()
+		h(ctx, job)
+		elapsed := time.Since(start)
+		logger.Infof("Job %s of type %s completed in %s seconds", job.ID, job.Type, elapsed.Seconds())
+		metrics.JobProcessedCount.WithLabelValues(string(job.Type), "finished").Inc()
+		metrics.BackgroundJobDuration.WithLabelValues(string(job.Type)).Observe(elapsed.Seconds())
+	} else {
+		logger.Errorf("Memory worker handler not found for job type: %s", job.Type)
+	}
+}
+
+func (w *MemoryWorker) Stats(_ context.Context) (Stats, error) {
+	return Stats{
+		Active:   w.sac.Load(),
+		Enqueued: w.sen.Load(),
+	}, nil
+}

--- a/pkg/jobs/memory_test.go
+++ b/pkg/jobs/memory_test.go
@@ -1,0 +1,213 @@
+package jobs
+
+import (
+	"context"
+	"os"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+var defaultConfig = Config{
+	QueueSize: 1,
+	Workers:   2,
+	Timeout:   30 * time.Second,
+}
+
+func TestMemoryWorker_Enqueue(t *testing.T) {
+	ctx := context.Background()
+	worker := NewMemoryClientWithConfig(defaultConfig)
+	defer worker.Stop(ctx)
+	var success atomic.Bool
+
+	worker.RegisterHandlers("test", func(context.Context, *Job) {
+		// called to process job
+		success.Store(true)
+	}, func(context.Context, *Job) {
+		// called when context is cancelled, expires or after unhandled panic
+		t.Error("Failure handler should not be called")
+	})
+	worker.Start(ctx)
+
+	job := &Job{
+		Type: "test",
+	}
+
+	err := worker.Enqueue(ctx, job)
+	if err != nil {
+		t.Errorf("Enqueue call failed: %v", err)
+	}
+
+	waitUntilTrue(t, success.Load, "Timeout: job was not processed successfully")
+}
+
+func TestMemoryWorker_Stats(t *testing.T) {
+	ctx := context.Background()
+	worker := NewMemoryClientWithConfig(defaultConfig)
+	defer worker.Stop(ctx)
+	var success atomic.Bool
+
+	worker.RegisterHandlers("test", func(context.Context, *Job) {
+		// called to process job
+		success.Store(true)
+	}, func(context.Context, *Job) {
+		// called when context is cancelled, expires or after unhandled panic
+		t.Error("Failure handler should not be called")
+	})
+
+	job := &Job{
+		Type: "test",
+	}
+
+	err := worker.Enqueue(ctx, job)
+	if err != nil {
+		t.Errorf("Enqueue call failed: %v", err)
+	}
+
+	s, err := worker.Stats(ctx)
+	if err != nil {
+		t.Errorf("Stats call failed: %v", err)
+	}
+	if s.Enqueued != 1 {
+		t.Errorf("Expected 1 enqueued job, got %d", s.Enqueued)
+	}
+
+	worker.Start(ctx)
+	waitUntilTrue(t, success.Load, "Timeout: job was not processed successfully")
+}
+
+func TestMemoryWorker_Timeout(t *testing.T) {
+	ctx := context.Background()
+	config := defaultConfig
+	config.Timeout = 1 * time.Microsecond
+	worker := NewMemoryClientWithConfig(config)
+	defer worker.Stop(ctx)
+	var success atomic.Bool
+
+	worker.RegisterHandlers("test", func(context.Context, *Job) {
+		// called to process job
+	}, func(context.Context, *Job) {
+		// called when context is cancelled, expires or after unhandled panic
+		success.Store(true)
+	})
+
+	job := &Job{
+		Type: "test",
+	}
+
+	err := worker.Enqueue(ctx, job)
+	if err != nil {
+		t.Errorf("Enqueue call failed: %v", err)
+	}
+
+	time.Sleep(2 * time.Microsecond)
+	worker.Start(ctx)
+	waitUntilTrue(t, success.Load, "Timeout: failure handler was not called for timeout test")
+}
+
+func TestMemoryWorker_Cancel(t *testing.T) {
+	ctx := context.Background()
+	worker := NewMemoryClientWithConfig(defaultConfig)
+	var success atomic.Bool
+
+	worker.RegisterHandlers("test", func(context.Context, *Job) {
+		// called to process job
+		go worker.Stop(ctx)
+		// graceful shutdown initiated - wait little bit more to trigger context cancel
+		time.Sleep(200 * time.Millisecond)
+	}, func(context.Context, *Job) {
+		// called when context is cancelled, expires or after unhandled panic
+		success.Store(true)
+	})
+
+	job := &Job{
+		Type: "test",
+	}
+
+	err := worker.Enqueue(ctx, job)
+	if err != nil {
+		t.Errorf("Enqueue call failed: %v", err)
+	}
+
+	worker.Start(ctx)
+	waitUntilTrue(t, success.Load, "Timeout: failure handler was not called for cancel test")
+}
+
+func TestMemoryWorker_Panic(t *testing.T) {
+	ctx := context.Background()
+	worker := NewMemoryClientWithConfig(defaultConfig)
+	defer worker.Stop(ctx)
+	var success atomic.Bool
+
+	worker.RegisterHandlers("test", func(context.Context, *Job) {
+		// called to process job
+		panic("panic calls failure handler")
+	}, func(context.Context, *Job) {
+		// called when context is cancelled, expires or after unhandled panic
+		success.Store(true)
+	})
+
+	job := &Job{
+		Type: "test",
+	}
+
+	err := worker.Enqueue(ctx, job)
+	if err != nil {
+		t.Errorf("Enqueue call failed: %v", err)
+	}
+
+	worker.Start(ctx)
+	waitUntilTrue(t, success.Load, "Timeout: failure handler was not called for panic test")
+}
+
+func TestMemoryWorker_Interrupt(t *testing.T) {
+	ctx := context.Background()
+	config := defaultConfig
+	config.IntSignal = os.Signal(syscall.SIGUSR1)
+	worker := NewMemoryClientWithConfig(config)
+	var success atomic.Bool
+
+	worker.RegisterHandlers("test", func(context.Context, *Job) {
+		// called to process job
+		p, err := os.FindProcess(os.Getpid())
+		if err != nil {
+			t.Errorf("Cannot find the process: %v", err)
+		}
+		if err := p.Signal(os.Signal(syscall.SIGUSR1)); err != nil {
+			t.Errorf("Cannot send the signal: %v", err)
+		}
+
+		// graceful shutdown initiated - wait little bit more to trigger context cancel
+		time.Sleep(200 * time.Millisecond)
+	}, func(context.Context, *Job) {
+		// called when context is cancelled, expires or after unhandled panic
+		success.Store(true)
+	})
+
+	job := &Job{
+		Type: "test",
+	}
+
+	err := worker.Enqueue(ctx, job)
+	if err != nil {
+		t.Errorf("Enqueue call failed: %v", err)
+	}
+	defer worker.Stop(ctx)
+
+	worker.Start(ctx)
+	waitUntilTrue(t, success.Load, "Timeout: failure handler was not called for interrupt test")
+}
+
+func waitUntilTrue(t *testing.T, check func() bool, msg string) {
+	timeout := time.After(5 * time.Second)
+	for !check() {
+		select {
+		case <-timeout:
+			t.Error(msg)
+			return
+		default:
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/pkg/jobs/queue.go
+++ b/pkg/jobs/queue.go
@@ -1,0 +1,59 @@
+package jobs
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+)
+
+var Queue JobWorker
+
+type handlers struct {
+	h  map[JobType]JobHandler
+	fh map[JobType]JobHandler
+}
+
+var hHap = make(map[JobType]handlers)
+
+// InitMemoryWorker initializes the default worker queue with an in-memory worker. Call
+// RegisterHandlers() before calling this function to register job handlers.
+func InitMemoryWorker() {
+	Queue = NewMemoryClient()
+	registerHandlers()
+}
+
+// InitMemoryWorker initializes the dummy (testing) worker queue with an in-memory worker. Call
+// RegisterHandlers() before calling this function to register job handlers.
+func InitDummyWorker() {
+	Queue = NewDummyWorker()
+	registerHandlers()
+}
+
+func registerHandlers() {
+	for k, v := range hHap {
+		logrus.Debugf("Registering handlers for job type: %s", k)
+		Queue.RegisterHandlers(k, v.h[k], v.fh[k])
+	}
+}
+
+// Returns the default worker queue.
+func Worker() JobWorker {
+	return Queue
+}
+
+// Enqueue sends a job to the worker queue.
+func Enqueue(ctx context.Context, job *Job) error {
+	return Queue.Enqueue(ctx, job)
+}
+
+// RegisterHandlers registers a job handler for a specific job type. This function must be called
+// before InitMemoryWorker() or InitDummyWorker(). All previously registered handlers are passed into
+// Queue.Worker.RegisterHandlers().
+//
+// To register a handler after worker initialization, use Worker().RegisterHandlers() instead.
+func RegisterHandlers(jobType JobType, jobHandler JobHandler, failureHandler JobHandler) {
+	hHap[jobType] = handlers{
+		h:  map[JobType]JobHandler{jobType: jobHandler},
+		fh: map[JobType]JobHandler{jobType: failureHandler},
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,55 @@
+package metrics
+
+import (
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const ApplicationName = "edge-api"
+
+var BinaryName = ApplicationName
+
+func init() {
+	BinaryName = os.Args[0]
+}
+
+var JobEnqueuedCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name:        "edge_enqueued_jobs_count",
+		Help:        "job count by result (finished/timeouted/panicked/cancelled) by type",
+		ConstLabels: prometheus.Labels{"service": ApplicationName, "component": BinaryName},
+	},
+	[]string{"type"},
+)
+
+var JobProcessedCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name:        "edge_processed_jobs_count",
+		Help:        "job count by result (finished/timeouted/panicked/cancelled) by type",
+		ConstLabels: prometheus.Labels{"service": ApplicationName, "component": BinaryName},
+	},
+	[]string{"type", "result"},
+)
+
+var JobQueueSize = prometheus.NewGauge(prometheus.GaugeOpts{
+	Name:        "edge_job_queue_size",
+	Help:        "background job queue size (total pending jobs)",
+	ConstLabels: prometheus.Labels{"service": ApplicationName, "component": BinaryName},
+})
+
+var JobActiveSize = prometheus.NewGauge(prometheus.GaugeOpts{
+	Name:        "edge_job_active_size",
+	Help:        "active background job (total processing jobs)",
+	ConstLabels: prometheus.Labels{"service": ApplicationName, "component": BinaryName},
+})
+
+var BackgroundJobDuration = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:        "edge_job_duration",
+		Help:        "background job duration (in seconds) by type",
+		ConstLabels: prometheus.Labels{"service": ApplicationName, "component": BinaryName},
+		Buckets:     []float64{1, 10, 30, 60 * 2, 60 * 10, 60 * 30, 60 * 120, 60 * 240},
+	},
+	[]string{"type"},
+)

--- a/pkg/metrics/registration.go
+++ b/pkg/metrics/registration.go
@@ -1,0 +1,13 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+func RegisterAPIMetrics() {
+	prometheus.MustRegister(
+		JobEnqueuedCount,
+		JobProcessedCount,
+		JobQueueSize,
+		JobActiveSize,
+		BackgroundJobDuration,
+	)
+}

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -35,6 +35,9 @@ var GlitchtipLogging = &Flag{Name: "edge-management.glitchtip_logging", EnvVar: 
 // KafkaLogging is the feature flag for logging kafka messages
 var KafkaLogging = &Flag{Name: "edge-management.kafka_logging", EnvVar: "KAFKA_LOGGING"}
 
+// JOB QUEUE FLAGS
+var JobQueue = &Flag{Name: "edge-management.job_queue", EnvVar: "FEATURE_JOBQUEUE"}
+
 // IMAGE FEATURE FLAGS
 
 // ImageCreateEDA is the feature flag for routes.CreateImage() EDA code


### PR DESCRIPTION
This pull request adds a simple job scheduler. It is a code ported from

https://github.com/RHEnVision/provisioning-backend/tree/main/pkg/worker

with memory-only implementation for now. Meaning jobs will be executed still on api pods, but if we decide to in the future, we can change it to SQL-based or Redis-based queue.

Kafka is not a good job queueing solution because load distribution across consumers is hash-based with default implementation being round-robin. Any sort of queueing business logic must be coded on top of that so there is no benefit. Redis, on the other hand, provide native queues. Or it can be SQL-based similarly to image builder's composer (job table, notify/subscribe for events).

For this reason, I propose to remove the WIP event-based Kafka solution and go with simplest possible in-process solution. As we get rid of big tasks and add Pulp integration, we may not need to move job processing into individual pods, but if we need to it is a trivial thing to. The implementation can be taken from provisioning service so this would be low-effort.

This should be an easy change as long as all arguments that are passed into background processing logic in the current codebase can be put into a struct that can be serialized later on (e.g. JSON/GOB). It is very important that all input data is not shared (e.g. no pointers to the "godlike" global state services in the `dependencies` package) as in the future workers may be running on different pods.

By default, `edge-api` spawns 10 managed worker goroutines with up to 10 queued jobs in total. Each job will expire after 4 hours (I hope to shorten this soon). The code logic must pass context into clients (e.g. HTTP client, SQL client) in order to receive a context error when that happens, at least into long-running steps. These numbers were made up, we need to tune these numbers once we implement Pulp, or even before if we choose to do this before that.

The proposed queue solves also context cancellation, panic and interrupts properly by providing a second (failure) handler that is called when job expires, is cancelled gracefully or interrupt signal is sent when k8s decides to kill the pod.

For easier unit testing, a separate implementation can be added which will use zero goroutines, the code will be executed straight in the `Enqueue` function and all the others (like `Start`, `Stop` or `Stats`) will be no-operations. This way, we can run tests in a consistent environment. Not part of this PR tho.

**How to use the scheduler**

A `Job` represents unit of work, it has a type, random uuid, identity and correlation (request_id typically) and an empty interface - anything that can be serialized. There are two interfaces for working with jobs, `Enqueuer` provides `Enqueue` method which adds a job to the queue and then `Worker` where handler functions get registered. A worker   can be started, gracefully stopped and provides statistics which can be monitored.

Each job type must have two handler functions registered:

* job handler: a function which is called to process a job. The input is the `Job` type, there is no output or error - all errors must be handled by the function (e.g. logged, written to db).
* failure handler: a function which is called when
  * job was running too long (timeout, 4 hours by default)
  * pod is shutting down gracefully (context cancel triggered by `Stop` method)
  * unhandled panic occurred in the job handler function
  * interrupt occured when k8s are about to kill the pod

Statistics provide two values:

* amount of active jobs (buys workers)
* amount of enqueued jobs (jobs waiting to be processed)

There is a hard limit of workers (10 in this proposal) which allows us to control the load on pods as well as hard limit of jobs which can be put into queue (10 as well). If this limit is reached, enqueuer will start blocking so requests may timeout. This means we will notice the problem in the monitoring soon as well as user will be informed something is not right.

As part of this PR I added metrics for HTTP requests (latency, result codes) and the new job queue so we can see amount of jobs entering the scheduler, number of finished/timeouted/panicked jobs and also latency.

I am also adding yet another (I know) feature flag to turn the new scheduler for "retry image build" operation. I have chosen this one because it is very easy to test it, just do `curl-stage POST /edge/v1/images/74265/retry` to schedule a new rebuild. My plan is to turn this on for my stage account and start testing this.