### PR TITLE
Revert "increase cpu"

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -351,7 +351,7 @@ parameters:
 - description: Cpu limit of service
   name: CPU_LIMIT
   required: false
-  value: "2"
+  value: "1"
 - description: Location of readiness probe
   name: READINESS_URI
   value: "/"


### PR DESCRIPTION
Reverts RedHatInsights/edge-api#2613

I'm up for raising it, but just for prod and through parameter, not by default.