### PR TITLE
jobs: store raw identity

### DIFF
--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -128,6 +128,7 @@ func initJobContext(origCtx context.Context, job *Job) (context.Context, logrus.
 		id = identity.XRHID{}
 	}
 	ctx = identity.WithIdentity(ctx, id)
+	ctx = identity.WithRawIdentity(ctx, job.Identity)
 
 	return ctx, logrus.WithContext(ctx).WithFields(
 		logrus.Fields{


### PR DESCRIPTION
Image retry call fails because raw identity is not available in the job context, thus image builder client errors out.