### PR TITLE
Dockerfile: remove middle stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ OCI_TOOL=$(shell command -v podman || command -v docker)
 IMAGE_TAG=$(shell git rev-parse --short=7 HEAD)
 
 EDGE_API_CONTAINER_TAG="quay.io/cloudservices/edge-api:$(IMAGE_TAG)"
+EDGE_API_DEV_CONTAINER_TAG="localhost/edge-api:dev-$(IMAGE_TAG)"
 
 TEST_CONTAINER_TAG="quay.io/fleet-management/libfdo-data:$(IMAGE_TAG)"
 
@@ -68,6 +69,13 @@ build-test-container:
 		--file "$(CONTAINERFILE_NAME)" \
 		--no-cache \
 		--tag "$(TEST_CONTAINER_TAG)" \
+		.
+
+build-dev-container:
+	$(OCI_TOOL) build \
+		--file "$(CONTAINERFILE_NAME)" \
+		--no-cache \
+		--tag "$(EDGE_API_DEV_CONTAINER_TAG)" \
 		.
 
 build:


### PR DESCRIPTION
# Description
Remove kickstart-related RPMs and reduce Dockerfile to two stages

FIXES: <!-- THEEDGE-NNNN -->

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
