### PR TITLE
refactor: job queue for more go routines

### DIFF
--- a/pkg/common/kafka/mock_kafka/mock_kafkaconfigmap.go
+++ b/pkg/common/kafka/mock_kafka/mock_kafkaconfigmap.go
@@ -11,44 +11,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockKafkaConfigMapServiceInterface is a mock of KafkaConfigMapServiceInterface interface
+// MockKafkaConfigMapServiceInterface is a mock of KafkaConfigMapServiceInterface interface.
 type MockKafkaConfigMapServiceInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockKafkaConfigMapServiceInterfaceMockRecorder
 }
 
-// MockKafkaConfigMapServiceInterfaceMockRecorder is the mock recorder for MockKafkaConfigMapServiceInterface
+// MockKafkaConfigMapServiceInterfaceMockRecorder is the mock recorder for MockKafkaConfigMapServiceInterface.
 type MockKafkaConfigMapServiceInterfaceMockRecorder struct {
 	mock *MockKafkaConfigMapServiceInterface
 }
 
-// NewMockKafkaConfigMapServiceInterface creates a new mock instance
+// NewMockKafkaConfigMapServiceInterface creates a new mock instance.
 func NewMockKafkaConfigMapServiceInterface(ctrl *gomock.Controller) *MockKafkaConfigMapServiceInterface {
 	mock := &MockKafkaConfigMapServiceInterface{ctrl: ctrl}
 	mock.recorder = &MockKafkaConfigMapServiceInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockKafkaConfigMapServiceInterface) EXPECT() *MockKafkaConfigMapServiceInterfaceMockRecorder {
 	return m.recorder
 }
 
-// GetKafkaProducerConfigMap mocks base method
-func (m *MockKafkaConfigMapServiceInterface) GetKafkaProducerConfigMap() kafka.ConfigMap {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetKafkaProducerConfigMap")
-	ret0, _ := ret[0].(kafka.ConfigMap)
-	return ret0
-}
-
-// GetKafkaProducerConfigMap indicates an expected call of GetKafkaProducerConfigMap
-func (mr *MockKafkaConfigMapServiceInterfaceMockRecorder) GetKafkaProducerConfigMap() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKafkaProducerConfigMap", reflect.TypeOf((*MockKafkaConfigMapServiceInterface)(nil).GetKafkaProducerConfigMap))
-}
-
-// GetKafkaConsumerConfigMap mocks base method
+// GetKafkaConsumerConfigMap mocks base method.
 func (m *MockKafkaConfigMapServiceInterface) GetKafkaConsumerConfigMap(consumerGroup string) kafka.ConfigMap {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetKafkaConsumerConfigMap", consumerGroup)
@@ -56,8 +42,22 @@ func (m *MockKafkaConfigMapServiceInterface) GetKafkaConsumerConfigMap(consumerG
 	return ret0
 }
 
-// GetKafkaConsumerConfigMap indicates an expected call of GetKafkaConsumerConfigMap
+// GetKafkaConsumerConfigMap indicates an expected call of GetKafkaConsumerConfigMap.
 func (mr *MockKafkaConfigMapServiceInterfaceMockRecorder) GetKafkaConsumerConfigMap(consumerGroup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKafkaConsumerConfigMap", reflect.TypeOf((*MockKafkaConfigMapServiceInterface)(nil).GetKafkaConsumerConfigMap), consumerGroup)
+}
+
+// GetKafkaProducerConfigMap mocks base method.
+func (m *MockKafkaConfigMapServiceInterface) GetKafkaProducerConfigMap() kafka.ConfigMap {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetKafkaProducerConfigMap")
+	ret0, _ := ret[0].(kafka.ConfigMap)
+	return ret0
+}
+
+// GetKafkaProducerConfigMap indicates an expected call of GetKafkaProducerConfigMap.
+func (mr *MockKafkaConfigMapServiceInterfaceMockRecorder) GetKafkaProducerConfigMap() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKafkaProducerConfigMap", reflect.TypeOf((*MockKafkaConfigMapServiceInterface)(nil).GetKafkaProducerConfigMap))
 }

