### PR TITLE
Build all artifacts on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,20 @@ build-test-container:
 		.
 
 build:
-	go build -o edge-api .
+	mkdir -p build 2>/dev/null
+	go build -o build/edge-api .
+	go build -o build/edge-api-migrate cmd/migrate/main.go
+	go build -o build/edge-api-wipe cmd/db/wipe.go
+	go build -o build/edge-api-migrate-device cmd/db/updDb/set_account_on_device.go
+	go build -o build/edge-api-migrate-repositories cmd/migraterepos/main.go
+	go build -o build/edge-api-migrate-groups cmd/migrategroups/main.go
+	go build -o build/edge-api-ibvents cmd/kafka/main.go
+	go build -o build/edge-api-images-build pkg/services/images_build/main.go
+	go build -o build/edge-api-isos-build pkg/services/images_iso/main.go
+	go build -o build/edge-api-cleanup cmd/cleanup/main.go
 
 clean:
+	rm -rf build
 	golangci-lint cache clean
 
 coverage:
@@ -113,7 +124,8 @@ help:
 	@echo "build-containers          Builds all the container images"
 	@echo "build-edge-api-container  Builds the edge-api container"
 	@echo "build-test-container      Builds the test container"
-	@echo "clean                     Removes cached golangci files"
+	@echo "build                     Build all binaries into ./build"
+	@echo "clean                     Removes binaries and cached golangci files"
 	@echo "coverage                  Runs 'go test' coverage on the project"
 	@echo "coverage-html             Create HTML version of coverage report"
 	@echo "coverage-no-fdo           Runs 'go test' coverage on the project without FDO"
@@ -318,4 +330,4 @@ mockgen: \
 	pkg/clients/rbac/mock_rbac/client.go \
 	pkg/clients/inventory/mock_inventory/inventory.go \
 	pkg/clients/inventorygroups/mock_inventorygroups/client.go \
-	pkg/clients/imagebuilder/mock_imagebuilder/client.go \
+	pkg/clients/imagebuilder/mock_imagebuilder/client.go

