### PR TITLE
THEEDGE-3926: add active deadline for cleanup job

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -365,6 +365,7 @@ objects:
         restartPolicy: Never
         concurrencyPolicy: Forbid
         suspend: ${{CLEANUP_SUSPEND}}
+        activeDeadlineSeconds: 259200
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
           args:


### PR DESCRIPTION
* clowdapp.yml - add 3 day active deadline for cleanup job

# Description
Add a three day active deadline for the cleanup job.
After three days, OpenShift will evict the pod(s) and kill the job.
This is only one step in preventing cleanup from running indefinitely on error.

FIXES:  THEEDGE-3926

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