--- a/pkg/common/kafka/mock_kafka/mock_producer.go
+++ b/pkg/common/kafka/mock_kafka/mock_producer.go
@@ -13,42 +13,42 @@ import (
 	models "github.com/redhatinsights/edge-api/pkg/models"
 )
 
-// MockProducer is a mock of Producer interface
+// MockProducer is a mock of Producer interface.
 type MockProducer struct {
 	ctrl     *gomock.Controller
 	recorder *MockProducerMockRecorder
 }
 
-// MockProducerMockRecorder is the mock recorder for MockProducer
+// MockProducerMockRecorder is the mock recorder for MockProducer.
 type MockProducerMockRecorder struct {
 	mock *MockProducer
 }
 
-// NewMockProducer creates a new mock instance
+// NewMockProducer creates a new mock instance.
 func NewMockProducer(ctrl *gomock.Controller) *MockProducer {
 	mock := &MockProducer{ctrl: ctrl}
 	mock.recorder = &MockProducerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockProducer) EXPECT() *MockProducerMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockProducer) Close() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Close")
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockProducerMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockProducer)(nil).Close))
 }
 
-// Events mocks base method
+// Events mocks base method.
 func (m *MockProducer) Events() chan kafka.Event {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Events")
@@ -56,13 +56,13 @@ func (m *MockProducer) Events() chan kafka.Event {
 	return ret0
 }
 
-// Events indicates an expected call of Events
+// Events indicates an expected call of Events.
 func (mr *MockProducerMockRecorder) Events() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Events", reflect.TypeOf((*MockProducer)(nil).Events))
 }
 
-// Flush mocks base method
+// Flush mocks base method.
 func (m *MockProducer) Flush(timeoutMs int) int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Flush", timeoutMs)
@@ -70,13 +70,13 @@ func (m *MockProducer) Flush(timeoutMs int) int {
 	return ret0
 }
 
-// Flush indicates an expected call of Flush
+// Flush indicates an expected call of Flush.
 func (mr *MockProducerMockRecorder) Flush(timeoutMs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flush", reflect.TypeOf((*MockProducer)(nil).Flush), timeoutMs)
 }
 
-// GetFatalError mocks base method
+// GetFatalError mocks base method.
 func (m *MockProducer) GetFatalError() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFatalError")
@@ -84,13 +84,13 @@ func (m *MockProducer) GetFatalError() error {
 	return ret0
 }
 
-// GetFatalError indicates an expected call of GetFatalError
+// GetFatalError indicates an expected call of GetFatalError.
 func (mr *MockProducerMockRecorder) GetFatalError() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFatalError", reflect.TypeOf((*MockProducer)(nil).GetFatalError))
 }
 
-// GetMetadata mocks base method
+// GetMetadata mocks base method.
 func (m *MockProducer) GetMetadata(topic *string, allTopics bool, timeoutMs int) (*kafka.Metadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetadata", topic, allTopics, timeoutMs)
@@ -99,13 +99,13 @@ func (m *MockProducer) GetMetadata(topic *string, allTopics bool, timeoutMs int)
 	return ret0, ret1
 }
 
-// GetMetadata indicates an expected call of GetMetadata
+// GetMetadata indicates an expected call of GetMetadata.
 func (mr *MockProducerMockRecorder) GetMetadata(topic, allTopics, timeoutMs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockProducer)(nil).GetMetadata), topic, allTopics, timeoutMs)
 }
 
-// Len mocks base method
+// Len mocks base method.
 func (m *MockProducer) Len() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Len")
@@ -113,13 +113,13 @@ func (m *MockProducer) Len() int {
 	return ret0
 }
 
-// Len indicates an expected call of Len
+// Len indicates an expected call of Len.
 func (mr *MockProducerMockRecorder) Len() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Len", reflect.TypeOf((*MockProducer)(nil).Len))
 }
 
