### PR TITLE
chore: add pprof for stage

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
+	"strings"
 	"syscall"
 	"time"
 
@@ -124,6 +125,11 @@ func webRoutes(cfg *config.EdgeConfig) *chi.Mux {
 	route.Get("/api/edge/v1/openapi.json", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, cfg.OpenAPIFilePath)
 	})
+
+	// Non-production routes
+	if strings.Contains(config.Get().EdgeAPIBaseURL, "stage") {
+		route.Mount("/debug", middleware.Profiler())
+	}
 
 	// Authenticated routes
 	authRoute := route.Group(nil)

--- a/pkg/jobs/memory.go
+++ b/pkg/jobs/memory.go
@@ -52,7 +52,7 @@ func NewMemoryClientWithConfig(config Config) *MemoryWorker {
 func NewMemoryClient() *MemoryWorker {
 	return NewMemoryClientWithConfig(Config{
 		QueueSize: 5,
-		Workers:   2,
+		Workers:   1,
 		Timeout:   4 * time.Hour,
 		IntSignal: os.Interrupt,
 	})


### PR DESCRIPTION
Adds the [official pprof tool](https://pkg.go.dev/net/http/pprof) for the stage environment so the official Go utility can be used to attach to stage and investigate possible memory leaks. **This is a temporary measurement**, pprof will slow down stage a bit.

I was thinking maybe introducing a flag so we could turn it on, restart the app and have it, but I think I will be done after a week or two so we can remove this. Chances are that I will not be able find anything, the project is relatively big so pprof might not be too useful with too much data.

Example:

```
$ go tool pprof http://localhost:3000/debug/pprof/heap
Fetching profile over HTTP from http://localhost:3000/debug/pprof/heap
Saved profile in /home/lzap/pprof/pprof.app.alloc_objects.alloc_space.inuse_objects.inuse_space.001.pb.gz
File: app
Build ID: d805eb4a2bcc83604c2f0949f9d0e4d67ff21dea
Type: inuse_space
Time: May 20, 2024 at 7:03am (CEST)
Entering interactive mode (type "help" for commands, "o" for options)

(pprof) help
  Commands:
    callgrind        Outputs a graph in callgrind format
    comments         Output all profile comments
    disasm           Output assembly listings annotated with samples
    dot              Outputs a graph in DOT format
    eog              Visualize graph through eog
    evince           Visualize graph through evince
    gif              Outputs a graph image in GIF format
    gv               Visualize graph through gv
    kcachegrind      Visualize report in KCachegrind
    list             Output annotated source for functions matching regexp
    pdf              Outputs a graph in PDF format
    peek             Output callers/callees of functions matching regexp
    png              Outputs a graph image in PNG format
    proto            Outputs the profile in compressed protobuf format
    ps               Outputs a graph in PS format
    raw              Outputs a text representation of the raw profile
    svg              Outputs a graph in SVG format
    tags             Outputs all tags in the profile
    text             Outputs top entries in text form
    top              Outputs top entries in text form
    topproto         Outputs top entries in compressed protobuf format
    traces           Outputs all profile samples in text form
    tree             Outputs a text rendering of call graph
    web              Visualize graph through web browser
    weblist          Display annotated source in a web browser
    o/options        List options and their current values
    q/quit/exit/^D   Exit pprof

  Options:
    call_tree        Create a context-sensitive call tree
    compact_labels   Show minimal headers
    divide_by        Ratio to divide all samples before visualization
    drop_negative    Ignore negative differences
    edgefraction     Hide edges below <f>*total
    focus            Restricts to samples going through a node matching regexp
    hide             Skips nodes matching regexp
    ignore           Skips paths going through any nodes matching regexp
    intel_syntax     Show assembly in Intel syntax
    mean             Average sample value over first value (count)
    nodecount        Max number of nodes to show
    nodefraction     Hide nodes below <f>*total
    noinlines        Ignore inlines.
    normalize        Scales profile based on the base profile.
    output           Output filename for file-based outputs
    prune_from       Drops any functions below the matched frame.
    relative_percentages Show percentages relative to focused subgraph
    sample_index     Sample value to report (0-based index or name)
    show             Only show nodes matching regexp
    show_from        Drops functions above the highest matched frame.
    source_path      Search path for source files
    tagfocus         Restricts to samples with tags in range or matched by regexp
    taghide          Skip tags matching this regexp
    tagignore        Discard samples with tags in range or matched by regexp
    tagleaf          Adds pseudo stack frames for labels key/value pairs at the callstack leaf.
    tagroot          Adds pseudo stack frames for labels key/value pairs at the callstack root.
    tagshow          Only consider tags matching this regexp
    trim             Honor nodefraction/edgefraction/nodecount defaults
    trim_path        Path to trim from source paths before search
    unit             Measurement units to display

  Option groups (only set one per group):
    granularity      
      functions        Aggregate at the function level.
      filefunctions    Aggregate at the function level.
      files            Aggregate at the file level.
      lines            Aggregate at the source code line level.
      addresses        Aggregate at the address level.
    sort             
      cum              Sort entries based on cumulative weight
      flat             Sort entries based on own weight
  :   Clear focus/ignore/hide/tagfocus/tagignore

  type "help <cmd|option>" for more information

(pprof) text
Showing nodes accounting for 1024.12kB, 100% of 1024.12kB total
Showing top 10 nodes out of 11
      flat  flat%   sum%        cum   cum%
  512.07kB 50.00% 50.00%   512.07kB 50.00%  github.com/aws/aws-sdk-go/aws/endpoints.init
  512.05kB 50.00%   100%   512.05kB 50.00%  regexp/syntax.(*parser).newRegexp (inline)
         0     0%   100%   512.05kB 50.00%  github.com/go-openapi/strfmt.init
         0     0%   100%   512.05kB 50.00%  regexp.Compile (inline)
         0     0%   100%   512.05kB 50.00%  regexp.MustCompile
         0     0%   100%   512.05kB 50.00%  regexp.compile
         0     0%   100%   512.05kB 50.00%  regexp/syntax.(*parser).literal
         0     0%   100%   512.05kB 50.00%  regexp/syntax.Parse (inline)
         0     0%   100%   512.05kB 50.00%  regexp/syntax.parse
         0     0%   100%  1024.12kB   100%  runtime.doInit
```

I am also decreasing the parallel job run from 2 to 1 to ensure only one job runs at a time for easier debugging.