### PR TITLE
refactor: preallocate package diff maps

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
-	"strings"
 	"syscall"
 	"time"
 
@@ -126,10 +125,10 @@ func webRoutes(cfg *config.EdgeConfig) *chi.Mux {
 		http.ServeFile(w, r, cfg.OpenAPIFilePath)
 	})
 
-	// Non-production routes
-	if strings.Contains(config.Get().EdgeAPIBaseURL, "stage") {
-		route.Mount("/api/edge/debug", middleware.Profiler())
-	}
+	// Uncomment to enable profiling
+	//if strings.Contains(config.Get().EdgeAPIBaseURL, "stage") {
+	//route.Mount("/api/edge/debug", middleware.Profiler())
+	//}
 
 	// Authenticated routes
 	authRoute := route.Group(nil)

--- a/main.go
+++ b/main.go
@@ -125,11 +125,6 @@ func webRoutes(cfg *config.EdgeConfig) *chi.Mux {
 		http.ServeFile(w, r, cfg.OpenAPIFilePath)
 	})
 
-	// Uncomment to enable profiling
-	//if strings.Contains(config.Get().EdgeAPIBaseURL, "stage") {
-	//route.Mount("/api/edge/debug", middleware.Profiler())
-	//}
-
 	// Authenticated routes
 	authRoute := route.Group(nil)
 	if cfg.Auth {

--- a/pkg/services/devices.go
+++ b/pkg/services/devices.go
@@ -363,8 +363,8 @@ func (s *DeviceService) GetUpdateAvailableForDevice(device inventory.Device, lat
 }
 
 func getPackageDiff(a, b []models.InstalledPackage) []models.InstalledPackage {
-	diff := make([]models.InstalledPackage, 0)
-	pkgs := make(map[string]models.InstalledPackage)
+	var diff []models.InstalledPackage
+	pkgs := make(map[string]models.InstalledPackage, len(b))
 	for _, pkg := range b {
 		pkgs[pkg.Name] = pkg
 	}
@@ -378,7 +378,7 @@ func getPackageDiff(a, b []models.InstalledPackage) []models.InstalledPackage {
 
 func getVersionDiff(new, old []models.InstalledPackage) []models.InstalledPackage {
 	var diff []models.InstalledPackage
-	oldPkgs := make(map[string]models.InstalledPackage)
+	oldPkgs := make(map[string]models.InstalledPackage, len(old))
 	for _, pkg := range old {
 		oldPkgs[pkg.Name] = pkg
 	}

--- a/pkg/services/files/uploader.go
+++ b/pkg/services/files/uploader.go
@@ -190,6 +190,8 @@ func (u *S3Uploader) UploadFileWithACL(fname string, uploadPath string, acl stri
 	if err != nil {
 		return "", fmt.Errorf("failed to open file %q, %v", fname, err)
 	}
+	defer f.Close()
+
 	if acl == "" {
 		acl = "private"
 	}
@@ -201,10 +203,7 @@ func (u *S3Uploader) UploadFileWithACL(fname string, uploadPath string, acl stri
 		u.log.WithField("error", err.Error()).Error("Error uploading to AWS S3")
 		return "", err
 	}
-	if err := f.Close(); err != nil {
-		u.log.WithField("error", err.Error()).Error("Error closing file")
-		return "", err
-	}
+
 	region := config.Get().BucketRegion
 	s3URL := fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", u.Bucket, region, uploadPath)
 	return s3URL, nil


### PR DESCRIPTION
This is a wrap-up of my memory optimalisation research. I was mainly focusing on image building, this was not complete investigation of all parts of the application. Only what is on fire right now - image building.

In the first patch, I comment out pprof profiler, I am done with the process. Keeping the three lines in the codebase in case we need this again.

Second, it looks like the biggest offender during my (quite narrow) testing were package diff functions, while it could be optimized further, I am just preallocating maps to the specific size - this is always a good practice and this will save some copying.

The biggest issue is that kubernetes count cached pages into memory limit of a pod and while the application takes around 200-300 MB of memory when doing an image build, Linux filesystem cache goes up significantly (2-6 GB) which can ultimately lead to OOM kill of a pod. The third patch is an attempt to prevent that by using direct linux I/O kernel flag `O_DIRECT` which causes the read and write operations to bypass Linux kernel cache. I searched for only the relevant `.Open` and `os.Create` statements and added the flag there by changing this to the underlaying `os.FileOpen` call. This affects downloading and uploading of ISO files, tar extracting and S3 uploading, I did not do the change for irrelevant file operations (e.g. kickstart, tests, temporary files).

Most of this code will be removed once we implement the planned Pulp integration.

I noticed one file handler leak, fixed that as well.