-// OffsetsForTimes mocks base method
+// OffsetsForTimes mocks base method.
 func (m *MockProducer) OffsetsForTimes(times []kafka.TopicPartition, timeoutMs int) ([]kafka.TopicPartition, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OffsetsForTimes", times, timeoutMs)
@@ -128,13 +128,13 @@ func (m *MockProducer) OffsetsForTimes(times []kafka.TopicPartition, timeoutMs i
 	return ret0, ret1
 }
 
-// OffsetsForTimes indicates an expected call of OffsetsForTimes
+// OffsetsForTimes indicates an expected call of OffsetsForTimes.
 func (mr *MockProducerMockRecorder) OffsetsForTimes(times, timeoutMs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OffsetsForTimes", reflect.TypeOf((*MockProducer)(nil).OffsetsForTimes), times, timeoutMs)
 }
 
-// Produce mocks base method
+// Produce mocks base method.
 func (m *MockProducer) Produce(msg *kafka.Message, deliveryChan chan kafka.Event) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Produce", msg, deliveryChan)
@@ -142,13 +142,13 @@ func (m *MockProducer) Produce(msg *kafka.Message, deliveryChan chan kafka.Event
 	return ret0
 }
 
-// Produce indicates an expected call of Produce
+// Produce indicates an expected call of Produce.
 func (mr *MockProducerMockRecorder) Produce(msg, deliveryChan interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Produce", reflect.TypeOf((*MockProducer)(nil).Produce), msg, deliveryChan)
 }
 
-// ProduceChannel mocks base method
+// ProduceChannel mocks base method.
 func (m *MockProducer) ProduceChannel() chan *kafka.Message {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProduceChannel")
@@ -156,13 +156,13 @@ func (m *MockProducer) ProduceChannel() chan *kafka.Message {
 	return ret0
 }
 
-// ProduceChannel indicates an expected call of ProduceChannel
+// ProduceChannel indicates an expected call of ProduceChannel.
 func (mr *MockProducerMockRecorder) ProduceChannel() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProduceChannel", reflect.TypeOf((*MockProducer)(nil).ProduceChannel))
 }
 
-// QueryWatermarkOffsets mocks base method
+// QueryWatermarkOffsets mocks base method.
 func (m *MockProducer) QueryWatermarkOffsets(topic string, partition int32, timeoutMs int) (int64, int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "QueryWatermarkOffsets", topic, partition, timeoutMs)
@@ -172,13 +172,13 @@ func (m *MockProducer) QueryWatermarkOffsets(topic string, partition int32, time
 	return ret0, ret1, ret2
 }
 
-// QueryWatermarkOffsets indicates an expected call of QueryWatermarkOffsets
+// QueryWatermarkOffsets indicates an expected call of QueryWatermarkOffsets.
 func (mr *MockProducerMockRecorder) QueryWatermarkOffsets(topic, partition, timeoutMs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryWatermarkOffsets", reflect.TypeOf((*MockProducer)(nil).QueryWatermarkOffsets), topic, partition, timeoutMs)
 }
 
-// SetOAuthBearerToken mocks base method
+// SetOAuthBearerToken mocks base method.
 func (m *MockProducer) SetOAuthBearerToken(oauthBearerToken kafka.OAuthBearerToken) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetOAuthBearerToken", oauthBearerToken)
@@ -186,13 +186,13 @@ func (m *MockProducer) SetOAuthBearerToken(oauthBearerToken kafka.OAuthBearerTok
 	return ret0
 }
 
-// SetOAuthBearerToken indicates an expected call of SetOAuthBearerToken
+// SetOAuthBearerToken indicates an expected call of SetOAuthBearerToken.
 func (mr *MockProducerMockRecorder) SetOAuthBearerToken(oauthBearerToken interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOAuthBearerToken", reflect.TypeOf((*MockProducer)(nil).SetOAuthBearerToken), oauthBearerToken)
 }
 
-// SetOAuthBearerTokenFailure mocks base method
+// SetOAuthBearerTokenFailure mocks base method.
 func (m *MockProducer) SetOAuthBearerTokenFailure(errstr string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetOAuthBearerTokenFailure", errstr)
@@ -200,13 +200,13 @@ func (m *MockProducer) SetOAuthBearerTokenFailure(errstr string) error {
 	return ret0
 }
 
-// SetOAuthBearerTokenFailure indicates an expected call of SetOAuthBearerTokenFailure
+// SetOAuthBearerTokenFailure indicates an expected call of SetOAuthBearerTokenFailure.
 func (mr *MockProducerMockRecorder) SetOAuthBearerTokenFailure(errstr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOAuthBearerTokenFailure", reflect.TypeOf((*MockProducer)(nil).SetOAuthBearerTokenFailure), errstr)
 }
 
-// String mocks base method
+// String mocks base method.
 func (m *MockProducer) String() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "String")
@@ -214,13 +214,13 @@ func (m *MockProducer) String() string {
 	return ret0
 }
 
-// String indicates an expected call of String
+// String indicates an expected call of String.
 func (mr *MockProducerMockRecorder) String() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockProducer)(nil).String))
 }
 
