### PR TITLE
jobqueue: handle TERM signal not just INT

### DIFF
--- a/pkg/jobs/memory_test.go
+++ b/pkg/jobs/memory_test.go
@@ -194,7 +194,7 @@ func TestMemoryWorker_Panic(t *testing.T) {
 func TestMemoryWorker_Interrupt(t *testing.T) {
 	ctx := context.Background()
 	config := defaultConfig
-	config.IntSignal = os.Signal(syscall.SIGUSR1)
+	config.IntSignal = []os.Signal{os.Signal(syscall.SIGUSR1)}
 	worker := NewMemoryClientWithConfig(config)
 	var success atomic.Bool
 


### PR DESCRIPTION
It appears that kubernetes sends TERM signal not INT signal during pod restart, this was a typo on my side what I really meant was TERM. This patch adds handling of both signals.

This fixes the issue when app is restarted and image build is still running, the failure handler was not called thus leaving the image hanging in the pending state forever.