### PR TITLE
fix: race condition in kafka producer

### DIFF
--- a/pkg/common/kafka/producer.go
+++ b/pkg/common/kafka/producer.go
@@ -58,9 +58,10 @@ func NewProducerService() ProducerServiceInterface {
 // GetProducerInstance returns a kafka producer instance
 func (p *ProducerService) GetProducerInstance() Producer {
 	log.Debug("Getting the producer instance")
+	lock.Lock()
+	defer lock.Unlock()
+
 	if singleInstance == nil {
-		lock.Lock()
-		defer lock.Unlock()
 		cfg := config.Get()
 		if cfg.KafkaBrokers != nil {
 			log.WithFields(log.Fields{"broker": cfg.KafkaBrokers[0].Hostname,


### PR DESCRIPTION
Read was not protected by the mutex. Randomly saw this in the codebase, probably no effect on behavior.