--- a/cmd/cleanup/cleanupdevices/cleanupdevices_suite_test.go
+++ b/cmd/cleanup/cleanupdevices/cleanupdevices_suite_test.go
@@ -17,8 +17,9 @@ import (
 func TestMigrate(t *testing.T) {
 	RegisterFailHandler(Fail)
 	dbName := setupTestDB()
+	defer tearDownTestDB(dbName)
+
 	RunSpecs(t, "Cleanup devices storage Suite")
-	tearDownTestDB(dbName)
 }
 
 func setupTestDB() string {

--- a/cmd/cleanup/cleanupimages/cleanupimages_suite_test.go
+++ b/cmd/cleanup/cleanupimages/cleanupimages_suite_test.go
@@ -17,8 +17,9 @@ import (
 func TestMigrate(t *testing.T) {
 	RegisterFailHandler(Fail)
 	dbName := setupTestDB()
+	defer tearDownTestDB(dbName)
+
 	RunSpecs(t, "Cleanup images storage Suite")
-	tearDownTestDB(dbName)
 }
 
 func setupTestDB() string {

--- a/cmd/cleanup/cleanuporphancommits/cleanuporphancommits_suite_test.go
+++ b/cmd/cleanup/cleanuporphancommits/cleanuporphancommits_suite_test.go
@@ -17,8 +17,9 @@ import (
 func TestCleanupOrphanCommits(t *testing.T) {
 	RegisterFailHandler(Fail)
 	dbName := setupTestDB()
+	defer tearDownTestDB(dbName)
+
 	RunSpecs(t, "Cleanup orphan commits Suite")
-	tearDownTestDB(dbName)
 }
 
 func setupTestDB() string {

--- a/cmd/cleanup/deleteimages/deleteimages_suite_test.go
+++ b/cmd/cleanup/deleteimages/deleteimages_suite_test.go
@@ -17,8 +17,9 @@ import (
 func TestMigrate(t *testing.T) {
 	RegisterFailHandler(Fail)
 	dbName := setupTestDB()
+	defer tearDownTestDB(dbName)
+
 	RunSpecs(t, "Cleanup images storage Suite")
-	tearDownTestDB(dbName)
 }
 
 func setupTestDB() string {

--- a/cmd/migrategroups/migrategroups/migrategroups_suite_test.go
+++ b/cmd/migrategroups/migrategroups/migrategroups_suite_test.go
@@ -18,6 +18,7 @@ func TestMigrate(t *testing.T) {
 	RegisterFailHandler(Fail)
 	dbName := setupTestDB()
 	defer tearDownTestDB(dbName)
+
 	RunSpecs(t, "Migrate device groups Suite")
 }
 

--- a/cmd/migraterepos/migraterepos/migraterepos_suite_test.go
+++ b/cmd/migraterepos/migraterepos/migraterepos_suite_test.go
@@ -18,6 +18,7 @@ func TestMigrate(t *testing.T) {
 	RegisterFailHandler(Fail)
 	dbName := setupTestDB()
 	defer tearDownTestDB(dbName)
+
 	RunSpecs(t, "Migrate custom repositories Suite")
 }
 

--- a/cmd/migraterepos/postmigraterepos/postmigraterepos_suite_test.go
+++ b/cmd/migraterepos/postmigraterepos/postmigraterepos_suite_test.go
@@ -18,6 +18,7 @@ func TestPostMigrate(t *testing.T) {
 	RegisterFailHandler(Fail)
 	dbName := setupTestDB()
 	defer tearDownTestDB(dbName)
+
 	RunSpecs(t, "Migrate custom repositories Suite")
 }
 

--- a/cmd/migraterepos/repairrepos/repairrepos_suite_test.go
+++ b/cmd/migraterepos/repairrepos/repairrepos_suite_test.go
@@ -17,8 +17,9 @@ import (
 func TestMigrate(t *testing.T) {
 	RegisterFailHandler(Fail)
 	dbName := setupTestDB()
+	defer tearDownTestDB(dbName)
+
 	RunSpecs(t, "Repair custom repositories Suite")
-	tearDownTestDB(dbName)
 }
 
 func setupTestDB() string {

--- a/pkg/db/main_test.go
+++ b/pkg/db/main_test.go
@@ -15,10 +15,13 @@ import (
 
 // This will set up the test database and run the tests for whole package
 func TestMain(m *testing.M) {
+	rc := 0
+	defer func() { os.Exit(rc) }()
+
 	setupTestDB()
-	retCode := m.Run()
-	tearDownTestDB()
-	os.Exit(retCode)
+	defer tearDownTestDB()
+
+	rc = m.Run()
 }
 
 var dbName string

--- a/pkg/models/main_test.go
+++ b/pkg/models/main_test.go
@@ -16,10 +16,13 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	rc := 0
+	defer func() { os.Exit(rc) }()
+
 	setUp()
-	retCode := m.Run()
-	tearDown()
-	os.Exit(retCode)
+	defer tearDown()
+
+	rc = m.Run()
 }
 
 var dbName string

--- a/pkg/routes/common/filters_test.go
+++ b/pkg/routes/common/filters_test.go
@@ -64,11 +64,18 @@ func setUp() {
 }
 
 func TestMain(m *testing.M) {
+	rc := 0
+	defer func() { os.Exit(rc) }()
+
 	setUp()
-	retCode := m.Run()
+	defer tearDown()
+
+	rc = m.Run()
 	db.DB.Exec("DELETE FROM images")
+}
+
+func tearDown() {
 	os.Remove(dbName)
-	os.Exit(retCode)
 }
 
 func TestContainFilterHandler(t *testing.T) {

--- a/pkg/routes/main_test.go
+++ b/pkg/routes/main_test.go
@@ -44,12 +44,13 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	rc := 0
+	defer func() { os.Exit(rc) }()
+
 	setUp()
-	retCode := m.Run()
-	defer func(exitCode int) {
-		tearDown()
-		os.Exit(exitCode)
-	}(retCode)
+	defer tearDown()
+
+	rc = m.Run()
 }
 
 var dbName string

--- a/pkg/services/main_test.go
+++ b/pkg/services/main_test.go
@@ -16,10 +16,13 @@ import (
 
 // This will setup the test database and run the tests for whole package
 func TestMain(m *testing.M) {
+	rc := 0
+	defer func() { os.Exit(rc) }()
+
 	setupTestDB()
-	retCode := m.Run()
-	tearDownTestDB()
-	os.Exit(retCode)
+	defer tearDownTestDB()
+
+	rc = m.Run()
 }
 
 var dbName string

--- a/pkg/services/update/update_suite_test.go
+++ b/pkg/services/update/update_suite_test.go
@@ -20,8 +20,9 @@ import (
 func TestDevices(t *testing.T) {
 	RegisterFailHandler(Fail)
 	setUp()
+	defer tearDown()
+
 	RunSpecs(t, "Update Suite")
-	tearDown()
 }
 
 var dbName string


### PR DESCRIPTION
SSIA

It is a good idea to fail early if the project does not build.

I also added another commit which further improves handling of temporary database files - uses defer trick to not to leave files behind when tests fail.