-// TestFatalError mocks base method
+// TestFatalError mocks base method.
 func (m *MockProducer) TestFatalError(code kafka.ErrorCode, str string) kafka.ErrorCode {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TestFatalError", code, str)
@@ -228,36 +228,36 @@ func (m *MockProducer) TestFatalError(code kafka.ErrorCode, str string) kafka.Er
 	return ret0
 }
 
-// TestFatalError indicates an expected call of TestFatalError
+// TestFatalError indicates an expected call of TestFatalError.
 func (mr *MockProducerMockRecorder) TestFatalError(code, str interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TestFatalError", reflect.TypeOf((*MockProducer)(nil).TestFatalError), code, str)
 }
 
-// MockProducerServiceInterface is a mock of ProducerServiceInterface interface
+// MockProducerServiceInterface is a mock of ProducerServiceInterface interface.
 type MockProducerServiceInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockProducerServiceInterfaceMockRecorder
 }
 
-// MockProducerServiceInterfaceMockRecorder is the mock recorder for MockProducerServiceInterface
+// MockProducerServiceInterfaceMockRecorder is the mock recorder for MockProducerServiceInterface.
 type MockProducerServiceInterfaceMockRecorder struct {
 	mock *MockProducerServiceInterface
 }
 
-// NewMockProducerServiceInterface creates a new mock instance
+// NewMockProducerServiceInterface creates a new mock instance.
 func NewMockProducerServiceInterface(ctrl *gomock.Controller) *MockProducerServiceInterface {
 	mock := &MockProducerServiceInterface{ctrl: ctrl}
 	mock.recorder = &MockProducerServiceInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockProducerServiceInterface) EXPECT() *MockProducerServiceInterfaceMockRecorder {
 	return m.recorder
 }
 
-// GetProducerInstance mocks base method
+// GetProducerInstance mocks base method.
 func (m *MockProducerServiceInterface) GetProducerInstance() kafkacommon.Producer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProducerInstance")
@@ -265,13 +265,13 @@ func (m *MockProducerServiceInterface) GetProducerInstance() kafkacommon.Produce
 	return ret0
 }
 
-// GetProducerInstance indicates an expected call of GetProducerInstance
+// GetProducerInstance indicates an expected call of GetProducerInstance.
 func (mr *MockProducerServiceInterfaceMockRecorder) GetProducerInstance() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProducerInstance", reflect.TypeOf((*MockProducerServiceInterface)(nil).GetProducerInstance))
 }
 
-// ProduceEvent mocks base method
+// ProduceEvent mocks base method.
 func (m *MockProducerServiceInterface) ProduceEvent(requestedTopic, recordKey string, event models.CRCCloudEvent) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProduceEvent", requestedTopic, recordKey, event)
