### PR TITLE
Add storage transfer metrics

### DIFF
--- a/pkg/cache/mem_cache.go
+++ b/pkg/cache/mem_cache.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"sync"
 	"time"
+
+	"github.com/redhatinsights/edge-api/pkg/metrics"
 )
 
 // Cache stores arbitrary data with expiration time.
@@ -80,6 +82,11 @@ func (cache *Cache[K, V]) Get(key K) (V, bool) {
 	defer cache.mu.Unlock()
 
 	item, exists := cache.items[key]
+	if exists {
+		metrics.MemoryCacheHitCount.WithLabelValues("hit").Inc()
+	} else {
+		metrics.MemoryCacheHitCount.WithLabelValues("miss").Inc()
+	}
 	if !exists || (item.expires > 0 && time.Now().UnixNano() > item.expires) {
 		var nothing V
 		return nothing, false

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -63,3 +63,37 @@ var PlatformClientDuration = prometheus.NewHistogramVec(
 	},
 	[]string{"method", "status"},
 )
+
+var StorageTransferCount = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Name:        "edge_storage_transfer_counts",
+		Help:        "number of download operations via S3 storage proxy",
+		ConstLabels: prometheus.Labels{"service": ApplicationName, "component": BinaryName},
+	},
+)
+
+var StorageTransferBytes = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Name:        "edge_storage_transfer_bytes",
+		Help:        "bytes transferred via S3 storage proxy",
+		ConstLabels: prometheus.Labels{"service": ApplicationName, "component": BinaryName},
+	},
+)
+
+var StorageTransferDuration = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Name:        "edge_storage_transfer_duration",
+		Help:        "duration of S3 storage proxy operations (in ms)",
+		ConstLabels: prometheus.Labels{"service": ApplicationName, "component": BinaryName},
+		Buckets:     []float64{5, 20, 50, 100, 200, 500, 1000, 5000, 10000},
+	},
+)
+
+var MemoryCacheHitCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name:        "edge_memory_cache_hit_count",
+		Help:        "memory cache hit count by operation",
+		ConstLabels: prometheus.Labels{"service": ApplicationName, "component": BinaryName},
+	},
+	[]string{"op"},
+)

--- a/pkg/metrics/registration.go
+++ b/pkg/metrics/registration.go
@@ -10,5 +10,9 @@ func RegisterAPIMetrics() {
 		JobActiveSize,
 		BackgroundJobDuration,
 		PlatformClientDuration,
+		StorageTransferBytes,
+		StorageTransferCount,
+		StorageTransferDuration,
+		MemoryCacheHitCount,
 	)
 }


### PR DESCRIPTION
This pull request adds metrics for storage transfer operations. It includes counters for the number of download operations via S3 storage proxy, bytes transferred via S3 storage proxy, and the duration of S3 storage proxy operations. Additionally, it adds a counter for memory cache hit count by operation.