### PR TITLE
Edit floorplan to export created_at for devices

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -345,7 +345,7 @@ objects:
         FROM commits;
     - prefix: ${FLOORIST_QUERY_PREFIX}/devices
       query: >-
-        SELECT uuid, org_id, deleted_at, current_hash, available_hash, last_seen
+        SELECT uuid, org_id, deleted_at, current_hash, available_hash, last_seen, created_at
         FROM devices;
 parameters:
 - description: Cpu limit of service


### PR DESCRIPTION
This is a small change but we will need this to track better the timeline of device usage.