### PR TITLE
Log slow queries as warnings

### DIFF
--- a/logger/gorm_logger.go
+++ b/logger/gorm_logger.go
@@ -61,13 +61,20 @@ func (l *GormLogger) Trace(ctx context.Context, begin time.Time, fc func() (stri
 			"rows":       rows,
 			"sql":        sql,
 			"request_id": rid,
-		}).Error("SQL failed")
+		}).Warn("SQL failed")
 	} else {
-		l.logger.WithContext(ctx).WithFields(logrus.Fields{
-			"latency_ms": elapsed.Milliseconds(),
+		latency := elapsed.Milliseconds()
+		lg := l.logger.WithContext(ctx).WithFields(logrus.Fields{
+			"latency_ms": latency,
 			"rows":       rows,
 			"sql":        sql,
 			"request_id": rid,
-		}).Debug("SQL query")
+		})
+		if latency > 2000 {
+			lg.Warn("Slow SQL query")
+		} else {
+			lg.Trace("SQL query")
+		}
+
 	}
 }


### PR DESCRIPTION
This builds on top of the Gorm logger I added and while debug/trace is typically turned off on production, we would like to see slow queries in Kibana - they are subject of further investigation and optimalization. This simple change logs all slower queries than 2 seconds into warning logger so we can investigate them later.