### PR TITLE
services: revert DBx/Orgx methods

### DIFF
--- a/pkg/services/commits.go
+++ b/pkg/services/commits.go
@@ -37,7 +37,7 @@ func (s *CommitService) GetCommitByID(commitID uint, orgID string) (*models.Comm
 	s.log = s.log.WithField("commitID", commitID)
 	s.log.Debug("Getting commit by id")
 	var commit models.Commit
-	result := db.Orgx(s.ctx, orgID, "").Joins("Repo").First(&commit, commitID)
+	result := db.Org(orgID, "").Joins("Repo").First(&commit, commitID)
 	if result.Error != nil {
 		s.log.WithField("error", result.Error.Error()).Error("Error searching for commit by commitID")
 		return nil, result.Error
@@ -50,7 +50,7 @@ func (s *CommitService) GetCommitByID(commitID uint, orgID string) (*models.Comm
 func (s *CommitService) GetCommitByOSTreeCommit(ost string) (*models.Commit, error) {
 	s.log = s.log.WithField("ostreeCommitHash", ost)
 	var commit models.Commit
-	result := db.DBx(s.ctx).Where("os_tree_commit = ?", ost).First(&commit)
+	result := db.DB.Where("os_tree_commit = ?", ost).First(&commit)
 	if result.Error != nil {
 		s.log.WithField("error", result.Error.Error()).Error("Error searching for commit by ostreeCommitHash")
 		return nil, result.Error
@@ -73,7 +73,7 @@ func (s *CommitService) ValidateDevicesImageSetWithCommit(devicesUUID []string, 
 		return err
 	}
 
-	if result := db.Orgx(s.ctx, orgID, "devices").Table("devices").
+	if result := db.Org(orgID, "devices").Table("devices").
 		Select(`images.image_set_id as "image_set_id", images.commit_Id , count(devices.uuid) as devices_count`).
 		Joins("JOIN images ON devices.image_id = images.id").
 		Joins("Join commits on commits.ID = images.commit_id").
@@ -98,7 +98,7 @@ func (s *CommitService) ValidateDevicesImageSetWithCommit(devicesUUID []string, 
 		}).Error()
 		return new(SomeDevicesDoesNotExists)
 	}
-	if result := db.Orgx(s.ctx, orgID, "").Where("commit_id = ?", commitID).First(&commitImage); result.Error != nil {
+	if result := db.Org(orgID, "").Where("commit_id = ?", commitID).First(&commitImage); result.Error != nil {
 		if result.Error == gorm.ErrRecordNotFound {
 			return new(CommitImageNotFound)
 		}

--- a/pkg/services/devicegroups.go
+++ b/pkg/services/devicegroups.go
@@ -62,7 +62,7 @@ func (s *DeviceGroupsService) DeviceGroupNameExists(orgID string, name string) (
 		return false, new(DeviceGroupMandatoryFieldsUndefined)
 	}
 	var deviceGroupsCount int64
-	result := db.Orgx(s.ctx, orgID, "").Model(&models.DeviceGroup{}).Where("name = ?", name).Count(&deviceGroupsCount)
+	result := db.Org(orgID, "").Model(&models.DeviceGroup{}).Where("name = ?", name).Count(&deviceGroupsCount)
 	if result.Error != nil {
 		return false, result.Error
 	}
@@ -73,7 +73,7 @@ func (s *DeviceGroupsService) DeviceGroupNameExists(orgID string, name string) (
 func (s *DeviceGroupsService) GetDeviceGroupsCount(orgID string, tx *gorm.DB) (int64, error) {
 
 	if tx == nil {
-		tx = db.DBx(s.ctx)
+		tx = db.DB
 	}
 
 	var count int64
@@ -97,7 +97,7 @@ func (s *DeviceGroupsService) DeleteDeviceGroupByID(ID string) error {
 		return err
 	}
 	// delete the device group
-	result := db.DBx(s.ctx).Delete(&deviceGroup)
+	result := db.DB.Delete(&deviceGroup)
 	if result.Error != nil {
 		sLog.WithField("error", result.Error.Error()).Error("Error deleting device group")
 		return result.Error
@@ -109,7 +109,7 @@ func (s *DeviceGroupsService) DeleteDeviceGroupByID(ID string) error {
 func (s *DeviceGroupsService) GetDeviceGroups(orgID string, limit int, offset int, tx *gorm.DB) (*[]models.DeviceGroupListDetail, error) {
 
 	if tx == nil {
-		tx = db.DBx(s.ctx)
+		tx = db.DB
 	}
 
 	var deviceGroups []models.DeviceGroup
@@ -184,12 +184,12 @@ func (s *DeviceGroupsService) GetDeviceImageInfo(images map[int]models.DeviceIma
 			var deviceImage models.Image
 			var deviceImageSet models.ImageSet
 			var CommitID uint
-			if result := db.Orgx(s.ctx, orgID, "").First(&deviceImage, imageID); result.Error != nil {
+			if result := db.Org(orgID, "").First(&deviceImage, imageID); result.Error != nil {
 				return result.Error
 			}
 
 			// should be changed to get the deviceInfo once we have the data correctly on DB
-			if result := db.Orgx(s.ctx, orgID, "").Preload("Images").
+			if result := db.Org(orgID, "").Preload("Images").
 				First(&deviceImageSet, deviceImage.ImageSetID).Order("ID desc"); result.Error != nil {
 				return result.Error
 			}
@@ -203,20 +203,20 @@ func (s *DeviceGroupsService) GetDeviceImageInfo(images map[int]models.DeviceIma
 				CommitID = deviceImageSet.Images[len(deviceImageSet.Images)-1].CommitID
 
 				// loading commit and packages to calculate diff
-				if err := db.DBx(s.ctx).First(&deviceImage.Commit, deviceImage.CommitID).Error; err != nil {
+				if err := db.DB.First(&deviceImage.Commit, deviceImage.CommitID).Error; err != nil {
 					s.log.WithField("error", err.Error()).Error("Error when getting Commit for CurrentImage")
 					return err
 				}
-				if err := db.DBx(s.ctx).Model(&deviceImage.Commit).Association("InstalledPackages").Find(&deviceImage.Commit.InstalledPackages); err != nil {
+				if err := db.DB.Model(&deviceImage.Commit).Association("InstalledPackages").Find(&deviceImage.Commit.InstalledPackages); err != nil {
 					s.log.WithField("error", err.Error()).Error("Error when getting InstalledPackages for CurrentImage")
 					return err
 				}
 
-				if err := db.DBx(s.ctx).First(&latestImage.Commit, latestImage.CommitID).Error; err != nil {
+				if err := db.DB.First(&latestImage.Commit, latestImage.CommitID).Error; err != nil {
 					s.log.WithField("error", err.Error()).Error("Error when getting Commit for LatestImage")
 					return err
 				}
-				if err := db.DBx(s.ctx).Model(&latestImage.Commit).Association("InstalledPackages").Find(&latestImage.Commit.InstalledPackages); err != nil {
+				if err := db.DB.Model(&latestImage.Commit).Association("InstalledPackages").Find(&latestImage.Commit.InstalledPackages); err != nil {
 					s.log.WithField("error", err.Error()).Error("Error when getting InstalledPackages for LatestImage")
 					return err
 				}
@@ -251,7 +251,7 @@ func (s *DeviceGroupsService) CreateDeviceGroup(deviceGroup *models.DeviceGroup)
 		Type:  string(static),
 		OrgID: deviceGroup.OrgID,
 	}
-	result := db.DBx(s.ctx).Create(&group)
+	result := db.DB.Create(&group)
 	if result.Error != nil {
 		s.log.WithField("error", result.Error.Error()).Error("Error creating device group")
 		return nil, result.Error
@@ -270,7 +270,7 @@ func (s *DeviceGroupsService) GetDeviceGroupByID(ID string) (*models.DeviceGroup
 		return nil, err
 	}
 
-	result := db.Orgx(s.ctx, orgID, "").Where("id = ?", ID).Preload("Devices").First(&deviceGroup)
+	result := db.Org(orgID, "").Where("id = ?", ID).Preload("Devices").First(&deviceGroup)
 	if result.Error != nil {
 		return nil, new(DeviceGroupNotFound)
 	}
@@ -293,7 +293,7 @@ func (s *DeviceGroupsService) GetDeviceGroupDetailsByID(ID string) (*models.Devi
 		return nil, err
 	}
 
-	result := db.Orgx(s.ctx, orgID, "").Where("id = ?", ID).Preload("Devices").First(&deviceGroupDetails.DeviceGroup)
+	result := db.Org(orgID, "").Where("id = ?", ID).Preload("Devices").First(&deviceGroupDetails.DeviceGroup)
 	if result.Error != nil {
 		s.log.WithField("error", result.Error.Error()).Error("Device details query error")
 		return nil, new(DeviceGroupNotFound)
@@ -341,7 +341,7 @@ func (s *DeviceGroupsService) UpdateDeviceGroup(deviceGroup *models.DeviceGroup,
 		}
 	}
 
-	result := db.DBx(s.ctx).Omit("Devices").Save(&groupDetails)
+	result := db.DB.Omit("Devices").Save(&groupDetails)
 	if result.Error != nil {
 		return result.Error
 	}
@@ -362,13 +362,13 @@ func (s *DeviceGroupsService) GetDeviceGroupDeviceByID(orgID string, deviceGroup
 
 	// get the device group
 	var deviceGroup models.DeviceGroup
-	if res := db.Orgx(s.ctx, orgID, "").First(&deviceGroup, deviceGroupID); res.Error != nil {
+	if res := db.Org(orgID, "").First(&deviceGroup, deviceGroupID); res.Error != nil {
 		return nil, res.Error
 	}
 
 	// we need to be sure that all the devices we want to remove already exists and belong to device group
 	var device models.Device
-	if err := db.DBx(s.ctx).Model(&deviceGroup).Association("Devices").Find(&device, deviceID); err != nil {
+	if err := db.DB.Model(&deviceGroup).Association("Devices").Find(&device, deviceID); err != nil {
 		return nil, err
 	}
 
@@ -388,7 +388,7 @@ func (s *DeviceGroupsService) AddDeviceGroupDevices(orgID string, deviceGroupID 
 
 	// get the device group
 	var deviceGroup models.DeviceGroup
-	if res := db.Orgx(s.ctx, orgID, "").First(&deviceGroup, deviceGroupID); res.Error != nil {
+	if res := db.Org(orgID, "").First(&deviceGroup, deviceGroupID); res.Error != nil {
 		return nil, res.Error
 	}
 
@@ -404,7 +404,7 @@ func (s *DeviceGroupsService) AddDeviceGroupDevices(orgID string, deviceGroupID 
 
 	// we need to be sure that all the devices we want to add already exists and have the same ID as the current device group ID
 	var devicesToAdd []models.Device
-	if res := db.Orgx(s.ctx, orgID, "").Find(&devicesToAdd, devicesIDsToAdd); res.Error != nil {
+	if res := db.Org(orgID, "").Find(&devicesToAdd, devicesIDsToAdd); res.Error != nil {
 		return nil, res.Error
 	}
 
@@ -415,7 +415,7 @@ func (s *DeviceGroupsService) AddDeviceGroupDevices(orgID string, deviceGroupID 
 	}
 
 	s.log.WithFields(log.Fields{"deviceCount": len(devicesToAdd), "deviceGroupID": deviceGroup.ID}).Debug("Adding devices to device group")
-	if err := db.DBx(s.ctx).Model(&deviceGroup).Omit("Devices.*").Association("Devices").Append(devicesToAdd); err != nil {
+	if err := db.DB.Model(&deviceGroup).Omit("Devices.*").Association("Devices").Append(devicesToAdd); err != nil {
 		return nil, err
 	}
 
@@ -435,7 +435,7 @@ func (s *DeviceGroupsService) DeleteDeviceGroupDevices(orgID string, deviceGroup
 
 	// get the device group
 	var deviceGroup models.DeviceGroup
-	if res := db.Orgx(s.ctx, orgID, "").First(&deviceGroup, deviceGroupID); res.Error != nil {
+	if res := db.Org(orgID, "").First(&deviceGroup, deviceGroupID); res.Error != nil {
 		return nil, res.Error
 	}
 
@@ -451,7 +451,7 @@ func (s *DeviceGroupsService) DeleteDeviceGroupDevices(orgID string, deviceGroup
 
 	// we need to be sure that all the devices we want to remove already exists and belong to device group
 	var devicesToRemove []models.Device
-	if err := db.DBx(s.ctx).Model(&deviceGroup).Association("Devices").Find(&devicesToRemove, devicesIDsToRemove); err != nil {
+	if err := db.DB.Model(&deviceGroup).Association("Devices").Find(&devicesToRemove, devicesIDsToRemove); err != nil {
 		return nil, err
 	}
 
@@ -462,7 +462,7 @@ func (s *DeviceGroupsService) DeleteDeviceGroupDevices(orgID string, deviceGroup
 	}
 
 	s.log.WithFields(log.Fields{"deviceCount": len(devicesToRemove), "deviceGroupID": deviceGroup.ID}).Debug("Removing devices from device group")
-	if err := db.DBx(s.ctx).Model(&deviceGroup).Association("Devices").Delete(devicesToRemove); err != nil {
+	if err := db.DB.Model(&deviceGroup).Association("Devices").Delete(devicesToRemove); err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -159,7 +159,7 @@ func (s *ImageService) getExistingImageCustomRepositoriesByURLS(orgID string, ur
 	// Get the local existing custom repos that correspond to content-sources urls
 	var repos []models.ThirdPartyRepo
 
-	if err := db.Orgx(s.ctx, orgID, "").Where("url", urls).Order("id asc").Find(&repos).Error; err != nil {
+	if err := db.Org(orgID, "").Where("url", urls).Order("id asc").Find(&repos).Error; err != nil {
 		s.log.WithFields(log.Fields{"repos_urls": urls, "error": err.Error()}).Error("error occurred while retrieving from local db")
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func (s *ImageService) SetImageContentSourcesRepositories(image *models.Image) e
 				existingEMRepo.DistributionArch = csRepo.DistributionArch
 				existingEMRepo.PackageCount = csRepo.PackageCount
 
-				if err := db.DBx(s.ctx).Save(existingEMRepo).Error; err != nil {
+				if err := db.DB.Save(existingEMRepo).Error; err != nil {
 					s.log.WithFields(log.Fields{"repo_url": url, "repo_id": existingEMRepo.ID, "error": err.Error()}).Error("error occurred while updating custom repository")
 					return err
 				}
@@ -245,7 +245,7 @@ func (s *ImageService) SetImageContentSourcesRepositories(image *models.Image) e
 				GpgKey:              csRepo.GpgKey,
 				PackageCount:        csRepo.PackageCount,
 			}
-			if err := db.DBx(s.ctx).Create(&emRepo).Error; err != nil {
+			if err := db.DB.Create(&emRepo).Error; err != nil {
 				s.log.WithFields(log.Fields{"repository_url": csRepo.URL, "error": err.Error()}).Error("error occurred while creating custom repository")
 				return err
 			}
@@ -262,11 +262,11 @@ func (s *ImageService) getImageSetForNewImage(orgID string, image *models.Image)
 	// if it exists and is not linked to any images reuse it,
 	// if it exists and linked to any images return error
 	var imageSet models.ImageSet
-	if result := db.Orgx(s.ctx, orgID, "").Preload("Images").Where("(name = ?)", image.Name).First(&imageSet); result.Error != nil {
+	if result := db.Org(orgID, "").Preload("Images").Where("(name = ?)", image.Name).First(&imageSet); result.Error != nil {
 		if result.Error == gorm.ErrRecordNotFound {
 			// Create a new imageSet
 			imageSet = models.ImageSet{OrgID: orgID, Name: image.Name, Version: image.Version}
-			if result := db.DBx(s.ctx).Create(&imageSet); result.Error != nil {
+			if result := db.DB.Create(&imageSet); result.Error != nil {
 				s.log.WithFields(log.Fields{
 					"imageSetName": image.Name,
 					"error":        result.Error.Error(),
@@ -372,7 +372,7 @@ func (s *ImageService) CreateImage(image *models.Image) error {
 		image.Installer.OrgID = image.OrgID
 	}
 
-	if result := db.DBx(s.ctx).Create(&image); result.Error != nil {
+	if result := db.DB.Create(&image); result.Error != nil {
 		return result.Error
 	}
 
@@ -445,7 +445,7 @@ func (s *ImageService) ValidateImagePackage(packageName string, image *models.Im
 // if no image found return nil
 func (s *ImageService) getLatestPreviousSuccessfulImage(image *models.Image) (*models.Image, error) {
 	var previousSuccessfulImage models.Image
-	if result := db.Orgx(s.ctx, image.OrgID, "images").
+	if result := db.Org(image.OrgID, "images").
 		Where(models.Image{ImageSetID: image.ImageSetID, Status: models.ImageStatusSuccess}).
 		Preload("Commit.Repo").Joins("Commit").
 		Where("images.created_at < ?", image.CreatedAt).
@@ -507,13 +507,13 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 	}
 
 	var currentImageSet models.ImageSet
-	result := db.DBx(s.ctx).Where("Id = ?", previousImage.ImageSetID).First(&currentImageSet)
+	result := db.DB.Where("Id = ?", previousImage.ImageSetID).First(&currentImageSet)
 	if result.Error != nil {
 		s.log.WithField("error", result.Error.Error()).Error("Error retrieving the image set from parent image")
 		return result.Error
 	}
 	currentImageSet.Version = previousImage.Version + 1
-	if err := db.DBx(s.ctx).Save(currentImageSet).Error; err != nil {
+	if err := db.DB.Save(currentImageSet).Error; err != nil {
 		return err
 	}
 
@@ -589,7 +589,7 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 		image.Installer.OrgID = image.OrgID
 	}
 
-	if result := db.DBx(s.ctx).Create(&image); result.Error != nil {
+	if result := db.DB.Create(&image); result.Error != nil {
 		s.log.WithField("error", result.Error.Error()).Error("Error creating image")
 		return result.Error
 	}
@@ -608,7 +608,7 @@ func (s *ImageService) processInstaller(ctx context.Context, image *models.Image
 	imageID := image.ID
 	for {
 		// reload the image from database, for a long-running process
-		if err := db.DBx(s.ctx).Joins("Commit").Joins("Installer").First(&image, imageID).Error; err != nil {
+		if err := db.DB.Joins("Commit").Joins("Installer").First(&image, imageID).Error; err != nil {
 			s.log.WithField("error", err.Error()).Error("error occurred when reloading image from database")
 			if goErrors.Is(err, gorm.ErrRecordNotFound) {
 				return new(ImageNotFoundError)
@@ -652,7 +652,7 @@ func (s *ImageService) processCommit(ctx context.Context, image *models.Image, l
 	imageID := image.ID
 	for {
 		// reload the image from database, for a long-running process
-		if err := db.DBx(s.ctx).Joins("Commit").Joins("Installer").First(&image, imageID).Error; err != nil {
+		if err := db.DB.Joins("Commit").Joins("Installer").First(&image, imageID).Error; err != nil {
 			log.WithContext(ctx).WithField("error", err.Error()).Error("error occurred when reloading image from database")
 			if goErrors.Is(err, gorm.ErrRecordNotFound) {
 				return nil, new(ImageNotFoundError)
@@ -711,7 +711,7 @@ func (s *ImageService) SetFinalImageStatus(i *models.Image) {
 			if i.Commit.Status == models.ImageStatusBuilding {
 				success = false
 				i.Commit.Status = models.ImageStatusError
-				db.DBx(s.ctx).Save(i.Commit)
+				db.DB.Save(i.Commit)
 			}
 		}
 		if out == models.ImageTypeInstaller {
@@ -721,7 +721,7 @@ func (s *ImageService) SetFinalImageStatus(i *models.Image) {
 			if i.Installer.Status == models.ImageStatusBuilding {
 				success = false
 				i.Installer.Status = models.ImageStatusError
-				db.DBx(s.ctx).Save(i.Installer)
+				db.DB.Save(i.Installer)
 			}
 		}
 	}
@@ -732,7 +732,7 @@ func (s *ImageService) SetFinalImageStatus(i *models.Image) {
 		i.Status = models.ImageStatusError
 	}
 
-	tx := db.DBx(s.ctx).Save(i)
+	tx := db.DB.Save(i)
 	if tx.Error != nil {
 		s.log.WithField("error", tx.Error.Error()).Error("Couldn't set final image status")
 	}
@@ -771,7 +771,7 @@ func (s *ImageService) processImage(ctx context.Context, id uint, loopDelay time
 				// we caught an interrupt. Mark the image as interrupted.
 				log.WithContext(ctx).WithField("imageID", id).Debug("Select case SIGINT interrupt has been triggered")
 
-				tx := db.DBx(s.ctx).Model(&models.Image{}).Where("ID = ?", id).Update("Status", models.ImageStatusInterrupted)
+				tx := db.DB.Model(&models.Image{}).Where("ID = ?", id).Update("Status", models.ImageStatusInterrupted)
 				log.WithContext(ctx).WithField("imageID", id).Debug("Image updated with interrupted status")
 				if tx.Error != nil {
 					log.WithContext(ctx).WithField("error", tx.Error.Error()).Error("Error updating image")
@@ -787,7 +787,7 @@ func (s *ImageService) processImage(ctx context.Context, id uint, loopDelay time
 		}()
 	}
 	// business as usual from here to end of block
-	if err := db.DBx(ctx).Joins("Commit").Joins("Installer").First(&image, id).Error; err != nil {
+	if err := db.DB.Joins("Commit").Joins("Installer").First(&image, id).Error; err != nil {
 		log.WithContext(ctx).WithFields(log.Fields{"error": err.Error(), "ImageID": id}).Error("error occurred loading the image from database")
 		return err
 	}
@@ -842,7 +842,7 @@ func (s *ImageService) CreateRepoForImage(ctx context.Context, img *models.Image
 	repo := &models.Repo{
 		Status: models.RepoStatusBuilding,
 	}
-	tx := db.DBx(s.ctx).Create(repo)
+	tx := db.DB.Create(repo)
 	if tx.Error != nil {
 		return nil, tx.Error
 	}
@@ -852,7 +852,7 @@ func (s *ImageService) CreateRepoForImage(ctx context.Context, img *models.Image
 	img.Commit.Repo = repo
 	img.Commit.RepoID = &repo.ID
 
-	tx = db.DBx(s.ctx).Save(img.Commit)
+	tx = db.DB.Save(img.Commit)
 	if tx.Error != nil {
 		return nil, tx.Error
 	}
@@ -1031,7 +1031,7 @@ func (s *ImageService) uploadISO(image *models.Image, imageName string) error {
 	}
 
 	image.Installer.ImageBuildISOURL = url
-	tx := db.DBx(s.ctx).Save(&image.Installer)
+	tx := db.DB.Save(&image.Installer)
 	if tx.Error != nil {
 		return tx.Error
 	}
@@ -1075,7 +1075,7 @@ func (s *ImageService) UpdateImageStatus(image *models.Image) (*models.Image, er
 			// check that if error contain timeout and job stop responding and image's time creation is less than 3 hours
 			if strings.Contains(err.Error(), "running this job stopped responding") {
 				image.Status = models.ImageStatusInterrupted
-				tx := db.DBx(s.ctx).Model(&models.Image{}).Where("ID = ?", image.ID).Update("Status", models.ImageStatusInterrupted)
+				tx := db.DB.Model(&models.Image{}).Where("ID = ?", image.ID).Update("Status", models.ImageStatusInterrupted)
 				if tx.Error != nil {
 					return image, err
 				}
@@ -1084,7 +1084,7 @@ func (s *ImageService) UpdateImageStatus(image *models.Image) (*models.Image, er
 			return image, err
 		}
 		if image.Commit.Status != models.ImageStatusBuilding {
-			tx := db.DBx(s.ctx).Save(&image.Commit)
+			tx := db.DB.Save(&image.Commit)
 			if tx.Error != nil {
 				return image, tx.Error
 			}
@@ -1096,14 +1096,14 @@ func (s *ImageService) UpdateImageStatus(image *models.Image) (*models.Image, er
 			return image, err
 		}
 		if image.Installer.Status != models.ImageStatusBuilding {
-			tx := db.DBx(s.ctx).Save(&image.Installer)
+			tx := db.DB.Save(&image.Installer)
 			if tx.Error != nil {
 				return image, tx.Error
 			}
 		}
 	}
 	if image.Status != models.ImageStatusBuilding {
-		tx := db.DBx(s.ctx).Save(&image)
+		tx := db.DB.Save(&image)
 		if tx.Error != nil {
 			return image, tx.Error
 		}
@@ -1115,7 +1115,7 @@ func (s *ImageService) UpdateImageStatus(image *models.Image) (*models.Image, er
 func (s *ImageService) CheckImageName(name, orgID string) (bool, error) {
 	var imageFindByName *models.Image
 	// Search for an organization with an image with specific name
-	result := db.Orgx(s.ctx, orgID, "").Where("(name = ?)", name).First(&imageFindByName)
+	result := db.Org(orgID, "").Where("(name = ?)", name).First(&imageFindByName)
 	// If we get an error from the query
 	if result.Error != nil {
 		// If no records were found
@@ -1174,7 +1174,7 @@ func (s *ImageService) calculateChecksum(isoPath string, image *models.Image) er
 
 	image.Installer.Checksum = hex.EncodeToString(sumCalculator.Sum(nil))
 	s.log.WithField("checksum", image.Installer.Checksum).Info("Checksum calculated")
-	tx := db.DBx(s.ctx).Save(&image.Installer)
+	tx := db.DB.Save(&image.Installer)
 	if tx.Error != nil {
 		s.log.WithField("error", tx.Error.Error()).Error("Error saving installer")
 		return tx.Error
@@ -1220,13 +1220,13 @@ func (s *ImageService) AddPackageInfo(image *models.Image) (ImageDetail, error) 
 
 func (s *ImageService) addImageExtraData(image *models.Image) (*models.Image, error) {
 	if image.InstallerID != nil {
-		result := db.DBx(s.ctx).First(&image.Installer, image.InstallerID)
+		result := db.DB.First(&image.Installer, image.InstallerID)
 		if result.Error != nil {
 			s.log.WithField("error", result.Error).Error("Error retrieving installer for image")
 			return nil, result.Error
 		}
 	}
-	err := db.DBx(s.ctx).Model(image).Association("Packages").Find(&image.Packages)
+	err := db.DB.Model(image).Association("Packages").Find(&image.Packages)
 	if err != nil {
 		s.log.WithField("error", err).Error("Error packages from image")
 		return nil, err
@@ -1248,7 +1248,7 @@ func (s *ImageService) GetImageByIDExtended(imageID uint, gormDB *gorm.DB) (*mod
 	if gormDB == nil {
 		gormDB = db.DB
 	}
-	dbQuery := db.OrgDBx(s.ctx, orgID, gormDB, "images")
+	dbQuery := db.OrgDB(orgID, gormDB, "images")
 
 	if err := dbQuery.First(&image, imageID).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -1273,7 +1273,7 @@ func (s *ImageService) GetImageByID(imageID string) (*models.Image, error) {
 		s.log.WithField("error", err).Debug("Request related error - ID is not integer")
 		return nil, new(IDMustBeInteger)
 	}
-	result := db.Orgx(s.ctx, orgID, "images").Preload("Commit.Repo").Preload("Commit.InstalledPackages").Preload("CustomPackages").Preload("ThirdPartyRepositories").Joins("Commit").First(&image, id)
+	result := db.Org(orgID, "images").Preload("Commit.Repo").Preload("Commit.InstalledPackages").Preload("CustomPackages").Preload("ThirdPartyRepositories").Joins("Commit").First(&image, id)
 	if result.Error != nil {
 		s.log.WithField("error", result.Error.Error()).Debug("Request related error - image is not found")
 		return nil, new(ImageNotFoundError)
@@ -1290,7 +1290,7 @@ func (s *ImageService) GetImageByOSTreeCommitHash(commitHash string) (*models.Im
 		s.log.WithField("error", err.Error()).Error("Error retrieving org_id")
 		return nil, new(OrgIDNotSet)
 	}
-	result := db.Orgx(s.ctx, orgID, "images").Joins("JOIN commits ON commits.id = images.commit_id AND commits.os_tree_commit = ?", commitHash).Joins("Installer").Preload("Packages").Preload("Commit.InstalledPackages").Preload("Commit.Repo").First(&image)
+	result := db.Org(orgID, "images").Joins("JOIN commits ON commits.id = images.commit_id AND commits.os_tree_commit = ?", commitHash).Joins("Installer").Preload("Packages").Preload("Commit.InstalledPackages").Preload("Commit.Repo").First(&image)
 	if result.Error != nil {
 		s.log.WithField("error", result.Error).Error("Error retrieving image by OSTreeHash")
 		return nil, new(ImageNotFoundError)
@@ -1356,7 +1356,7 @@ func (s *ImageService) RetryCreateImage(ctx context.Context, image *models.Image
 
 func (s *ImageService) setImageStatus(image *models.Image, status string) error {
 	image.Status = status
-	tx := db.DBx(s.ctx).Save(image)
+	tx := db.DB.Save(image)
 	if tx.Error != nil {
 		s.log.WithFields(log.Fields{"imageID": image.ID, "status": status, "error": tx.Error.Error()}).Error("Failed to update image status")
 		return tx.Error
@@ -1368,7 +1368,7 @@ func (s *ImageService) setImageStatus(image *models.Image, status string) error 
 
 func (s *ImageService) setCommitStatus(image *models.Image, status string) error {
 	image.Commit.Status = status
-	tx := db.DBx(s.ctx).Save(image.Commit)
+	tx := db.DB.Save(image.Commit)
 	if tx.Error != nil {
 		s.log.WithFields(log.Fields{"imageID": image.ID, "commitID": image.Commit.ID, "status": status, "error": tx.Error.Error()}).Error("Failed to update commit status")
 		return tx.Error
@@ -1380,7 +1380,7 @@ func (s *ImageService) setCommitStatus(image *models.Image, status string) error
 
 func (s *ImageService) setInstallerStatus(image *models.Image, status string) error {
 	image.Installer.Status = status
-	tx := db.DBx(s.ctx).Save(image.Installer)
+	tx := db.DB.Save(image.Installer)
 	if tx.Error != nil {
 		s.log.WithFields(log.Fields{"imageID": image.ID, "installerID": image.Installer.ID, "status": status, "error": tx.Error.Error()}).Error("Failed to update installer status")
 		return tx.Error
@@ -1435,7 +1435,7 @@ func (s *ImageService) resumeProcessImage(ctx context.Context, image *models.Ima
 			// we caught an interrupt. Mark the image as interrupted.
 			s.log.WithField("imageID", id).Debug("Select case SIGINT interrupt has been triggered")
 
-			tx := db.DBx(s.ctx).Model(&models.Image{}).Where("ID = ?", id).Update("Status", models.ImageStatusInterrupted)
+			tx := db.DB.Model(&models.Image{}).Where("ID = ?", id).Update("Status", models.ImageStatusInterrupted)
 			s.log.WithField("imageID", id).Debug("Image updated with interrupted status")
 			if tx.Error != nil {
 				s.log.WithField("error", tx.Error.Error()).Error("Error updating image")
@@ -1583,7 +1583,7 @@ func (s *ImageService) CheckIfIsLatestVersion(previousImage *models.Image) error
 	}
 
 	var latestImageVersion models.Image
-	if result := db.Orgx(s.ctx, previousImage.OrgID, "").Where(models.Image{ImageSetID: previousImage.ImageSetID}).Order("version DESC").First(&latestImageVersion); result.Error != nil {
+	if result := db.Org(previousImage.OrgID, "").Where(models.Image{ImageSetID: previousImage.ImageSetID}).Order("version DESC").First(&latestImageVersion); result.Error != nil {
 		return result.Error
 	}
 
@@ -1601,7 +1601,7 @@ func (s *ImageService) GetUpdateInfo(image models.Image) (*models.ImageUpdateAva
 		return nil, nil
 	}
 	var updateFromImage models.Image
-	if result := db.DBx(s.ctx).Where("Image_set_id = ? and Images.Status = ? and Images.Id < ?",
+	if result := db.DB.Where("Image_set_id = ? and Images.Status = ? and Images.Id < ?",
 		image.ImageSetID, models.ImageStatusSuccess, image.ID).Joins("Commit").
 		Order("Images.created_at DESC").First(&updateFromImage); result.Error != nil {
 		if result.Error == gorm.ErrRecordNotFound {
@@ -1612,23 +1612,23 @@ func (s *ImageService) GetUpdateInfo(image models.Image) (*models.ImageUpdateAva
 		return nil, result.Error
 	}
 
-	if result := db.DBx(s.ctx).First(&updateFromImage.Commit, updateFromImage.CommitID); result.Error != nil {
+	if result := db.DB.First(&updateFromImage.Commit, updateFromImage.CommitID); result.Error != nil {
 		s.log.WithField("error", result.Error.Error()).Error("Error when retrieving updateFromImage commit")
 		if result.Error == gorm.ErrRecordNotFound {
 			return nil, new(ImageCommitNotFound)
 		}
 		return nil, result.Error
 	}
-	if err := db.DBx(s.ctx).Model(&updateFromImage.Commit).Association("InstalledPackages").Find(&updateFromImage.Commit.InstalledPackages); err != nil {
+	if err := db.DB.Model(&updateFromImage.Commit).Association("InstalledPackages").Find(&updateFromImage.Commit.InstalledPackages); err != nil {
 		s.log.WithField("error", err.Error()).Error("Error retrieving installed packages")
 		return nil, err
 	}
-	if err := db.DBx(s.ctx).Model(&updateFromImage).Association("Packages").Find(&updateFromImage.Packages); err != nil {
+	if err := db.DB.Model(&updateFromImage).Association("Packages").Find(&updateFromImage.Packages); err != nil {
 		s.log.WithField("error", err.Error()).Error("Error retrieving updated packages")
 		return nil, err
 	}
 
-	if err := db.DBx(s.ctx).Model(&updateFromImage).Association("CustomPackages").Find(&updateFromImage.CustomPackages); err != nil {
+	if err := db.DB.Model(&updateFromImage).Association("CustomPackages").Find(&updateFromImage.CustomPackages); err != nil {
 		s.log.WithField("error", err.Error()).Error("Error retrieving updated CustomPackages")
 		return nil, err
 	}
@@ -1668,12 +1668,12 @@ func (s *ImageService) CreateInstallerForImage(ctx context.Context, image *model
 
 	image.ImageType = models.ImageTypeInstaller
 	image.Installer.Status = models.ImageStatusBuilding
-	tx := db.DBx(s.ctx).Save(&image)
+	tx := db.DB.Save(&image)
 	if tx.Error != nil {
 		log.WithContext(ctx).WithField("error", tx.Error.Error()).Error("Error saving image")
 		return nil, c, tx.Error
 	}
-	tx = db.DBx(s.ctx).Save(&image.Installer)
+	tx = db.DB.Save(&image.Installer)
 	if tx.Error != nil {
 		log.WithContext(ctx).WithField("error", tx.Error.Error()).Error("Error saving installer")
 		return nil, c, tx.Error
@@ -1698,7 +1698,7 @@ func (s *ImageService) GetRollbackImage(image *models.Image) (*models.Image, err
 		s.log.WithField("error", err.Error()).Error("Error retrieving org_id")
 		return nil, new(OrgIDNotSet)
 	}
-	result := db.Orgx(s.ctx, orgID, "images").Joins("Commit").Joins("Installer").Preload("Packages").Preload("CustomPackages").Preload("ThirdPartyRepositories").Preload("Commit.InstalledPackages").Preload("Commit.Repo").Where(&models.Image{ImageSetID: image.ImageSetID, Status: models.ImageStatusSuccess}).Last(&rollback, "images.id < ?", image.ID)
+	result := db.Org(orgID, "images").Joins("Commit").Joins("Installer").Preload("Packages").Preload("CustomPackages").Preload("ThirdPartyRepositories").Preload("Commit.InstalledPackages").Preload("Commit.Repo").Where(&models.Image{ImageSetID: image.ImageSetID, Status: models.ImageStatusSuccess}).Last(&rollback, "images.id < ?", image.ID)
 	if result.Error != nil {
 		s.log.WithField("error", result.Error).Error("Error retrieving rollback image")
 		return nil, new(ImageNotFoundError)
@@ -1795,12 +1795,12 @@ func (s *ImageService) SetDevicesUpdateAvailabilityFromImageSet(orgID string, Im
 
 	// get the last image with success status
 	var lastImage models.Image
-	if result := db.Orgx(s.ctx, orgID, "").Where("(image_set_id = ? AND status = ?)", ImageSetID, models.ImageStatusSuccess).Order("created_at DESC").First(&lastImage); result.Error != nil {
+	if result := db.Org(orgID, "").Where("(image_set_id = ? AND status = ?)", ImageSetID, models.ImageStatusSuccess).Order("created_at DESC").First(&lastImage); result.Error != nil {
 		return result.Error
 	}
 
 	// update all devices with last image that has update_available=true to update_available=false
-	if result := db.Orgx(s.ctx, orgID, "").Model(&models.Device{}).
+	if result := db.Org(orgID, "").Model(&models.Device{}).
 		Where("(update_available = ? AND image_id = ?)", true, lastImage.ID).
 		UpdateColumn("update_available", false); result.Error != nil {
 		logger.WithField("error", result.Error).Error("Error occurred while updating device update_available")
@@ -1808,11 +1808,11 @@ func (s *ImageService) SetDevicesUpdateAvailabilityFromImageSet(orgID string, Im
 	}
 
 	// Create priorImagesSubQuery query for all successfully created images prior to lastImage
-	priorImagesSubQuery := db.Orgx(s.ctx, orgID, "").Model(&models.Image{}).Select("id").Where("image_set_id = ? AND status = ? AND created_at < ?",
+	priorImagesSubQuery := db.Org(orgID, "").Model(&models.Image{}).Select("id").Where("image_set_id = ? AND status = ? AND created_at < ?",
 		ImageSetID, models.ImageStatusSuccess, lastImage.CreatedAt)
 
 	// Update all devices with prior images that has update_available=false to update_available=true
-	if result := db.Orgx(s.ctx, orgID, "").Model(&models.Device{}).
+	if result := db.Org(orgID, "").Model(&models.Device{}).
 		Where("(update_available = ? AND image_id IN (?))", false, priorImagesSubQuery).
 		UpdateColumn("update_available", true); result.Error != nil {
 		logger.WithField("error", result.Error).Error("Error occurred when updating org_id devices update_available")
@@ -1830,11 +1830,11 @@ func (s *ImageService) GetImagesViewCount(tx *gorm.DB) (int64, error) {
 	}
 
 	if tx == nil {
-		tx = db.DBx(s.ctx)
+		tx = db.DB
 	}
 
 	var count int64
-	result := db.OrgDBx(s.ctx, orgID, tx, "").Model(&models.Image{}).Count(&count)
+	result := db.OrgDB(orgID, tx, "").Model(&models.Image{}).Count(&count)
 
 	if result.Error != nil {
 		s.log.WithFields(log.Fields{"error": result.Error.Error(), "OrgID": orgID}).Error("Error getting images count")
@@ -1853,7 +1853,7 @@ func (s *ImageService) GetImageDevicesCount(imageId uint) (int64, error) {
 	}
 
 	var count int64
-	res := db.Orgx(s.ctx, orgID, "").Model(&models.Device{}).Where("image_id =? ", imageId).Count(&count)
+	res := db.Org(orgID, "").Model(&models.Device{}).Where("image_id =? ", imageId).Count(&count)
 	if res.Error != nil {
 		s.log.WithField("error", res.Error.Error()).Error("Error getting device count")
 		return 0, res.Error
@@ -1869,12 +1869,12 @@ func (s *ImageService) GetImagesView(limit int, offset int, tx *gorm.DB) (*[]mod
 	}
 
 	if tx == nil {
-		tx = db.DBx(s.ctx)
+		tx = db.DB
 	}
 
 	var images []models.Image
 
-	if result := db.OrgDBx(s.ctx, orgID, tx, "").Limit(limit).Offset(offset).
+	if result := db.OrgDB(orgID, tx, "").Limit(limit).Offset(offset).
 		Preload("Installer").
 		Preload("Commit").
 		Find(&images); result.Error != nil {
@@ -1919,7 +1919,7 @@ func (s *ImageService) DeleteImage(i *models.Image) error {
 
 	// if this is the only image in an image set, delete the set also
 	var imageSet models.ImageSet
-	result := db.Orgx(s.ctx, i.OrgID, "").Preload("Images").Where("(name = ?)", i.Name).First(&imageSet)
+	result := db.Org(i.OrgID, "").Preload("Images").Where("(name = ?)", i.Name).First(&imageSet)
 	if result.Error != nil {
 		s.log.WithFields(
 			log.Fields{"Image_id": i.ID, "error": result.Error},
@@ -1927,7 +1927,7 @@ func (s *ImageService) DeleteImage(i *models.Image) error {
 		return result.Error
 	}
 
-	if result := db.DBx(s.ctx).Delete(&i); result.Error != nil {
+	if result := db.DB.Delete(&i); result.Error != nil {
 		s.log.WithFields(
 			log.Fields{"Image_id": i.ID, "error": result.Error},
 		).Error("Error when deleting image")
@@ -1935,7 +1935,7 @@ func (s *ImageService) DeleteImage(i *models.Image) error {
 	}
 
 	if len(imageSet.Images) <= 1 {
-		if result := db.DBx(s.ctx).Delete(&imageSet); result.Error != nil {
+		if result := db.DB.Delete(&imageSet); result.Error != nil {
 			s.log.WithFields(
 				log.Fields{"Image_id": i.ID, "error": result.Error},
 			).Error("Error when deleting image set")

--- a/pkg/services/repobuilder.go
+++ b/pkg/services/repobuilder.go
@@ -58,7 +58,7 @@ func NewRepoBuilder(ctx context.Context, log log.FieldLogger) RepoBuilderInterfa
 // with static deltas generated between them all
 func (rb *RepoBuilder) BuildUpdateRepo(id uint) (*models.UpdateTransaction, error) {
 	var update *models.UpdateTransaction
-	if err := db.DBx(rb.ctx).Preload("DispatchRecords").
+	if err := db.DB.Preload("DispatchRecords").
 		Preload("Devices").
 		Joins("Commit").
 		Joins("Repo").
@@ -308,10 +308,10 @@ func (rb *RepoBuilder) BuildUpdateRepo(id uint) (*models.UpdateTransaction, erro
 
 	rb.log.WithField("repo", update.Repo.URL).Info("Update repo URL")
 	update.Repo.Status = models.RepoStatusSuccess
-	if err := db.DBx(rb.ctx).Omit("Devices.*").Save(&update).Error; err != nil {
+	if err := db.DB.Omit("Devices.*").Save(&update).Error; err != nil {
 		return nil, err
 	}
-	if err := db.DBx(rb.ctx).Omit("Devices.*").Save(&update.Repo).Error; err != nil {
+	if err := db.DB.Omit("Devices.*").Save(&update.Repo).Error; err != nil {
 		return nil, err
 	}
 
@@ -322,7 +322,7 @@ func (rb *RepoBuilder) BuildUpdateRepo(id uint) (*models.UpdateTransaction, erro
 func (rb *RepoBuilder) ImportRepo(r *models.Repo) (*models.Repo, error) {
 
 	var cmt models.Commit
-	cmtDB := db.DBx(rb.ctx).Where("repo_id = ?", r.ID).First(&cmt)
+	cmtDB := db.DB.Where("repo_id = ?", r.ID).First(&cmt)
 	if cmtDB.Error != nil {
 		return nil, cmtDB.Error
 	}
@@ -343,7 +343,7 @@ func (rb *RepoBuilder) ImportRepo(r *models.Repo) (*models.Repo, error) {
 	if err != nil {
 		rb.log.WithField("error", err.Error()).Error("Error downloading repo...")
 		r.Status = models.RepoStatusError
-		result := db.DBx(rb.ctx).Save(&r)
+		result := db.DB.Save(&r)
 		if result.Error != nil {
 			rb.log.WithField("error", result.Error.Error()).Error("Error saving repo...")
 		}
@@ -353,7 +353,7 @@ func (rb *RepoBuilder) ImportRepo(r *models.Repo) (*models.Repo, error) {
 	if errUpload != nil {
 		rb.log.WithField("error", errUpload.Error()).Error("Error uploading repo...")
 		r.Status = models.RepoStatusError
-		result := db.DBx(rb.ctx).Save(&r)
+		result := db.DB.Save(&r)
 		if result.Error != nil {
 			rb.log.WithField("error", result.Error.Error()).Error("Error saving repo...")
 		}
@@ -363,7 +363,7 @@ func (rb *RepoBuilder) ImportRepo(r *models.Repo) (*models.Repo, error) {
 	if err != nil {
 		rb.log.WithField("error", err.Error()).Error("Error extracting repo")
 		r.Status = models.RepoStatusError
-		result := db.DBx(rb.ctx).Save(&r)
+		result := db.DB.Save(&r)
 		if result.Error != nil {
 			rb.log.WithField("error", result.Error.Error()).Error("Error saving repo")
 		}
@@ -378,7 +378,7 @@ func (rb *RepoBuilder) ImportRepo(r *models.Repo) (*models.Repo, error) {
 
 	r.URL = repoURL
 	r.Status = models.RepoStatusSuccess
-	result := db.DBx(rb.ctx).Save(&r)
+	result := db.DB.Save(&r)
 	if result.Error != nil {
 		rb.log.WithField("error", result.Error.Error()).Error("Error saving repo")
 		return nil, fmt.Errorf("error saving status :: %s", result.Error.Error())
@@ -468,7 +468,7 @@ func (rb *RepoBuilder) UploadVersionRepo(c *models.Commit, tarFileName string) e
 	}
 	c.ImageBuildTarURL = repoTarURL
 	c.ExternalURL = false
-	result := db.DBx(rb.ctx).Save(c)
+	result := db.DB.Save(c)
 	if result.Error != nil {
 		rb.log.WithField("error", result.Error.Error()).Error("Error saving tar file")
 		return result.Error

--- a/pkg/services/thirdpartyrepo.go
+++ b/pkg/services/thirdpartyrepo.go
@@ -58,7 +58,7 @@ func (s *ThirdPartyRepoService) ThirdPartyRepoURLExists(orgID string, url string
 	}
 
 	var reposCount int64
-	if err := db.Orgx(s.ctx, orgID, "").Model(&models.ThirdPartyRepo{}).
+	if err := db.Org(orgID, "").Model(&models.ThirdPartyRepo{}).
 		Where("(url = ? OR url = ?)", url, cleanedURL).
 		Count(&reposCount).Error; err != nil {
 		s.log.WithField("error", err.Error()).Error("Error checking custom repository existence")
@@ -77,7 +77,7 @@ func (s *ThirdPartyRepoService) ThirdPartyRepoNameExists(orgID string, name stri
 	}
 
 	var reposCount int64
-	if result := db.Orgx(s.ctx, orgID, "").Model(&models.ThirdPartyRepo{}).Where("name = ?", name).Count(&reposCount); result.Error != nil {
+	if result := db.Org(orgID, "").Model(&models.ThirdPartyRepo{}).Where("name = ?", name).Count(&reposCount); result.Error != nil {
 		s.log.WithField("error", result.Error.Error()).Error("Error checking custom repository existence")
 		return false, result.Error
 	}
@@ -92,7 +92,7 @@ func (s *ThirdPartyRepoService) thirdPartyRepoImagesExists(id string, imageStatu
 		return false, err
 	}
 	var imagesCount int64
-	tx := db.DBx(s.ctx).Model(&models.Image{}).
+	tx := db.DB.Model(&models.Image{}).
 		Joins("JOIN images_repos ON images_repos.image_id = images.id").
 		Where("images_repos.third_party_repo_id = ?", repo.ID)
 	if len(imageStatuses) > 0 {
@@ -140,7 +140,7 @@ func (s *ThirdPartyRepoService) CreateThirdPartyRepo(thirdPartyRepo *models.Thir
 		Description: thirdPartyRepo.Description,
 		OrgID:       orgID,
 	}
-	if result := db.DBx(s.ctx).Create(&createdThirdPartyRepo); result.Error != nil {
+	if result := db.DB.Create(&createdThirdPartyRepo); result.Error != nil {
 		s.log.WithField("error", result.Error.Error()).Error("Error creating custom repository")
 		return nil, result.Error
 	}
@@ -156,7 +156,7 @@ func (s *ThirdPartyRepoService) GetThirdPartyRepoByID(ID string) (*models.ThirdP
 		s.log.WithField("error", err.Error()).Error("Error getting orgID from context")
 		return nil, err
 	}
-	if result := db.Orgx(s.ctx, orgID, "").Where("id = ?", ID).First(&tprepo); result.Error != nil {
+	if result := db.Org(orgID, "").Where("id = ?", ID).First(&tprepo); result.Error != nil {
 		if result.Error == gorm.ErrRecordNotFound {
 			return nil, new(ThirdPartyRepositoryNotFound)
 		}
@@ -214,7 +214,7 @@ func (s *ThirdPartyRepoService) UpdateThirdPartyRepo(tprepo *models.ThirdPartyRe
 	if tprepo.Description != "" {
 		repoDetails.Description = tprepo.Description
 	}
-	result := db.DBx(s.ctx).Save(repoDetails)
+	result := db.DB.Save(repoDetails)
 	if result.Error != nil {
 		return result.Error
 	}
@@ -242,7 +242,7 @@ func (s *ThirdPartyRepoService) DeleteThirdPartyRepoByID(ID string) (*models.Thi
 	if imagesExists {
 		return nil, new(ThirdPartyRepositoryImagesExists)
 	}
-	if result := db.Orgx(s.ctx, orgID, "").Delete(&repoDetails); result.Error != nil {
+	if result := db.Org(orgID, "").Delete(&repoDetails); result.Error != nil {
 		s.log.WithField("error", result.Error.Error()).Error("Error deleting custom repository")
 		return nil, result.Error
 	}


### PR DESCRIPTION
The shared context gets cancelled after a request ends. The DBx helper can only be used with properly passed context.

This reverts commit 6c62f065e77a7adbbd8daaebe53891ad03dc041a.

Rather than trying to find and fix all the background places, I would rather revert the change completely. If we want a SQL trace logging somewhere specifically, context should be passed normally and then `DB` can be renamed to `DBx(ctx)`.