### PR TITLE
temp return zero byte files for missing ostree optionals

### DIFF
--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -121,6 +121,11 @@ var SilentGormLogging = &Flag{Name: "edge-management.silent_gorm_logging", EnvVa
 // PulpIntegration covers the overall integration of pulp and deprecation of AWS storage
 var PulpIntegration = &Flag{Name: "edge-management.pulp_integration", EnvVar: "FEATURE_PULP_INTEGRATION"}
 
+// OSTREE FLAGS
+
+// Return204for404 returns 204 No Content instead of 404 Not Found when not finding an optional ostree file
+var Return200for404 = &Flag{Name: "edge-management.return_200_4_404", EnvVar: "FEATURE_RETURN_200_4_404"}
+
 // (ADD FEATURE FLAGS ABOVE)
 // FEATURE FLAG CHECK CODE
 


### PR DESCRIPTION
# Description
Temporary test of returning zero byte file for missing ostree optional files.

FIXES: <!-- THEEDGE-NNNN -->

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
