### PR TITLE
chore: export pprof via /api/edge

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func webRoutes(cfg *config.EdgeConfig) *chi.Mux {
 
 	// Non-production routes
 	if strings.Contains(config.Get().EdgeAPIBaseURL, "stage") {
-		route.Mount("/debug", middleware.Profiler())
+		route.Mount("/api/edge/debug", middleware.Profiler())
 	}
 
 	// Authenticated routes


### PR DESCRIPTION
Looks like I am unable to access an endpoint that does not start with `/api/edge` on stage. This fixes it.