### PR TITLE
EDA remove deprecated image event calls from routes

### DIFF
--- a/pkg/services/images_test.go
+++ b/pkg/services/images_test.go
@@ -3062,8 +3062,6 @@ func TestCreateInstallerForImageSuccessfully(t *testing.T) {
 	err := os.Unsetenv(feature.DeprecateKickstartInjection.EnvVar)
 	g.Expect(err).ToNot(HaveOccurred())
 	// ensure feature.ImageCreateISOEDA is disabled
-	err = os.Unsetenv(feature.ImageCreateEDA.EnvVar)
-	g.Expect(err).ToNot(HaveOccurred())
 
 	currentDir, err := os.Getwd()
 	g.Expect(err).ToNot(HaveOccurred())
@@ -3160,9 +3158,6 @@ func TestCreateInstallerForImageSuccessfullyWithSkipInjectKickstart(t *testing.T
 	g := NewGomegaWithT(t)
 	// set feature flag feature.SkipInjectKickstartToISO to skip injecting kickstart to ISO file
 	err := os.Setenv(feature.DeprecateKickstartInjection.EnvVar, "true")
-	g.Expect(err).ToNot(HaveOccurred())
-	// ensure feature.ImageCreateISOEDA is disabled
-	err = os.Unsetenv(feature.ImageCreateEDA.EnvVar)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	defer func() {

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -40,12 +40,6 @@ var JobQueue = &Flag{Name: "edge-management.job_queue", EnvVar: "FEATURE_JOBQUEU
 
 // IMAGE FEATURE FLAGS
 
-// ImageCreateEDA is the feature flag for routes.CreateImage() EDA code
-var ImageCreateEDA = &Flag{Name: "edge-management.image_create", EnvVar: "FEATURE_IMAGECREATE"}
-
-// ImageUpdateEDA is the feature flag for routes.CreateImageUpdate() EDA code
-var ImageUpdateEDA = &Flag{Name: "edge-management.image_update", EnvVar: "FEATURE_IMAGEUPDATE"}
-
 // ImageCreateCommitEDA is the feature flag for routes.CreateCommit() EDA code
 var ImageCreateCommitEDA = &Flag{Name: "", EnvVar: "FEATURE_IMAGECREATE_COMMIT"}
 


### PR DESCRIPTION
# Description
Remove deprecated/stale EDA feature calls related to Images from routes package

FIXES: HMS-3989

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