@@ -279,7 +279,7 @@ func (m *MockProducerServiceInterface) ProduceEvent(requestedTopic, recordKey st
 	return ret0
 }
 
-// ProduceEvent indicates an expected call of ProduceEvent
+// ProduceEvent indicates an expected call of ProduceEvent.
 func (mr *MockProducerServiceInterfaceMockRecorder) ProduceEvent(requestedTopic, recordKey, event interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProduceEvent", reflect.TypeOf((*MockProducerServiceInterface)(nil).ProduceEvent), requestedTopic, recordKey, event)

--- a/pkg/common/kafka/mock_kafka/mock_topics.go
+++ b/pkg/common/kafka/mock_kafka/mock_topics.go
@@ -10,30 +10,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockTopicServiceInterface is a mock of TopicServiceInterface interface
+// MockTopicServiceInterface is a mock of TopicServiceInterface interface.
 type MockTopicServiceInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockTopicServiceInterfaceMockRecorder
 }
 
-// MockTopicServiceInterfaceMockRecorder is the mock recorder for MockTopicServiceInterface
+// MockTopicServiceInterfaceMockRecorder is the mock recorder for MockTopicServiceInterface.
 type MockTopicServiceInterfaceMockRecorder struct {
 	mock *MockTopicServiceInterface
 }
 
-// NewMockTopicServiceInterface creates a new mock instance
+// NewMockTopicServiceInterface creates a new mock instance.
 func NewMockTopicServiceInterface(ctrl *gomock.Controller) *MockTopicServiceInterface {
 	mock := &MockTopicServiceInterface{ctrl: ctrl}
 	mock.recorder = &MockTopicServiceInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTopicServiceInterface) EXPECT() *MockTopicServiceInterfaceMockRecorder {
 	return m.recorder
 }
 
