### PR TITLE
Add feature flag check with context

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -1471,7 +1471,7 @@ func (s *ImageService) RetryCreateImage(ctx context.Context, image *models.Image
 		s.log.WithField("error", err.Error()).Error("Failed setting image status")
 		return nil
 	}
-	if feature.JobQueue.IsEnabled() {
+	if feature.JobQueue.IsEnabledCtx(ctx) {
 		job := jobs.Job{
 			Type: "RetryCreateImageJob",
 			Args: &RetryCreateImageJob{ImageID: image.ID},


### PR DESCRIPTION
This pull request adds a new function `CheckFeatureCtx` to the `feature` package that allows checking if a given feature is available with context. It also includes changes to the `main.go` and `images.go` files to use the new function.

I wonder how features were previously added per customer account. I heard that some customers had specific workflows.