### PR TITLE
Initialize dependencies just once

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,6 @@ func logMiddleware(next http.Handler) http.Handler {
 
 		t1 := time.Now()
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
-		s := dependencies.ServicesFromContext(r.Context())
 
 		org_id, _ := common.GetOrgID(r)
 		fields := log.Fields{
@@ -93,14 +92,14 @@ func logMiddleware(next http.Handler) http.Handler {
 			"method":     r.Method,
 		}
 
-		s.Log.WithFields(fields).Debugf("Started %s request %s", r.Method, r.URL.Path)
+		log.WithContext(r.Context()).WithFields(fields).Debugf("Started %s request %s", r.Method, r.URL.Path)
 
 		defer func() {
 			latency := time.Since(t1).Milliseconds()
 			fields["latency_ms"] = latency
 			fields["status_code"] = ww.Status()
 			fields["bytes"] = ww.BytesWritten()
-			s.Log.WithFields(fields).Infof("Finished %s request %s with %d", r.Method, r.URL.Path, ww.Status())
+			log.WithContext(r.Context()).WithFields(fields).Infof("Finished %s request %s with %d", r.Method, r.URL.Path, ww.Status())
 		}()
 
 		next.ServeHTTP(ww, r)

--- a/main.go
+++ b/main.go
@@ -114,7 +114,6 @@ func webRoutes(cfg *config.EdgeConfig) *chi.Mux {
 		middleware.RealIP,
 		middleware.Recoverer,
 		setupDocsMiddleware,
-		dependencies.Middleware,
 		logMiddleware,
 	)
 
@@ -127,13 +126,11 @@ func webRoutes(cfg *config.EdgeConfig) *chi.Mux {
 	// Authenticated routes
 	authRoute := route.Group(nil)
 	if cfg.Auth {
-		authRoute.Use(
-			identity.EnforceIdentity,
-			dependencies.Middleware,
-		)
+		authRoute.Use(identity.EnforceIdentity)
 	}
 
 	authRoute.Route("/api/edge/v1", func(s chi.Router) {
+		s.Use(dependencies.Middleware)
 		s.Route("/images", routes.MakeImagesRouter)
 		s.Route("/updates", routes.MakeUpdatesRouter)
 		s.Route("/image-sets", routes.MakeImageSetsRouter)


### PR DESCRIPTION
# Description

We are initializing dependencies already in https://github.com/RedHatInsights/edge-api/blob/8f736c36b9c69ba2c446e618b6976e8d54213298/main.go#L118

This is redundant, removing it.