-// GetTopic mocks base method
+// GetTopic mocks base method.
 func (m *MockTopicServiceInterface) GetTopic(requested string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTopic", requested)
@@ -42,7 +42,7 @@ func (m *MockTopicServiceInterface) GetTopic(requested string) (string, error) {
 	return ret0, ret1
 }
 
-// GetTopic indicates an expected call of GetTopic
+// GetTopic indicates an expected call of GetTopic.
 func (mr *MockTopicServiceInterfaceMockRecorder) GetTopic(requested interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTopic", reflect.TypeOf((*MockTopicServiceInterface)(nil).GetTopic), requested)

--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -23,12 +23,28 @@ type JobType string
 // will be called.
 type JobHandler func(ctx context.Context, job *Job)
 
+// JobQueue represents a queue where job is enqueued.
+type JobQueue int
+
+const (
+	// SlowQueue is a queue for jobs that can be processed slowly.
+	SlowQueue JobQueue = iota
+
+	// FastQueue is a queue for jobs that should be processed quickly.
+	FastQueue
+)
+
 // Job represents a single job. It is a message that is sent to a worker.
 // Job arguments are serialized so do not store pointers - workers must not share any
 // memory with the caller.
 type Job struct {
 	// Random UUID for logging and tracing. It is generated randomly by Enqueue function when blank.
 	ID uuid.UUID
+
+	// Job queue. Fast queue is for jobs that should be processed quickly, slow queue is for jobs
+	// that can be processed slowly. This allows better resource management. When not specified,
+	// job is enqueued to the slow queue.
+	Queue JobQueue
 
 	// Job type or "queue"
 	Type JobType
@@ -44,9 +60,10 @@ type Job struct {
 }
 
 // New creates new job and sets identity and correlation id from passed context.
-func New(ctx context.Context, jobType JobType, args any) *Job {
+func New(ctx context.Context, jobType JobType, jq JobQueue, args any) *Job {
 	return &Job{
 		ID:            uuid.New(),
+		Queue:         jq,
 		Type:          jobType,
 		Identity:      identity.GetRawIdentity(ctx),
 		CorrelationID: request_id.GetReqID(ctx),
@@ -56,6 +73,11 @@ func New(ctx context.Context, jobType JobType, args any) *Job {
 
 var ErrJobNotFound = errors.New("job not found")
 var ErrHandlerNotFound = errors.New("handler not registered")
+
+// IgnoredJobHandler is a handler that does nothing. It is used when no handler is registered for a job.
+var IgnoredJobHandler JobHandler = func(_ context.Context, _ *Job) {
+	// do nothing
+}
 
 // JobEnqueuer sends Job messages into worker queue.
 type JobEnqueuer interface {

--- a/pkg/jobs/queue.go
+++ b/pkg/jobs/queue.go
@@ -46,9 +46,15 @@ func Enqueue(ctx context.Context, job *Job) error {
 	return Queue.Enqueue(ctx, job)
 }
 
-// NewAndEnqueue sends an existing job to the worker queue.
+// NewAndEnqueue sends an existing job to the fast worker queue.
 func NewAndEnqueue(ctx context.Context, jobType JobType, args any) error {
-	job := New(ctx, jobType, args)
+	job := New(ctx, jobType, FastQueue, args)
+	return Queue.Enqueue(ctx, job)
+}
+
+// NewAndEnqueueSlow sends an existing job to the slow worker queue.
+func NewAndEnqueueSlow(ctx context.Context, jobType JobType, args any) error {
+	job := New(ctx, jobType, SlowQueue, args)
 	return Queue.Enqueue(ctx, job)
 }
 

--- a/pkg/services/mock_services/images.go
+++ b/pkg/services/mock_services/images.go
@@ -111,13 +111,12 @@ func (mr *MockImageServiceInterfaceMockRecorder) CreateImage(image interface{}) 
 }
 
 // CreateInstallerForImage mocks base method.
-func (m *MockImageServiceInterface) CreateInstallerForImage(arg0 context.Context, arg1 *models.Image) (*models.Image, chan error, error) {
+func (m *MockImageServiceInterface) CreateInstallerForImage(arg0 context.Context, arg1 *models.Image) (*models.Image, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInstallerForImage", arg0, arg1)
 	ret0, _ := ret[0].(*models.Image)
-	ret1, _ := ret[1].(chan error)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CreateInstallerForImage indicates an expected call of CreateInstallerForImage.
@@ -302,6 +301,20 @@ func (m *MockImageServiceInterface) ProcessImage(ctx context.Context, img *model
 func (mr *MockImageServiceInterfaceMockRecorder) ProcessImage(ctx, img, handleInterruptSignal interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessImage", reflect.TypeOf((*MockImageServiceInterface)(nil).ProcessImage), ctx, img, handleInterruptSignal)
+}
+
+// ProcessInstaller mocks base method.
+func (m *MockImageServiceInterface) ProcessInstaller(ctx context.Context, image *models.Image) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProcessInstaller", ctx, image)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ProcessInstaller indicates an expected call of ProcessInstaller.
+func (mr *MockImageServiceInterfaceMockRecorder) ProcessInstaller(ctx, image interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessInstaller", reflect.TypeOf((*MockImageServiceInterface)(nil).ProcessInstaller), ctx, image)
 }
 
 // ResumeCreateImage mocks base method.


### PR DESCRIPTION
This splits job queue into two - slow and fast, the latter being the default. This will prevent job starving when long-running jobs take all the resources (worker goroutines) and will not allow faster jobs to complete. The job size and worker pool size is guesswork for now, prometheus will show us numbers once we turn this on.

I reviewed all goroutines and transformed the code to use the job queue except four occurences which are soon going away with the pulp migration. Here is the list of new jobs:

```
$ ag NewAndEnqueue | egrep -o '\w+Job' | sort -u
CreateRepoForImageJob
CreateUpdateAsyncJob
ProcessImageJob
ProcessInstallerJob
ResumeCreateImageJob
RetryCreateImageJob
SyncDevicesWithInventoryJob
```

I made a guess on which jobs are likely slow and I use slow queue for them, we can update this later once we have some data from prometheus.