### PR TITLE
identity: Set the Original identity only once

### DIFF
--- a/cmd/migraterepos/migraterepos/migraterepos_test.go
+++ b/cmd/migraterepos/migraterepos/migraterepos_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/redhatinsights/edge-api/pkg/models"
 	"github.com/redhatinsights/edge-api/pkg/routes/common"
 	feature "github.com/redhatinsights/edge-api/unleash/features"
+	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
 
 	"github.com/bxcodec/faker/v3"
 	"github.com/google/uuid"
@@ -71,7 +72,7 @@ var _ = Describe("Migrate custom repositories", func() {
 		It("migrate all repos successfully", func() {
 			contentSourcesGetCallIndex := 0
 			contentSourcesPostCallIndex := 0
-			ts := httptest.NewServer(dependencies.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts := httptest.NewServer(identity.EnforceIdentity(dependencies.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				rhIndent, err := common.GetIdentityInstanceFromContext(r.Context())
 				Expect(err).ToNot(HaveOccurred())
 				// ensure identity user OrgAdmin is true
@@ -131,7 +132,7 @@ var _ = Describe("Migrate custom repositories", func() {
 				default:
 					w.WriteHeader(http.StatusBadRequest)
 				}
-			})))
+			}))))
 			defer ts.Close()
 			config.Get().ContentSourcesURL = ts.URL
 

--- a/pkg/dependencies/main.go
+++ b/pkg/dependencies/main.go
@@ -96,7 +96,6 @@ func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		edgeAPIServices := Init(r.Context())
 		ctx := ContextWithServices(r.Context(), edgeAPIServices)
-		ctx = common.SetOriginalIdentity(ctx, r.Header.Get("X-Rh-Identity"))
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }


### PR DESCRIPTION
# Description

We are already setting the Raw encoded identity here:

https://github.com/RedHatInsights/platform-go-middlewares/blob/48aa4a66e621e08b2cac8030e0da9b9e00efc780/identity/identity.go#L305

This removes setting it again in dependancies.Middleware

## Type of change

What is it?

- [x] Refactor
