### PR TITLE
Add content guards for Pulp

### DIFF
--- a/cmd/pulpcli/main.go
+++ b/cmd/pulpcli/main.go
@@ -45,21 +45,21 @@ func fixtureCreate(ctx context.Context, c *pulp.PulpService, orgID, tarFilename 
 	fmt.Println("Repository created", *repo.PulpHref)
 	fmt.Println("--------------------------------")
 
-	hcg, err := c.HeaderGuardReadOrCreate(ctx, pulp.JQOrgID, orgID)
+	cg, err := c.ContentGuardEnsure(ctx, orgID)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println("Header guard found or created", *hcg.PulpHref)
+	fmt.Println("Content guard found or created", *cg.PulpHref, (*cg.Guards)[0], (*cg.Guards)[1])
 	fmt.Println("--------------------------------")
 
-	dist, err := c.DistributionsCreate(ctx, resourceName, resourceName, *repo.PulpHref, *hcg.PulpHref)
+	dist, err := c.DistributionsCreate(ctx, resourceName, resourceName, *repo.PulpHref, *cg.PulpHref)
 	if err != nil {
 		panic(err)
 	}
 	fmt.Println("Distribution created", *dist.PulpHref)
 	fmt.Println("--------------------------------")
 
-	repoImported, err := c.RepositoriesImport(ctx, pulp.ScanUUID(*repo.PulpHref), "repo", *artifact.PulpHref)
+	repoImported, err := c.RepositoriesImport(ctx, pulp.ScanUUID(repo.PulpHref), "repo", *artifact.PulpHref)
 	if err != nil {
 		panic(err)
 	}
@@ -67,6 +67,7 @@ func fixtureCreate(ctx context.Context, c *pulp.PulpService, orgID, tarFilename 
 	fmt.Println("--------------------------------")
 
 	fmt.Printf("curl -L --proxy http://squid.xxxx.redhat.com:3128 --cert /etc/pki/consumer/cert.pem --key /etc/pki/consumer/key.pem https://cert.console.stage.redhat.com/api/pulp-content/%s/%s/\n", c.Domain(), resourceName)
+	fmt.Printf("curl -L --proxy http://squid.xxxx.redhat.com:3128 -u edge-content-dev:XXXX https://pulp.stage.xxxx.net/api/pulp-content/%s/%s/\n", c.Domain(), resourceName)
 	fmt.Println("--------------------------------")
 }
 
@@ -91,7 +92,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		fmt.Println("Created domain:", pulp.ScanUUID(*createdDomain.PulpHref), ", please update the domainHref in the test source!")
+		fmt.Println("Created domain:", pulp.ScanUUID(createdDomain.PulpHref), ", please update the domainHref in the test source!")
 		return
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -81,6 +81,8 @@ type EdgeConfig struct {
 	PulpURL                    string                    `json:"pulp_url,omitempty"`
 	PulpUsername               string                    `json:"pulp_username,omitempty"`
 	PulpPassword               string                    `json:"pulp_password,omitempty"`
+	PulpContentUsername        string                    `json:"pulp_content_username,omitempty"`
+	PulpContentPassword        string                    `json:"pulp_content_password,omitempty"`
 	PulpIdentityName           string                    `json:"pulp_identity_name,omitempty"`
 	PulpProxyURL               string                    `json:"pulp_proxy_url,omitempty"`
 	PulpOauth2URL              string                    `json:"pulp_oauth2_url,omitempty"`
@@ -185,6 +187,8 @@ func CreateEdgeAPIConfig() (*EdgeConfig, error) {
 	options.SetDefault("PulpURL", "http://pulp-service:8080")
 	options.SetDefault("PulpUsername", "edge-api-dev")
 	options.SetDefault("PulpPassword", "")
+	options.SetDefault("PulpContentUsername", "edge-content-dev")
+	options.SetDefault("PulpContentPassword", "")
 	options.SetDefault("PulpIdentityName", "edge-api-dev")
 	options.SetDefault("PulpProxyURL", "")
 	options.SetDefault("PulpOauth2URL", "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token")
@@ -297,6 +301,8 @@ func CreateEdgeAPIConfig() (*EdgeConfig, error) {
 		PulpURL:                    options.GetString("PulpURL"),
 		PulpUsername:               options.GetString("PulpUsername"),
 		PulpPassword:               options.GetString("PulpPassword"),
+		PulpContentUsername:        options.GetString("PulpContentUsername"),
+		PulpContentPassword:        options.GetString("PulpContentPassword"),
 		PulpIdentityName:           options.GetString("PulpIdentityName"),
 		PulpProxyURL:               options.GetString("PulpProxyURL"),
 		PulpOauth2URL:              options.GetString("PulpOauth2URL"),

--- a/pkg/clients/pulp/artifacts.go
+++ b/pkg/clients/pulp/artifacts.go
@@ -237,7 +237,7 @@ func (ps *PulpService) ArtifactsList(ctx context.Context, sha256 string) ([]Arti
 		return nil, fmt.Errorf("unexpected response: %d, body: %s", resp.StatusCode(), string(resp.Body))
 	}
 
-	if resp.JSON200.Count >= DefaultPageSize {
+	if resp.JSON200.Count > DefaultPageSize {
 		return nil, fmt.Errorf("default page size too small: %d", resp.JSON200.Count)
 	}
 

--- a/pkg/clients/pulp/distributions.go
+++ b/pkg/clients/pulp/distributions.go
@@ -29,7 +29,7 @@ func (ps *PulpService) DistributionsCreate(ctx context.Context, name, basePath, 
 		return nil, err
 	}
 
-	result, err := ps.DistributionsRead(ctx, ScanUUID(href))
+	result, err := ps.DistributionsRead(ctx, ScanUUID(&href))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/clients/pulp/domains.go
+++ b/pkg/clients/pulp/domains.go
@@ -80,7 +80,7 @@ func (ps *PulpService) DomainsList(ctx context.Context, nameFilter string) ([]Do
 		return nil, fmt.Errorf("unexpected response: %d, body: %s", resp.StatusCode(), string(resp.Body))
 	}
 
-	if resp.JSON200.Count >= DefaultPageSize {
+	if resp.JSON200.Count > DefaultPageSize {
 		return nil, fmt.Errorf("default page size too small: %d", resp.JSON200.Count)
 	}
 

--- a/pkg/clients/pulp/guards_composite.go
+++ b/pkg/clients/pulp/guards_composite.go
@@ -1,0 +1,163 @@
+package pulp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/redhatinsights/edge-api/pkg/ptr"
+	"github.com/sirupsen/logrus"
+)
+
+func compositeGuardName(orgID string) string {
+	return "EDGE_COMP_ORGID=" + orgID
+}
+
+// CompositeGuardCreate creates a new composite guard with the given orgID, headerHref, and rbacHref.
+func (ps *PulpService) CompositeGuardCreate(ctx context.Context, orgID, headerHref, rbacHref string) (*CompositeContentGuardResponse, error) {
+	req := ContentguardsCoreCompositeCreateJSONRequestBody{
+		Name:        compositeGuardName(orgID),
+		Guards:      ptr.To([]string{headerHref, rbacHref}),
+		Description: ptr.To("EDGE"),
+	}
+	resp, err := ps.cwr.ContentguardsCoreCompositeCreateWithResponse(ctx, ps.dom, req, addAuthenticationHeader)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON201 == nil {
+		return nil, fmt.Errorf("unexpected response: %d, body: %s", resp.StatusCode(), string(resp.Body))
+	}
+
+	return resp.JSON201, nil
+}
+
+// CompositeGuardRead returns the composite guard with the given ID.
+func (ps *PulpService) CompositeGuardRead(ctx context.Context, id uuid.UUID) (*CompositeContentGuardResponse, error) {
+	req := ContentguardsCoreCompositeReadParams{}
+	resp, err := ps.cwr.ContentguardsCoreCompositeReadWithResponse(ctx, ps.dom, id, &req, addAuthenticationHeader)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response: %d, body: %s", resp.StatusCode(), string(resp.Body))
+	}
+
+	return resp.JSON200, nil
+}
+
+// CompositeGuardReadByOrgID returns the composite guard for the given orgID.
+func (ps *PulpService) CompositeGuardReadByOrgID(ctx context.Context, orgID string) (*CompositeContentGuardResponse, error) {
+	hgl, err := ps.CompositeGuardList(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(hgl) == 0 {
+		return nil, fmt.Errorf("composite guard not found for orgID %s: %w", orgID, ErrRecordNotFound)
+	}
+
+	id := ScanUUID(hgl[0].PulpHref)
+	return ps.CompositeGuardRead(ctx, id)
+}
+
+// CompositeGuardEnsure ensures that the composite guard is created and returns it. The method is idempotent.
+func (ps *PulpService) CompositeGuardEnsure(ctx context.Context, orgID, headerHref, rbacHref string) (*CompositeContentGuardResponse, error) {
+	cg, err := ps.CompositeGuardReadByOrgID(ctx, compositeGuardName(orgID))
+	// nolint: gocritic
+	if errors.Is(err, ErrRecordNotFound) {
+		cg, err = ps.CompositeGuardCreate(ctx, orgID, headerHref, rbacHref)
+		if err != nil {
+			return nil, err
+		}
+
+		return cg, nil
+	} else if err != nil {
+		return nil, err
+	} else if cg == nil {
+		return nil, fmt.Errorf("unexpected nil guard")
+	}
+
+	gs := ptr.FromOrEmpty(cg.Guards)
+	if !(len(gs) == 2 && (gs[0] != headerHref && gs[1] != rbacHref) || (gs[1] != headerHref && gs[0] != rbacHref)) {
+		logrus.WithContext(ctx).Warnf("unexpected Composite Content Guard: %v, deleting it", gs)
+		err = ps.CompositeGuardDelete(ctx, ScanUUID(cg.PulpHref))
+		if err != nil {
+			return nil, err
+		}
+
+		cg, err = ps.CompositeGuardCreate(ctx, orgID, headerHref, rbacHref)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return cg, nil
+}
+
+// ContentGuardEnsure ensures that the header and RBAC guards are created and returns the composite guard. If it finds
+// that the composite guard is not created or the guards are not the same as the ones provided, it will delete it
+// and recreate it. This method is idempotent and will not create the guards if they already exist.
+func (ps *PulpService) ContentGuardEnsure(ctx context.Context, orgID string) (*CompositeContentGuardResponse, error) {
+	hcg, err := ps.HeaderGuardEnsure(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+
+	rcg, err := ps.RbacGuardEnsure(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ccg, err := ps.CompositeGuardEnsure(ctx, orgID, *hcg.PulpHref, *rcg.PulpHref)
+	if err != nil {
+		return nil, err
+	}
+
+	return ccg, nil
+}
+
+// CompositeGuardDelete deletes the composite guard with the given ID.
+func (ps *PulpService) CompositeGuardDelete(ctx context.Context, id uuid.UUID) error {
+	resp, err := ps.cwr.ContentguardsCoreCompositeDelete(ctx, ps.dom, id, addAuthenticationHeader)
+
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != 204 {
+		return fmt.Errorf("unexpected response: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// CompositeGuardList returns a list of composite guards with the given name filter.
+func (ps *PulpService) CompositeGuardList(ctx context.Context, nameFilter string) ([]CompositeContentGuardResponse, error) {
+	req := ContentguardsCoreCompositeListParams{
+		Limit: &DefaultPageSize,
+	}
+	if nameFilter != "" {
+		req.Name = &nameFilter
+	}
+
+	resp, err := ps.cwr.ContentguardsCoreCompositeListWithResponse(ctx, ps.dom, &req, addAuthenticationHeader)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response: %d, body: %s", resp.StatusCode(), string(resp.Body))
+	}
+
+	if resp.JSON200.Count > DefaultPageSize {
+		return nil, fmt.Errorf("default page size too small: %d", resp.JSON200.Count)
+	}
+
+	return resp.JSON200.Results, nil
+}

--- a/pkg/clients/pulp/guards_rbac.go
+++ b/pkg/clients/pulp/guards_rbac.go
@@ -1,0 +1,181 @@
+package pulp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/ptr"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
+)
+
+var guardRbacName = "ROLE=readonly"
+
+func rbacUsername() string {
+	return config.Get().PulpContentUsername
+}
+
+// RbacGuardList returns a list of RBAC guards. The nameFilter can be used to filter the results.
+func (ps *PulpService) RbacGuardList(ctx context.Context, nameFilter string) ([]RBACContentGuardResponse, error) {
+	req := ContentguardsCoreRbacListParams{
+		Limit: &DefaultPageSize,
+	}
+	if nameFilter != "" {
+		req.Name = &nameFilter
+	}
+
+	resp, err := ps.cwr.ContentguardsCoreRbacListWithResponse(ctx, ps.dom, &req, addAuthenticationHeader)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response: %d, body: %s", resp.StatusCode(), string(resp.Body))
+	}
+
+	if resp.JSON200.Count > DefaultPageSize {
+		return nil, fmt.Errorf("default page size too small: %d", resp.JSON200.Count)
+	}
+
+	return resp.JSON200.Results, nil
+}
+
+// RbacGuardRead returns the RBAC guard with the given ID.
+func (ps *PulpService) RbacGuardRead(ctx context.Context, id uuid.UUID) (*RBACContentGuardResponse, error) {
+	req := ContentguardsCoreRbacReadParams{}
+	resp, err := ps.cwr.ContentguardsCoreRbacReadWithResponse(ctx, ps.dom, id, &req, addAuthenticationHeader)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response: %d, body: %s", resp.StatusCode(), string(resp.Body))
+	}
+
+	return resp.JSON200, nil
+}
+
+// RbacGuardFind returns the RBAC guard.
+func (ps *PulpService) RbacGuardFind(ctx context.Context) (*RBACContentGuardResponse, error) {
+	hgl, err := ps.RbacGuardList(ctx, guardRbacName)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(hgl) == 0 {
+		return nil, fmt.Errorf("header guard not found for name %s: %w", guardRbacName, ErrRecordNotFound)
+	}
+
+	id := ScanUUID(hgl[0].PulpHref)
+	return ps.RbacGuardRead(ctx, id)
+}
+
+// RbacGuardCreate creates a new RBAC guard and returns it.
+func (ps *PulpService) RbacGuardCreate(ctx context.Context) (*RBACContentGuardResponse, error) {
+	req := RBACContentGuard{
+		Name:        guardRbacName,
+		Description: ptr.To("EDGE"),
+	}
+	resp, err := ps.cwr.ContentguardsCoreRbacCreateWithResponse(ctx, ps.dom, req, addAuthenticationHeader)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON201 == nil {
+		return nil, fmt.Errorf("unexpected response: %d, body: %s", resp.StatusCode(), string(resp.Body))
+	}
+
+	return resp.JSON201, nil
+}
+
+// RbacGuardEnsure ensures that the RBAC guard is created and returns it. The method is idempotent.
+func (ps *PulpService) RbacGuardEnsure(ctx context.Context) (*RBACContentGuardResponse, error) {
+	cg, err := ps.RbacGuardFind(ctx)
+	// nolint: gocritic
+	if errors.Is(err, ErrRecordNotFound) {
+		cg, err = ps.RbacGuardCreate(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		return cg, nil
+	} else if err != nil {
+		return nil, err
+	} else if cg == nil {
+		return nil, fmt.Errorf("unexpected nil guard")
+	}
+
+	u := ptr.FromOrEmpty(cg.Users)
+	if !slices.ContainsFunc(u, func(gur GroupUserResponse) bool {
+		return gur.Username == rbacUsername()
+	}) {
+		logrus.WithContext(ctx).Warnf("user %s not found in RBAC Content Guard: %+v, adding it", rbacUsername(), u)
+		users := []string{rbacUsername()}
+		rreq := NestedRole{
+			Role:  rbacUsername(),
+			Users: &users,
+		}
+		id := ScanUUID(cg.PulpHref)
+		rresp, err := ps.cwr.ContentguardsCoreRbacAddRoleWithResponse(ctx, ps.dom, id, rreq, addAuthenticationHeader)
+
+		if err != nil {
+			return nil, err
+		}
+
+		if rresp.JSON201 == nil {
+			return nil, fmt.Errorf("unexpected response: %d, body: %s", rresp.StatusCode(), string(rresp.Body))
+		}
+	}
+	return cg, nil
+}
+
+// RbacGuardDelete deletes the RBAC guard with the given ID.
+func (ps *PulpService) RbacGuardDelete(ctx context.Context, id uuid.UUID) error {
+	listParams := ContentguardsCoreRbacListRolesParams{}
+	roles, err := ps.cwr.ContentguardsCoreRbacListRolesWithResponse(ctx, ps.dom, id, &listParams, addAuthenticationHeader)
+
+	if err != nil {
+		return err
+	}
+
+	if roles.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %d, body: %s", roles.StatusCode(), string(roles.Body))
+	}
+
+	for _, role := range roles.JSON200.Roles {
+		nr := NestedRole{
+			Role:  role.Role,
+			Users: &[]string{},
+		}
+
+		logrus.WithContext(ctx).Warnf("removing RBAC guardrole: %s", role.Role)
+		removed, err := ps.cwr.ContentguardsCoreRbacRemoveRoleWithResponse(ctx, ps.dom, id, nr, addAuthenticationHeader)
+
+		if err != nil {
+			return err
+		}
+
+		if removed.JSON201 == nil {
+			return fmt.Errorf("unexpected response: %d, body: %s", removed.StatusCode(), string(removed.Body))
+		}
+	}
+
+	resp, err := ps.cwr.ContentguardsCoreRbacDelete(ctx, ps.dom, id, addAuthenticationHeader)
+
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != 204 {
+		return fmt.Errorf("unexpected response: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/clients/pulp/href.go
+++ b/pkg/clients/pulp/href.go
@@ -9,8 +9,12 @@ import (
 // 01902b07-242d-7ee0-9964-6191c8f8d622
 var uuidRegexp = regexp.MustCompile("[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}")
 
-func ScanUUID(href string) uuid.UUID {
-	str := uuidRegexp.FindString(href)
+func ScanUUID(href *string) uuid.UUID {
+	if href == nil {
+		return uuid.UUID{}
+	}
+
+	str := uuidRegexp.FindString(*href)
 
 	if str == "" {
 		return uuid.UUID{}

--- a/pkg/clients/pulp/href_test.go
+++ b/pkg/clients/pulp/href_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/redhatinsights/edge-api/pkg/ptr"
 )
 
 func TestScanUUID(t *testing.T) {
@@ -38,7 +39,8 @@ func TestScanUUID(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				actual := ScanUUID(tt.href)
+				// linter G601 workaround
+				actual := ScanUUID(ptr.To(tt.href))
 				if actual != tt.expected {
 					t.Errorf("scanUUID(%s): expected %v, actual %v", tt.href, tt.expected, actual)
 				}

--- a/pkg/clients/pulp/pulp_client.gen.go
+++ b/pkg/clients/pulp/pulp_client.gen.go
@@ -111,6 +111,24 @@ const (
 	ContentguardsCoreHeaderListParamsOrderingPulpType             ContentguardsCoreHeaderListParamsOrdering = "pulp_type"
 )
 
+// Defines values for ContentguardsCoreRbacListParamsOrdering.
+const (
+	ContentguardsCoreRbacListParamsOrderingDescription          ContentguardsCoreRbacListParamsOrdering = "description"
+	ContentguardsCoreRbacListParamsOrderingMinusDescription     ContentguardsCoreRbacListParamsOrdering = "-description"
+	ContentguardsCoreRbacListParamsOrderingMinusName            ContentguardsCoreRbacListParamsOrdering = "-name"
+	ContentguardsCoreRbacListParamsOrderingMinusPk              ContentguardsCoreRbacListParamsOrdering = "-pk"
+	ContentguardsCoreRbacListParamsOrderingMinusPulpCreated     ContentguardsCoreRbacListParamsOrdering = "-pulp_created"
+	ContentguardsCoreRbacListParamsOrderingMinusPulpId          ContentguardsCoreRbacListParamsOrdering = "-pulp_id"
+	ContentguardsCoreRbacListParamsOrderingMinusPulpLastUpdated ContentguardsCoreRbacListParamsOrdering = "-pulp_last_updated"
+	ContentguardsCoreRbacListParamsOrderingMinusPulpType        ContentguardsCoreRbacListParamsOrdering = "-pulp_type"
+	ContentguardsCoreRbacListParamsOrderingName                 ContentguardsCoreRbacListParamsOrdering = "name"
+	ContentguardsCoreRbacListParamsOrderingPk                   ContentguardsCoreRbacListParamsOrdering = "pk"
+	ContentguardsCoreRbacListParamsOrderingPulpCreated          ContentguardsCoreRbacListParamsOrdering = "pulp_created"
+	ContentguardsCoreRbacListParamsOrderingPulpId               ContentguardsCoreRbacListParamsOrdering = "pulp_id"
+	ContentguardsCoreRbacListParamsOrderingPulpLastUpdated      ContentguardsCoreRbacListParamsOrdering = "pulp_last_updated"
+	ContentguardsCoreRbacListParamsOrderingPulpType             ContentguardsCoreRbacListParamsOrdering = "pulp_type"
+)
+
 // Defines values for DistributionsOstreeOstreeListParamsOrdering.
 const (
 	DistributionsOstreeOstreeListParamsOrderingBasePath             DistributionsOstreeOstreeListParamsOrdering = "base_path"
@@ -185,36 +203,36 @@ const (
 
 // Defines values for TasksListParamsOrdering.
 const (
-	TasksListParamsOrderingEncArgs                      TasksListParamsOrdering = "enc_args"
-	TasksListParamsOrderingEncKwargs                    TasksListParamsOrdering = "enc_kwargs"
-	TasksListParamsOrderingError                        TasksListParamsOrdering = "error"
-	TasksListParamsOrderingFinishedAt                   TasksListParamsOrdering = "finished_at"
-	TasksListParamsOrderingLoggingCid                   TasksListParamsOrdering = "logging_cid"
-	TasksListParamsOrderingMinusEncArgs                 TasksListParamsOrdering = "-enc_args"
-	TasksListParamsOrderingMinusEncKwargs               TasksListParamsOrdering = "-enc_kwargs"
-	TasksListParamsOrderingMinusError                   TasksListParamsOrdering = "-error"
-	TasksListParamsOrderingMinusFinishedAt              TasksListParamsOrdering = "-finished_at"
-	TasksListParamsOrderingMinusLoggingCid              TasksListParamsOrdering = "-logging_cid"
-	TasksListParamsOrderingMinusName                    TasksListParamsOrdering = "-name"
-	TasksListParamsOrderingMinusPk                      TasksListParamsOrdering = "-pk"
-	TasksListParamsOrderingMinusPulpCreated             TasksListParamsOrdering = "-pulp_created"
-	TasksListParamsOrderingMinusPulpId                  TasksListParamsOrdering = "-pulp_id"
-	TasksListParamsOrderingMinusPulpLastUpdated         TasksListParamsOrdering = "-pulp_last_updated"
-	TasksListParamsOrderingMinusReservedResourcesRecord TasksListParamsOrdering = "-reserved_resources_record"
-	TasksListParamsOrderingMinusStartedAt               TasksListParamsOrdering = "-started_at"
-	TasksListParamsOrderingMinusState                   TasksListParamsOrdering = "-state"
-	TasksListParamsOrderingMinusUnblockedAt             TasksListParamsOrdering = "-unblocked_at"
-	TasksListParamsOrderingMinusVersions                TasksListParamsOrdering = "-versions"
-	TasksListParamsOrderingName                         TasksListParamsOrdering = "name"
-	TasksListParamsOrderingPk                           TasksListParamsOrdering = "pk"
-	TasksListParamsOrderingPulpCreated                  TasksListParamsOrdering = "pulp_created"
-	TasksListParamsOrderingPulpId                       TasksListParamsOrdering = "pulp_id"
-	TasksListParamsOrderingPulpLastUpdated              TasksListParamsOrdering = "pulp_last_updated"
-	TasksListParamsOrderingReservedResourcesRecord      TasksListParamsOrdering = "reserved_resources_record"
-	TasksListParamsOrderingStartedAt                    TasksListParamsOrdering = "started_at"
-	TasksListParamsOrderingState                        TasksListParamsOrdering = "state"
-	TasksListParamsOrderingUnblockedAt                  TasksListParamsOrdering = "unblocked_at"
-	TasksListParamsOrderingVersions                     TasksListParamsOrdering = "versions"
+	EncArgs                      TasksListParamsOrdering = "enc_args"
+	EncKwargs                    TasksListParamsOrdering = "enc_kwargs"
+	Error                        TasksListParamsOrdering = "error"
+	FinishedAt                   TasksListParamsOrdering = "finished_at"
+	LoggingCid                   TasksListParamsOrdering = "logging_cid"
+	MinusEncArgs                 TasksListParamsOrdering = "-enc_args"
+	MinusEncKwargs               TasksListParamsOrdering = "-enc_kwargs"
+	MinusError                   TasksListParamsOrdering = "-error"
+	MinusFinishedAt              TasksListParamsOrdering = "-finished_at"
+	MinusLoggingCid              TasksListParamsOrdering = "-logging_cid"
+	MinusName                    TasksListParamsOrdering = "-name"
+	MinusPk                      TasksListParamsOrdering = "-pk"
+	MinusPulpCreated             TasksListParamsOrdering = "-pulp_created"
+	MinusPulpId                  TasksListParamsOrdering = "-pulp_id"
+	MinusPulpLastUpdated         TasksListParamsOrdering = "-pulp_last_updated"
+	MinusReservedResourcesRecord TasksListParamsOrdering = "-reserved_resources_record"
+	MinusStartedAt               TasksListParamsOrdering = "-started_at"
+	MinusState                   TasksListParamsOrdering = "-state"
+	MinusUnblockedAt             TasksListParamsOrdering = "-unblocked_at"
+	MinusVersions                TasksListParamsOrdering = "-versions"
+	Name                         TasksListParamsOrdering = "name"
+	Pk                           TasksListParamsOrdering = "pk"
+	PulpCreated                  TasksListParamsOrdering = "pulp_created"
+	PulpId                       TasksListParamsOrdering = "pulp_id"
+	PulpLastUpdated              TasksListParamsOrdering = "pulp_last_updated"
+	ReservedResourcesRecord      TasksListParamsOrdering = "reserved_resources_record"
+	StartedAt                    TasksListParamsOrdering = "started_at"
+	State                        TasksListParamsOrdering = "state"
+	UnblockedAt                  TasksListParamsOrdering = "unblocked_at"
+	Versions                     TasksListParamsOrdering = "versions"
 )
 
 // Defines values for TasksListParamsState.
@@ -407,6 +425,23 @@ type DomainResponse struct {
 	StorageSettings map[string]interface{} `json:"storage_settings"`
 }
 
+// GroupResponse Serializer for Group.
+type GroupResponse struct {
+	Id *int64 `json:"id,omitempty"`
+
+	// Name Name
+	Name     string  `json:"name"`
+	PulpHref *string `json:"pulp_href,omitempty"`
+}
+
+// GroupUserResponse Serializer for Users that belong to a Group.
+type GroupUserResponse struct {
+	PulpHref *string `json:"pulp_href,omitempty"`
+
+	// Username Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.
+	Username string `json:"username"`
+}
+
 // HeaderContentGuard A serializer for HeaderContentGuard.
 type HeaderContentGuard struct {
 	// Description An optional description.
@@ -533,6 +568,14 @@ type PaginatedHeaderContentGuardResponseList struct {
 	Results  []HeaderContentGuardResponse `json:"results"`
 }
 
+// PaginatedRBACContentGuardResponseList defines model for PaginatedRBACContentGuardResponseList.
+type PaginatedRBACContentGuardResponseList struct {
+	Count    int                        `json:"count"`
+	Next     *string                    `json:"next"`
+	Previous *string                    `json:"previous"`
+	Results  []RBACContentGuardResponse `json:"results"`
+}
+
 // PaginatedTaskResponseList defines model for PaginatedTaskResponseList.
 type PaginatedTaskResponseList struct {
 	Count    int            `json:"count"`
@@ -626,6 +669,21 @@ type PatchedHeaderContentGuard struct {
 	Name *string `json:"name,omitempty"`
 }
 
+// PatchedRBACContentGuard Base serializer for use with :class:`pulpcore.app.models.Model`
+//
+// This ensures that all Serializers provide values for the 'pulp_href` field.
+//
+// The class provides a default for the “ref_name“ attribute in the
+// ModelSerializers's “Meta“ class. This ensures that the OpenAPI definitions
+// of plugins are namespaced properly.
+type PatchedRBACContentGuard struct {
+	// Description An optional description.
+	Description *string `json:"description"`
+
+	// Name The unique name.
+	Name *string `json:"name,omitempty"`
+}
+
 // PatchedTaskCancel Base serializer for use with :class:`pulpcore.app.models.Model`
 //
 // This ensures that all Serializers provide values for the 'pulp_href` field.
@@ -712,6 +770,45 @@ type Purge struct {
 
 	// States List of task-states to be purged. Only 'final' states are allowed.
 	States *[]StatesEnum `json:"states,omitempty"`
+}
+
+// RBACContentGuard Base serializer for use with :class:`pulpcore.app.models.Model`
+//
+// This ensures that all Serializers provide values for the 'pulp_href` field.
+//
+// The class provides a default for the “ref_name“ attribute in the
+// ModelSerializers's “Meta“ class. This ensures that the OpenAPI definitions
+// of plugins are namespaced properly.
+type RBACContentGuard struct {
+	// Description An optional description.
+	Description *string `json:"description"`
+
+	// Name The unique name.
+	Name string `json:"name"`
+}
+
+// RBACContentGuardResponse Base serializer for use with :class:`pulpcore.app.models.Model`
+//
+// This ensures that all Serializers provide values for the 'pulp_href` field.
+//
+// The class provides a default for the “ref_name“ attribute in the
+// ModelSerializers's “Meta“ class. This ensures that the OpenAPI definitions
+// of plugins are namespaced properly.
+type RBACContentGuardResponse struct {
+	// Description An optional description.
+	Description *string          `json:"description"`
+	Groups      *[]GroupResponse `json:"groups,omitempty"`
+
+	// Name The unique name.
+	Name string `json:"name"`
+
+	// PulpCreated Timestamp of creation.
+	PulpCreated *time.Time `json:"pulp_created,omitempty"`
+	PulpHref    *string    `json:"pulp_href,omitempty"`
+
+	// PulpLastUpdated Timestamp of the last time this resource was updated. Note: for immutable resources - like content, repository versions, and publication - pulp_created and pulp_last_updated dates will be the same.
+	PulpLastUpdated *time.Time           `json:"pulp_last_updated,omitempty"`
+	Users           *[]GroupUserResponse `json:"users,omitempty"`
 }
 
 // RepositoryAddRemoveContent Base serializer for use with :class:`pulpcore.app.models.Model`
@@ -1286,6 +1383,103 @@ type ContentguardsCoreHeaderListRolesParams struct {
 
 // ContentguardsCoreHeaderMyPermissionsParams defines parameters for ContentguardsCoreHeaderMyPermissions.
 type ContentguardsCoreHeaderMyPermissionsParams struct {
+	// Fields A list of fields to include in the response.
+	Fields *[]string `form:"fields,omitempty" json:"fields,omitempty"`
+
+	// ExcludeFields A list of fields to exclude from the response.
+	ExcludeFields *[]string `form:"exclude_fields,omitempty" json:"exclude_fields,omitempty"`
+}
+
+// ContentguardsCoreRbacListParams defines parameters for ContentguardsCoreRbacList.
+type ContentguardsCoreRbacListParams struct {
+	// Limit Number of results to return per page.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Name Filter results where name matches value
+	Name *string `form:"name,omitempty" json:"name,omitempty"`
+
+	// NameContains Filter results where name contains value
+	NameContains *string `form:"name__contains,omitempty" json:"name__contains,omitempty"`
+
+	// NameIcontains Filter results where name contains value
+	NameIcontains *string `form:"name__icontains,omitempty" json:"name__icontains,omitempty"`
+
+	// NameIexact Filter results where name matches value
+	NameIexact *string `form:"name__iexact,omitempty" json:"name__iexact,omitempty"`
+
+	// NameIn Filter results where name is in a comma-separated list of values
+	NameIn *[]string `form:"name__in,omitempty" json:"name__in,omitempty"`
+
+	// NameIregex Filter results where name matches regex value
+	NameIregex *string `form:"name__iregex,omitempty" json:"name__iregex,omitempty"`
+
+	// NameIstartswith Filter results where name starts with value
+	NameIstartswith *string `form:"name__istartswith,omitempty" json:"name__istartswith,omitempty"`
+
+	// NameRegex Filter results where name matches regex value
+	NameRegex *string `form:"name__regex,omitempty" json:"name__regex,omitempty"`
+
+	// NameStartswith Filter results where name starts with value
+	NameStartswith *string `form:"name__startswith,omitempty" json:"name__startswith,omitempty"`
+
+	// Offset The initial index from which to return the results.
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+
+	// Ordering Ordering
+	//
+	// * `pulp_id` - Pulp id
+	// * `-pulp_id` - Pulp id (descending)
+	// * `pulp_created` - Pulp created
+	// * `-pulp_created` - Pulp created (descending)
+	// * `pulp_last_updated` - Pulp last updated
+	// * `-pulp_last_updated` - Pulp last updated (descending)
+	// * `pulp_type` - Pulp type
+	// * `-pulp_type` - Pulp type (descending)
+	// * `name` - Name
+	// * `-name` - Name (descending)
+	// * `description` - Description
+	// * `-description` - Description (descending)
+	// * `pk` - Pk
+	// * `-pk` - Pk (descending)
+	Ordering *[]ContentguardsCoreRbacListParamsOrdering `form:"ordering,omitempty" json:"ordering,omitempty"`
+
+	// PulpHrefIn Multiple values may be separated by commas.
+	PulpHrefIn *[]string `form:"pulp_href__in,omitempty" json:"pulp_href__in,omitempty"`
+
+	// PulpIdIn Multiple values may be separated by commas.
+	PulpIdIn *[]openapi_types.UUID `form:"pulp_id__in,omitempty" json:"pulp_id__in,omitempty"`
+	Q        *string               `form:"q,omitempty" json:"q,omitempty"`
+
+	// Fields A list of fields to include in the response.
+	Fields *[]string `form:"fields,omitempty" json:"fields,omitempty"`
+
+	// ExcludeFields A list of fields to exclude from the response.
+	ExcludeFields *[]string `form:"exclude_fields,omitempty" json:"exclude_fields,omitempty"`
+}
+
+// ContentguardsCoreRbacListParamsOrdering defines parameters for ContentguardsCoreRbacList.
+type ContentguardsCoreRbacListParamsOrdering string
+
+// ContentguardsCoreRbacReadParams defines parameters for ContentguardsCoreRbacRead.
+type ContentguardsCoreRbacReadParams struct {
+	// Fields A list of fields to include in the response.
+	Fields *[]string `form:"fields,omitempty" json:"fields,omitempty"`
+
+	// ExcludeFields A list of fields to exclude from the response.
+	ExcludeFields *[]string `form:"exclude_fields,omitempty" json:"exclude_fields,omitempty"`
+}
+
+// ContentguardsCoreRbacListRolesParams defines parameters for ContentguardsCoreRbacListRoles.
+type ContentguardsCoreRbacListRolesParams struct {
+	// Fields A list of fields to include in the response.
+	Fields *[]string `form:"fields,omitempty" json:"fields,omitempty"`
+
+	// ExcludeFields A list of fields to exclude from the response.
+	ExcludeFields *[]string `form:"exclude_fields,omitempty" json:"exclude_fields,omitempty"`
+}
+
+// ContentguardsCoreRbacMyPermissionsParams defines parameters for ContentguardsCoreRbacMyPermissions.
+type ContentguardsCoreRbacMyPermissionsParams struct {
 	// Fields A list of fields to include in the response.
 	Fields *[]string `form:"fields,omitempty" json:"fields,omitempty"`
 
@@ -1943,6 +2137,51 @@ type ContentguardsCoreHeaderRemoveRoleFormdataRequestBody = NestedRole
 // ContentguardsCoreHeaderRemoveRoleMultipartRequestBody defines body for ContentguardsCoreHeaderRemoveRole for multipart/form-data ContentType.
 type ContentguardsCoreHeaderRemoveRoleMultipartRequestBody = NestedRole
 
+// ContentguardsCoreRbacCreateJSONRequestBody defines body for ContentguardsCoreRbacCreate for application/json ContentType.
+type ContentguardsCoreRbacCreateJSONRequestBody = RBACContentGuard
+
+// ContentguardsCoreRbacCreateFormdataRequestBody defines body for ContentguardsCoreRbacCreate for application/x-www-form-urlencoded ContentType.
+type ContentguardsCoreRbacCreateFormdataRequestBody = RBACContentGuard
+
+// ContentguardsCoreRbacCreateMultipartRequestBody defines body for ContentguardsCoreRbacCreate for multipart/form-data ContentType.
+type ContentguardsCoreRbacCreateMultipartRequestBody = RBACContentGuard
+
+// ContentguardsCoreRbacPartialUpdateJSONRequestBody defines body for ContentguardsCoreRbacPartialUpdate for application/json ContentType.
+type ContentguardsCoreRbacPartialUpdateJSONRequestBody = PatchedRBACContentGuard
+
+// ContentguardsCoreRbacPartialUpdateFormdataRequestBody defines body for ContentguardsCoreRbacPartialUpdate for application/x-www-form-urlencoded ContentType.
+type ContentguardsCoreRbacPartialUpdateFormdataRequestBody = PatchedRBACContentGuard
+
+// ContentguardsCoreRbacPartialUpdateMultipartRequestBody defines body for ContentguardsCoreRbacPartialUpdate for multipart/form-data ContentType.
+type ContentguardsCoreRbacPartialUpdateMultipartRequestBody = PatchedRBACContentGuard
+
+// ContentguardsCoreRbacUpdateJSONRequestBody defines body for ContentguardsCoreRbacUpdate for application/json ContentType.
+type ContentguardsCoreRbacUpdateJSONRequestBody = RBACContentGuard
+
+// ContentguardsCoreRbacUpdateFormdataRequestBody defines body for ContentguardsCoreRbacUpdate for application/x-www-form-urlencoded ContentType.
+type ContentguardsCoreRbacUpdateFormdataRequestBody = RBACContentGuard
+
+// ContentguardsCoreRbacUpdateMultipartRequestBody defines body for ContentguardsCoreRbacUpdate for multipart/form-data ContentType.
+type ContentguardsCoreRbacUpdateMultipartRequestBody = RBACContentGuard
+
+// ContentguardsCoreRbacAddRoleJSONRequestBody defines body for ContentguardsCoreRbacAddRole for application/json ContentType.
+type ContentguardsCoreRbacAddRoleJSONRequestBody = NestedRole
+
+// ContentguardsCoreRbacAddRoleFormdataRequestBody defines body for ContentguardsCoreRbacAddRole for application/x-www-form-urlencoded ContentType.
+type ContentguardsCoreRbacAddRoleFormdataRequestBody = NestedRole
+
+// ContentguardsCoreRbacAddRoleMultipartRequestBody defines body for ContentguardsCoreRbacAddRole for multipart/form-data ContentType.
+type ContentguardsCoreRbacAddRoleMultipartRequestBody = NestedRole
+
+// ContentguardsCoreRbacRemoveRoleJSONRequestBody defines body for ContentguardsCoreRbacRemoveRole for application/json ContentType.
+type ContentguardsCoreRbacRemoveRoleJSONRequestBody = NestedRole
+
+// ContentguardsCoreRbacRemoveRoleFormdataRequestBody defines body for ContentguardsCoreRbacRemoveRole for application/x-www-form-urlencoded ContentType.
+type ContentguardsCoreRbacRemoveRoleFormdataRequestBody = NestedRole
+
+// ContentguardsCoreRbacRemoveRoleMultipartRequestBody defines body for ContentguardsCoreRbacRemoveRole for multipart/form-data ContentType.
+type ContentguardsCoreRbacRemoveRoleMultipartRequestBody = NestedRole
+
 // DistributionsOstreeOstreeCreateJSONRequestBody defines body for DistributionsOstreeOstreeCreate for application/json ContentType.
 type DistributionsOstreeOstreeCreateJSONRequestBody = OstreeOstreeDistribution
 
@@ -2367,6 +2606,56 @@ type ClientInterface interface {
 	ContentguardsCoreHeaderRemoveRole(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreHeaderRemoveRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	ContentguardsCoreHeaderRemoveRoleWithFormdataBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreHeaderRemoveRoleFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ContentguardsCoreRbacList request
+	ContentguardsCoreRbacList(ctx context.Context, pulpDomain string, params *ContentguardsCoreRbacListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ContentguardsCoreRbacCreateWithBody request with any body
+	ContentguardsCoreRbacCreateWithBody(ctx context.Context, pulpDomain string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ContentguardsCoreRbacCreate(ctx context.Context, pulpDomain string, body ContentguardsCoreRbacCreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ContentguardsCoreRbacCreateWithFormdataBody(ctx context.Context, pulpDomain string, body ContentguardsCoreRbacCreateFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ContentguardsCoreRbacDelete request
+	ContentguardsCoreRbacDelete(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ContentguardsCoreRbacRead request
+	ContentguardsCoreRbacRead(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, params *ContentguardsCoreRbacReadParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ContentguardsCoreRbacPartialUpdateWithBody request with any body
+	ContentguardsCoreRbacPartialUpdateWithBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ContentguardsCoreRbacPartialUpdate(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacPartialUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ContentguardsCoreRbacPartialUpdateWithFormdataBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacPartialUpdateFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ContentguardsCoreRbacUpdateWithBody request with any body
+	ContentguardsCoreRbacUpdateWithBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ContentguardsCoreRbacUpdate(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ContentguardsCoreRbacUpdateWithFormdataBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacUpdateFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ContentguardsCoreRbacAddRoleWithBody request with any body
+	ContentguardsCoreRbacAddRoleWithBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ContentguardsCoreRbacAddRole(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacAddRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ContentguardsCoreRbacAddRoleWithFormdataBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacAddRoleFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ContentguardsCoreRbacListRoles request
+	ContentguardsCoreRbacListRoles(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, params *ContentguardsCoreRbacListRolesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ContentguardsCoreRbacMyPermissions request
+	ContentguardsCoreRbacMyPermissions(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, params *ContentguardsCoreRbacMyPermissionsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ContentguardsCoreRbacRemoveRoleWithBody request with any body
+	ContentguardsCoreRbacRemoveRoleWithBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ContentguardsCoreRbacRemoveRole(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacRemoveRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ContentguardsCoreRbacRemoveRoleWithFormdataBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacRemoveRoleFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DistributionsOstreeOstreeList request
 	DistributionsOstreeOstreeList(ctx context.Context, pulpDomain string, params *DistributionsOstreeOstreeListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -3188,6 +3477,246 @@ func (c *Client) ContentguardsCoreHeaderRemoveRole(ctx context.Context, pulpDoma
 
 func (c *Client) ContentguardsCoreHeaderRemoveRoleWithFormdataBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreHeaderRemoveRoleFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewContentguardsCoreHeaderRemoveRoleRequestWithFormdataBody(c.Server, pulpDomain, pulpId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacList(ctx context.Context, pulpDomain string, params *ContentguardsCoreRbacListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacListRequest(c.Server, pulpDomain, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacCreateWithBody(ctx context.Context, pulpDomain string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacCreateRequestWithBody(c.Server, pulpDomain, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacCreate(ctx context.Context, pulpDomain string, body ContentguardsCoreRbacCreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacCreateRequest(c.Server, pulpDomain, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacCreateWithFormdataBody(ctx context.Context, pulpDomain string, body ContentguardsCoreRbacCreateFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacCreateRequestWithFormdataBody(c.Server, pulpDomain, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacDelete(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacDeleteRequest(c.Server, pulpDomain, pulpId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacRead(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, params *ContentguardsCoreRbacReadParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacReadRequest(c.Server, pulpDomain, pulpId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacPartialUpdateWithBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacPartialUpdateRequestWithBody(c.Server, pulpDomain, pulpId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacPartialUpdate(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacPartialUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacPartialUpdateRequest(c.Server, pulpDomain, pulpId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacPartialUpdateWithFormdataBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacPartialUpdateFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacPartialUpdateRequestWithFormdataBody(c.Server, pulpDomain, pulpId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacUpdateWithBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacUpdateRequestWithBody(c.Server, pulpDomain, pulpId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacUpdate(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacUpdateRequest(c.Server, pulpDomain, pulpId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacUpdateWithFormdataBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacUpdateFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacUpdateRequestWithFormdataBody(c.Server, pulpDomain, pulpId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacAddRoleWithBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacAddRoleRequestWithBody(c.Server, pulpDomain, pulpId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacAddRole(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacAddRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacAddRoleRequest(c.Server, pulpDomain, pulpId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacAddRoleWithFormdataBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacAddRoleFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacAddRoleRequestWithFormdataBody(c.Server, pulpDomain, pulpId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacListRoles(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, params *ContentguardsCoreRbacListRolesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacListRolesRequest(c.Server, pulpDomain, pulpId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacMyPermissions(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, params *ContentguardsCoreRbacMyPermissionsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacMyPermissionsRequest(c.Server, pulpDomain, pulpId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacRemoveRoleWithBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacRemoveRoleRequestWithBody(c.Server, pulpDomain, pulpId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacRemoveRole(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacRemoveRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacRemoveRoleRequest(c.Server, pulpDomain, pulpId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ContentguardsCoreRbacRemoveRoleWithFormdataBody(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacRemoveRoleFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewContentguardsCoreRbacRemoveRoleRequestWithFormdataBody(c.Server, pulpDomain, pulpId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -6943,6 +7472,914 @@ func NewContentguardsCoreHeaderRemoveRoleRequestWithBody(server string, pulpDoma
 	}
 
 	operationPath := fmt.Sprintf("/api/pulp/%s/api/v3/contentguards/core/header/%s/remove_role/", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewContentguardsCoreRbacListRequest generates requests for ContentguardsCoreRbacList
+func NewContentguardsCoreRbacListRequest(server string, pulpDomain string, params *ContentguardsCoreRbacListParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "pulp_domain", runtime.ParamLocationPath, pulpDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/pulp/%s/api/v3/contentguards/core/rbac/", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Name != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name", runtime.ParamLocationQuery, *params.Name); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.NameContains != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name__contains", runtime.ParamLocationQuery, *params.NameContains); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.NameIcontains != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name__icontains", runtime.ParamLocationQuery, *params.NameIcontains); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.NameIexact != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name__iexact", runtime.ParamLocationQuery, *params.NameIexact); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.NameIn != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "name__in", runtime.ParamLocationQuery, *params.NameIn); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.NameIregex != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name__iregex", runtime.ParamLocationQuery, *params.NameIregex); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.NameIstartswith != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name__istartswith", runtime.ParamLocationQuery, *params.NameIstartswith); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.NameRegex != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name__regex", runtime.ParamLocationQuery, *params.NameRegex); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.NameStartswith != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name__startswith", runtime.ParamLocationQuery, *params.NameStartswith); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Offset != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "offset", runtime.ParamLocationQuery, *params.Offset); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Ordering != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "ordering", runtime.ParamLocationQuery, *params.Ordering); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PulpHrefIn != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "pulp_href__in", runtime.ParamLocationQuery, *params.PulpHrefIn); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PulpIdIn != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "pulp_id__in", runtime.ParamLocationQuery, *params.PulpIdIn); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Q != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "q", runtime.ParamLocationQuery, *params.Q); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Fields != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "fields", runtime.ParamLocationQuery, *params.Fields); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ExcludeFields != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "exclude_fields", runtime.ParamLocationQuery, *params.ExcludeFields); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewContentguardsCoreRbacCreateRequest calls the generic ContentguardsCoreRbacCreate builder with application/json body
+func NewContentguardsCoreRbacCreateRequest(server string, pulpDomain string, body ContentguardsCoreRbacCreateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewContentguardsCoreRbacCreateRequestWithBody(server, pulpDomain, "application/json", bodyReader)
+}
+
+// NewContentguardsCoreRbacCreateRequestWithFormdataBody calls the generic ContentguardsCoreRbacCreate builder with application/x-www-form-urlencoded body
+func NewContentguardsCoreRbacCreateRequestWithFormdataBody(server string, pulpDomain string, body ContentguardsCoreRbacCreateFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewContentguardsCoreRbacCreateRequestWithBody(server, pulpDomain, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewContentguardsCoreRbacCreateRequestWithBody generates requests for ContentguardsCoreRbacCreate with any type of body
+func NewContentguardsCoreRbacCreateRequestWithBody(server string, pulpDomain string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "pulp_domain", runtime.ParamLocationPath, pulpDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/pulp/%s/api/v3/contentguards/core/rbac/", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewContentguardsCoreRbacDeleteRequest generates requests for ContentguardsCoreRbacDelete
+func NewContentguardsCoreRbacDeleteRequest(server string, pulpDomain string, pulpId openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "pulp_domain", runtime.ParamLocationPath, pulpDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "pulp_id", runtime.ParamLocationPath, pulpId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/pulp/%s/api/v3/contentguards/core/rbac/%s/", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewContentguardsCoreRbacReadRequest generates requests for ContentguardsCoreRbacRead
+func NewContentguardsCoreRbacReadRequest(server string, pulpDomain string, pulpId openapi_types.UUID, params *ContentguardsCoreRbacReadParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "pulp_domain", runtime.ParamLocationPath, pulpDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "pulp_id", runtime.ParamLocationPath, pulpId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/pulp/%s/api/v3/contentguards/core/rbac/%s/", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Fields != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "fields", runtime.ParamLocationQuery, *params.Fields); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ExcludeFields != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "exclude_fields", runtime.ParamLocationQuery, *params.ExcludeFields); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewContentguardsCoreRbacPartialUpdateRequest calls the generic ContentguardsCoreRbacPartialUpdate builder with application/json body
+func NewContentguardsCoreRbacPartialUpdateRequest(server string, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacPartialUpdateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewContentguardsCoreRbacPartialUpdateRequestWithBody(server, pulpDomain, pulpId, "application/json", bodyReader)
+}
+
+// NewContentguardsCoreRbacPartialUpdateRequestWithFormdataBody calls the generic ContentguardsCoreRbacPartialUpdate builder with application/x-www-form-urlencoded body
+func NewContentguardsCoreRbacPartialUpdateRequestWithFormdataBody(server string, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacPartialUpdateFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewContentguardsCoreRbacPartialUpdateRequestWithBody(server, pulpDomain, pulpId, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewContentguardsCoreRbacPartialUpdateRequestWithBody generates requests for ContentguardsCoreRbacPartialUpdate with any type of body
+func NewContentguardsCoreRbacPartialUpdateRequestWithBody(server string, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "pulp_domain", runtime.ParamLocationPath, pulpDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "pulp_id", runtime.ParamLocationPath, pulpId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/pulp/%s/api/v3/contentguards/core/rbac/%s/", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewContentguardsCoreRbacUpdateRequest calls the generic ContentguardsCoreRbacUpdate builder with application/json body
+func NewContentguardsCoreRbacUpdateRequest(server string, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacUpdateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewContentguardsCoreRbacUpdateRequestWithBody(server, pulpDomain, pulpId, "application/json", bodyReader)
+}
+
+// NewContentguardsCoreRbacUpdateRequestWithFormdataBody calls the generic ContentguardsCoreRbacUpdate builder with application/x-www-form-urlencoded body
+func NewContentguardsCoreRbacUpdateRequestWithFormdataBody(server string, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacUpdateFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewContentguardsCoreRbacUpdateRequestWithBody(server, pulpDomain, pulpId, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewContentguardsCoreRbacUpdateRequestWithBody generates requests for ContentguardsCoreRbacUpdate with any type of body
+func NewContentguardsCoreRbacUpdateRequestWithBody(server string, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "pulp_domain", runtime.ParamLocationPath, pulpDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "pulp_id", runtime.ParamLocationPath, pulpId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/pulp/%s/api/v3/contentguards/core/rbac/%s/", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewContentguardsCoreRbacAddRoleRequest calls the generic ContentguardsCoreRbacAddRole builder with application/json body
+func NewContentguardsCoreRbacAddRoleRequest(server string, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacAddRoleJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewContentguardsCoreRbacAddRoleRequestWithBody(server, pulpDomain, pulpId, "application/json", bodyReader)
+}
+
+// NewContentguardsCoreRbacAddRoleRequestWithFormdataBody calls the generic ContentguardsCoreRbacAddRole builder with application/x-www-form-urlencoded body
+func NewContentguardsCoreRbacAddRoleRequestWithFormdataBody(server string, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacAddRoleFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewContentguardsCoreRbacAddRoleRequestWithBody(server, pulpDomain, pulpId, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewContentguardsCoreRbacAddRoleRequestWithBody generates requests for ContentguardsCoreRbacAddRole with any type of body
+func NewContentguardsCoreRbacAddRoleRequestWithBody(server string, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "pulp_domain", runtime.ParamLocationPath, pulpDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "pulp_id", runtime.ParamLocationPath, pulpId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/pulp/%s/api/v3/contentguards/core/rbac/%s/add_role/", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewContentguardsCoreRbacListRolesRequest generates requests for ContentguardsCoreRbacListRoles
+func NewContentguardsCoreRbacListRolesRequest(server string, pulpDomain string, pulpId openapi_types.UUID, params *ContentguardsCoreRbacListRolesParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "pulp_domain", runtime.ParamLocationPath, pulpDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "pulp_id", runtime.ParamLocationPath, pulpId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/pulp/%s/api/v3/contentguards/core/rbac/%s/list_roles/", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Fields != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "fields", runtime.ParamLocationQuery, *params.Fields); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ExcludeFields != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "exclude_fields", runtime.ParamLocationQuery, *params.ExcludeFields); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewContentguardsCoreRbacMyPermissionsRequest generates requests for ContentguardsCoreRbacMyPermissions
+func NewContentguardsCoreRbacMyPermissionsRequest(server string, pulpDomain string, pulpId openapi_types.UUID, params *ContentguardsCoreRbacMyPermissionsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "pulp_domain", runtime.ParamLocationPath, pulpDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "pulp_id", runtime.ParamLocationPath, pulpId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/pulp/%s/api/v3/contentguards/core/rbac/%s/my_permissions/", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Fields != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "fields", runtime.ParamLocationQuery, *params.Fields); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ExcludeFields != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "exclude_fields", runtime.ParamLocationQuery, *params.ExcludeFields); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewContentguardsCoreRbacRemoveRoleRequest calls the generic ContentguardsCoreRbacRemoveRole builder with application/json body
+func NewContentguardsCoreRbacRemoveRoleRequest(server string, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacRemoveRoleJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewContentguardsCoreRbacRemoveRoleRequestWithBody(server, pulpDomain, pulpId, "application/json", bodyReader)
+}
+
+// NewContentguardsCoreRbacRemoveRoleRequestWithFormdataBody calls the generic ContentguardsCoreRbacRemoveRole builder with application/x-www-form-urlencoded body
+func NewContentguardsCoreRbacRemoveRoleRequestWithFormdataBody(server string, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacRemoveRoleFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewContentguardsCoreRbacRemoveRoleRequestWithBody(server, pulpDomain, pulpId, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewContentguardsCoreRbacRemoveRoleRequestWithBody generates requests for ContentguardsCoreRbacRemoveRole with any type of body
+func NewContentguardsCoreRbacRemoveRoleRequestWithBody(server string, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "pulp_domain", runtime.ParamLocationPath, pulpDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "pulp_id", runtime.ParamLocationPath, pulpId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/pulp/%s/api/v3/contentguards/core/rbac/%s/remove_role/", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -11667,6 +13104,56 @@ type ClientWithResponsesInterface interface {
 
 	ContentguardsCoreHeaderRemoveRoleWithFormdataBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreHeaderRemoveRoleFormdataRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreHeaderRemoveRoleResponse, error)
 
+	// ContentguardsCoreRbacListWithResponse request
+	ContentguardsCoreRbacListWithResponse(ctx context.Context, pulpDomain string, params *ContentguardsCoreRbacListParams, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacListResponse, error)
+
+	// ContentguardsCoreRbacCreateWithBodyWithResponse request with any body
+	ContentguardsCoreRbacCreateWithBodyWithResponse(ctx context.Context, pulpDomain string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacCreateResponse, error)
+
+	ContentguardsCoreRbacCreateWithResponse(ctx context.Context, pulpDomain string, body ContentguardsCoreRbacCreateJSONRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacCreateResponse, error)
+
+	ContentguardsCoreRbacCreateWithFormdataBodyWithResponse(ctx context.Context, pulpDomain string, body ContentguardsCoreRbacCreateFormdataRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacCreateResponse, error)
+
+	// ContentguardsCoreRbacDeleteWithResponse request
+	ContentguardsCoreRbacDeleteWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacDeleteResponse, error)
+
+	// ContentguardsCoreRbacReadWithResponse request
+	ContentguardsCoreRbacReadWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, params *ContentguardsCoreRbacReadParams, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacReadResponse, error)
+
+	// ContentguardsCoreRbacPartialUpdateWithBodyWithResponse request with any body
+	ContentguardsCoreRbacPartialUpdateWithBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacPartialUpdateResponse, error)
+
+	ContentguardsCoreRbacPartialUpdateWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacPartialUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacPartialUpdateResponse, error)
+
+	ContentguardsCoreRbacPartialUpdateWithFormdataBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacPartialUpdateFormdataRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacPartialUpdateResponse, error)
+
+	// ContentguardsCoreRbacUpdateWithBodyWithResponse request with any body
+	ContentguardsCoreRbacUpdateWithBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacUpdateResponse, error)
+
+	ContentguardsCoreRbacUpdateWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacUpdateResponse, error)
+
+	ContentguardsCoreRbacUpdateWithFormdataBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacUpdateFormdataRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacUpdateResponse, error)
+
+	// ContentguardsCoreRbacAddRoleWithBodyWithResponse request with any body
+	ContentguardsCoreRbacAddRoleWithBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacAddRoleResponse, error)
+
+	ContentguardsCoreRbacAddRoleWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacAddRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacAddRoleResponse, error)
+
+	ContentguardsCoreRbacAddRoleWithFormdataBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacAddRoleFormdataRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacAddRoleResponse, error)
+
+	// ContentguardsCoreRbacListRolesWithResponse request
+	ContentguardsCoreRbacListRolesWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, params *ContentguardsCoreRbacListRolesParams, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacListRolesResponse, error)
+
+	// ContentguardsCoreRbacMyPermissionsWithResponse request
+	ContentguardsCoreRbacMyPermissionsWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, params *ContentguardsCoreRbacMyPermissionsParams, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacMyPermissionsResponse, error)
+
+	// ContentguardsCoreRbacRemoveRoleWithBodyWithResponse request with any body
+	ContentguardsCoreRbacRemoveRoleWithBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacRemoveRoleResponse, error)
+
+	ContentguardsCoreRbacRemoveRoleWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacRemoveRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacRemoveRoleResponse, error)
+
+	ContentguardsCoreRbacRemoveRoleWithFormdataBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacRemoveRoleFormdataRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacRemoveRoleResponse, error)
+
 	// DistributionsOstreeOstreeListWithResponse request
 	DistributionsOstreeOstreeListWithResponse(ctx context.Context, pulpDomain string, params *DistributionsOstreeOstreeListParams, reqEditors ...RequestEditorFn) (*DistributionsOstreeOstreeListResponse, error)
 
@@ -12482,6 +13969,225 @@ func (r ContentguardsCoreHeaderRemoveRoleResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ContentguardsCoreHeaderRemoveRoleResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ContentguardsCoreRbacListResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *PaginatedRBACContentGuardResponseList
+}
+
+// Status returns HTTPResponse.Status
+func (r ContentguardsCoreRbacListResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ContentguardsCoreRbacListResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ContentguardsCoreRbacCreateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *RBACContentGuardResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r ContentguardsCoreRbacCreateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ContentguardsCoreRbacCreateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ContentguardsCoreRbacDeleteResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r ContentguardsCoreRbacDeleteResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ContentguardsCoreRbacDeleteResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ContentguardsCoreRbacReadResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *RBACContentGuardResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r ContentguardsCoreRbacReadResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ContentguardsCoreRbacReadResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ContentguardsCoreRbacPartialUpdateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *RBACContentGuardResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r ContentguardsCoreRbacPartialUpdateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ContentguardsCoreRbacPartialUpdateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ContentguardsCoreRbacUpdateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *RBACContentGuardResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r ContentguardsCoreRbacUpdateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ContentguardsCoreRbacUpdateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ContentguardsCoreRbacAddRoleResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *NestedRoleResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r ContentguardsCoreRbacAddRoleResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ContentguardsCoreRbacAddRoleResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ContentguardsCoreRbacListRolesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ObjectRolesResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r ContentguardsCoreRbacListRolesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ContentguardsCoreRbacListRolesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ContentguardsCoreRbacMyPermissionsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *MyPermissionsResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r ContentguardsCoreRbacMyPermissionsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ContentguardsCoreRbacMyPermissionsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ContentguardsCoreRbacRemoveRoleResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *NestedRoleResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r ContentguardsCoreRbacRemoveRoleResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ContentguardsCoreRbacRemoveRoleResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -13859,6 +15565,176 @@ func (c *ClientWithResponses) ContentguardsCoreHeaderRemoveRoleWithFormdataBodyW
 		return nil, err
 	}
 	return ParseContentguardsCoreHeaderRemoveRoleResponse(rsp)
+}
+
+// ContentguardsCoreRbacListWithResponse request returning *ContentguardsCoreRbacListResponse
+func (c *ClientWithResponses) ContentguardsCoreRbacListWithResponse(ctx context.Context, pulpDomain string, params *ContentguardsCoreRbacListParams, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacListResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacList(ctx, pulpDomain, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacListResponse(rsp)
+}
+
+// ContentguardsCoreRbacCreateWithBodyWithResponse request with arbitrary body returning *ContentguardsCoreRbacCreateResponse
+func (c *ClientWithResponses) ContentguardsCoreRbacCreateWithBodyWithResponse(ctx context.Context, pulpDomain string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacCreateResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacCreateWithBody(ctx, pulpDomain, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacCreateResponse(rsp)
+}
+
+func (c *ClientWithResponses) ContentguardsCoreRbacCreateWithResponse(ctx context.Context, pulpDomain string, body ContentguardsCoreRbacCreateJSONRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacCreateResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacCreate(ctx, pulpDomain, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacCreateResponse(rsp)
+}
+
+func (c *ClientWithResponses) ContentguardsCoreRbacCreateWithFormdataBodyWithResponse(ctx context.Context, pulpDomain string, body ContentguardsCoreRbacCreateFormdataRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacCreateResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacCreateWithFormdataBody(ctx, pulpDomain, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacCreateResponse(rsp)
+}
+
+// ContentguardsCoreRbacDeleteWithResponse request returning *ContentguardsCoreRbacDeleteResponse
+func (c *ClientWithResponses) ContentguardsCoreRbacDeleteWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacDeleteResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacDelete(ctx, pulpDomain, pulpId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacDeleteResponse(rsp)
+}
+
+// ContentguardsCoreRbacReadWithResponse request returning *ContentguardsCoreRbacReadResponse
+func (c *ClientWithResponses) ContentguardsCoreRbacReadWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, params *ContentguardsCoreRbacReadParams, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacReadResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacRead(ctx, pulpDomain, pulpId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacReadResponse(rsp)
+}
+
+// ContentguardsCoreRbacPartialUpdateWithBodyWithResponse request with arbitrary body returning *ContentguardsCoreRbacPartialUpdateResponse
+func (c *ClientWithResponses) ContentguardsCoreRbacPartialUpdateWithBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacPartialUpdateResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacPartialUpdateWithBody(ctx, pulpDomain, pulpId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacPartialUpdateResponse(rsp)
+}
+
+func (c *ClientWithResponses) ContentguardsCoreRbacPartialUpdateWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacPartialUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacPartialUpdateResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacPartialUpdate(ctx, pulpDomain, pulpId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacPartialUpdateResponse(rsp)
+}
+
+func (c *ClientWithResponses) ContentguardsCoreRbacPartialUpdateWithFormdataBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacPartialUpdateFormdataRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacPartialUpdateResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacPartialUpdateWithFormdataBody(ctx, pulpDomain, pulpId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacPartialUpdateResponse(rsp)
+}
+
+// ContentguardsCoreRbacUpdateWithBodyWithResponse request with arbitrary body returning *ContentguardsCoreRbacUpdateResponse
+func (c *ClientWithResponses) ContentguardsCoreRbacUpdateWithBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacUpdateResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacUpdateWithBody(ctx, pulpDomain, pulpId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacUpdateResponse(rsp)
+}
+
+func (c *ClientWithResponses) ContentguardsCoreRbacUpdateWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacUpdateResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacUpdate(ctx, pulpDomain, pulpId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacUpdateResponse(rsp)
+}
+
+func (c *ClientWithResponses) ContentguardsCoreRbacUpdateWithFormdataBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacUpdateFormdataRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacUpdateResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacUpdateWithFormdataBody(ctx, pulpDomain, pulpId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacUpdateResponse(rsp)
+}
+
+// ContentguardsCoreRbacAddRoleWithBodyWithResponse request with arbitrary body returning *ContentguardsCoreRbacAddRoleResponse
+func (c *ClientWithResponses) ContentguardsCoreRbacAddRoleWithBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacAddRoleResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacAddRoleWithBody(ctx, pulpDomain, pulpId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacAddRoleResponse(rsp)
+}
+
+func (c *ClientWithResponses) ContentguardsCoreRbacAddRoleWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacAddRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacAddRoleResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacAddRole(ctx, pulpDomain, pulpId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacAddRoleResponse(rsp)
+}
+
+func (c *ClientWithResponses) ContentguardsCoreRbacAddRoleWithFormdataBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacAddRoleFormdataRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacAddRoleResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacAddRoleWithFormdataBody(ctx, pulpDomain, pulpId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacAddRoleResponse(rsp)
+}
+
+// ContentguardsCoreRbacListRolesWithResponse request returning *ContentguardsCoreRbacListRolesResponse
+func (c *ClientWithResponses) ContentguardsCoreRbacListRolesWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, params *ContentguardsCoreRbacListRolesParams, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacListRolesResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacListRoles(ctx, pulpDomain, pulpId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacListRolesResponse(rsp)
+}
+
+// ContentguardsCoreRbacMyPermissionsWithResponse request returning *ContentguardsCoreRbacMyPermissionsResponse
+func (c *ClientWithResponses) ContentguardsCoreRbacMyPermissionsWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, params *ContentguardsCoreRbacMyPermissionsParams, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacMyPermissionsResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacMyPermissions(ctx, pulpDomain, pulpId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacMyPermissionsResponse(rsp)
+}
+
+// ContentguardsCoreRbacRemoveRoleWithBodyWithResponse request with arbitrary body returning *ContentguardsCoreRbacRemoveRoleResponse
+func (c *ClientWithResponses) ContentguardsCoreRbacRemoveRoleWithBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacRemoveRoleResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacRemoveRoleWithBody(ctx, pulpDomain, pulpId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacRemoveRoleResponse(rsp)
+}
+
+func (c *ClientWithResponses) ContentguardsCoreRbacRemoveRoleWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacRemoveRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacRemoveRoleResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacRemoveRole(ctx, pulpDomain, pulpId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacRemoveRoleResponse(rsp)
+}
+
+func (c *ClientWithResponses) ContentguardsCoreRbacRemoveRoleWithFormdataBodyWithResponse(ctx context.Context, pulpDomain string, pulpId openapi_types.UUID, body ContentguardsCoreRbacRemoveRoleFormdataRequestBody, reqEditors ...RequestEditorFn) (*ContentguardsCoreRbacRemoveRoleResponse, error) {
+	rsp, err := c.ContentguardsCoreRbacRemoveRoleWithFormdataBody(ctx, pulpDomain, pulpId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseContentguardsCoreRbacRemoveRoleResponse(rsp)
 }
 
 // DistributionsOstreeOstreeListWithResponse request returning *DistributionsOstreeOstreeListResponse
@@ -15303,6 +17179,256 @@ func ParseContentguardsCoreHeaderRemoveRoleResponse(rsp *http.Response) (*Conten
 	}
 
 	response := &ContentguardsCoreHeaderRemoveRoleResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest NestedRoleResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseContentguardsCoreRbacListResponse parses an HTTP response from a ContentguardsCoreRbacListWithResponse call
+func ParseContentguardsCoreRbacListResponse(rsp *http.Response) (*ContentguardsCoreRbacListResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ContentguardsCoreRbacListResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest PaginatedRBACContentGuardResponseList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseContentguardsCoreRbacCreateResponse parses an HTTP response from a ContentguardsCoreRbacCreateWithResponse call
+func ParseContentguardsCoreRbacCreateResponse(rsp *http.Response) (*ContentguardsCoreRbacCreateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ContentguardsCoreRbacCreateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest RBACContentGuardResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseContentguardsCoreRbacDeleteResponse parses an HTTP response from a ContentguardsCoreRbacDeleteWithResponse call
+func ParseContentguardsCoreRbacDeleteResponse(rsp *http.Response) (*ContentguardsCoreRbacDeleteResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ContentguardsCoreRbacDeleteResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseContentguardsCoreRbacReadResponse parses an HTTP response from a ContentguardsCoreRbacReadWithResponse call
+func ParseContentguardsCoreRbacReadResponse(rsp *http.Response) (*ContentguardsCoreRbacReadResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ContentguardsCoreRbacReadResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RBACContentGuardResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseContentguardsCoreRbacPartialUpdateResponse parses an HTTP response from a ContentguardsCoreRbacPartialUpdateWithResponse call
+func ParseContentguardsCoreRbacPartialUpdateResponse(rsp *http.Response) (*ContentguardsCoreRbacPartialUpdateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ContentguardsCoreRbacPartialUpdateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RBACContentGuardResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseContentguardsCoreRbacUpdateResponse parses an HTTP response from a ContentguardsCoreRbacUpdateWithResponse call
+func ParseContentguardsCoreRbacUpdateResponse(rsp *http.Response) (*ContentguardsCoreRbacUpdateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ContentguardsCoreRbacUpdateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RBACContentGuardResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseContentguardsCoreRbacAddRoleResponse parses an HTTP response from a ContentguardsCoreRbacAddRoleWithResponse call
+func ParseContentguardsCoreRbacAddRoleResponse(rsp *http.Response) (*ContentguardsCoreRbacAddRoleResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ContentguardsCoreRbacAddRoleResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest NestedRoleResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseContentguardsCoreRbacListRolesResponse parses an HTTP response from a ContentguardsCoreRbacListRolesWithResponse call
+func ParseContentguardsCoreRbacListRolesResponse(rsp *http.Response) (*ContentguardsCoreRbacListRolesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ContentguardsCoreRbacListRolesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ObjectRolesResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseContentguardsCoreRbacMyPermissionsResponse parses an HTTP response from a ContentguardsCoreRbacMyPermissionsWithResponse call
+func ParseContentguardsCoreRbacMyPermissionsResponse(rsp *http.Response) (*ContentguardsCoreRbacMyPermissionsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ContentguardsCoreRbacMyPermissionsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest MyPermissionsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseContentguardsCoreRbacRemoveRoleResponse parses an HTTP response from a ContentguardsCoreRbacRemoveRoleWithResponse call
+func ParseContentguardsCoreRbacRemoveRoleResponse(rsp *http.Response) (*ContentguardsCoreRbacRemoveRoleResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ContentguardsCoreRbacRemoveRoleResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/pkg/clients/pulp/pulp_config.yaml
+++ b/pkg/clients/pulp/pulp_config.yaml
@@ -12,5 +12,6 @@ output-options:
     - "Repositories: Ostree"
     - "Distributions: Ostree"
     - "Content: Content"
+    - "Contentguards: Rbac"
     - "Contentguards: Header"
     - "Contentguards: Composite"

--- a/pkg/clients/pulp/pulp_openapi.json
+++ b/pkg/clients/pulp/pulp_openapi.json
@@ -17,12 +17,13 @@
             "url": "https://pulp.plan.io/attachments/download/517478/pulp_logo_word_rectangle.svg"
         },
         "x-pulp-app-versions": {
-            "core": "3.54.0",
+            "core": "3.54.1",
             "gem": "0.5.1",
-            "ostree": "2.3.0",
+            "ostree": "2.4.3",
+            "python": "3.12.0",
             "rpm": "3.25.3",
-            "certguard": "3.54.0",
-            "file": "3.54.0"
+            "certguard": "3.54.1",
+            "file": "3.54.1"
         },
         "x-pulp-domain-enabled": true
     },
@@ -2860,6 +2861,7 @@
                                 "ostree.object",
                                 "ostree.refs",
                                 "ostree.summary",
+                                "python.python",
                                 "rpm.advisory",
                                 "rpm.distribution_tree",
                                 "rpm.modulemd",
@@ -2873,7 +2875,7 @@
                                 "rpm.repo_metadata_file"
                             ]
                         },
-                        "description": "Pulp type\n\n* `core.publishedmetadata` - core.publishedmetadata\n* `gem.gem` - gem.gem\n* `ostree.object` - ostree.object\n* `ostree.commit` - ostree.commit\n* `ostree.refs` - ostree.refs\n* `ostree.content` - ostree.content\n* `ostree.config` - ostree.config\n* `ostree.summary` - ostree.summary\n* `rpm.advisory` - rpm.advisory\n* `rpm.packagegroup` - rpm.packagegroup\n* `rpm.packagecategory` - rpm.packagecategory\n* `rpm.packageenvironment` - rpm.packageenvironment\n* `rpm.packagelangpacks` - rpm.packagelangpacks\n* `rpm.repo_metadata_file` - rpm.repo_metadata_file\n* `rpm.distribution_tree` - rpm.distribution_tree\n* `rpm.package` - rpm.package\n* `rpm.modulemd` - rpm.modulemd\n* `rpm.modulemd_defaults` - rpm.modulemd_defaults\n* `rpm.modulemd_obsolete` - rpm.modulemd_obsolete\n* `file.file` - file.file"
+                        "description": "Pulp type\n\n* `core.publishedmetadata` - core.publishedmetadata\n* `gem.gem` - gem.gem\n* `ostree.object` - ostree.object\n* `ostree.commit` - ostree.commit\n* `ostree.refs` - ostree.refs\n* `ostree.content` - ostree.content\n* `ostree.config` - ostree.config\n* `ostree.summary` - ostree.summary\n* `python.python` - python.python\n* `rpm.advisory` - rpm.advisory\n* `rpm.packagegroup` - rpm.packagegroup\n* `rpm.packagecategory` - rpm.packagecategory\n* `rpm.packageenvironment` - rpm.packageenvironment\n* `rpm.packagelangpacks` - rpm.packagelangpacks\n* `rpm.repo_metadata_file` - rpm.repo_metadata_file\n* `rpm.distribution_tree` - rpm.distribution_tree\n* `rpm.package` - rpm.package\n* `rpm.modulemd` - rpm.modulemd\n* `rpm.modulemd_defaults` - rpm.modulemd_defaults\n* `rpm.modulemd_obsolete` - rpm.modulemd_obsolete\n* `file.file` - file.file"
                     },
                     {
                         "in": "query",
@@ -2892,6 +2894,7 @@
                                     "ostree.object",
                                     "ostree.refs",
                                     "ostree.summary",
+                                    "python.python",
                                     "rpm.advisory",
                                     "rpm.distribution_tree",
                                     "rpm.modulemd",
@@ -2906,7 +2909,7 @@
                                 ]
                             }
                         },
-                        "description": "Multiple values may be separated by commas.\n\n* `core.publishedmetadata` - core.publishedmetadata\n* `gem.gem` - gem.gem\n* `ostree.object` - ostree.object\n* `ostree.commit` - ostree.commit\n* `ostree.refs` - ostree.refs\n* `ostree.content` - ostree.content\n* `ostree.config` - ostree.config\n* `ostree.summary` - ostree.summary\n* `rpm.advisory` - rpm.advisory\n* `rpm.packagegroup` - rpm.packagegroup\n* `rpm.packagecategory` - rpm.packagecategory\n* `rpm.packageenvironment` - rpm.packageenvironment\n* `rpm.packagelangpacks` - rpm.packagelangpacks\n* `rpm.repo_metadata_file` - rpm.repo_metadata_file\n* `rpm.distribution_tree` - rpm.distribution_tree\n* `rpm.package` - rpm.package\n* `rpm.modulemd` - rpm.modulemd\n* `rpm.modulemd_defaults` - rpm.modulemd_defaults\n* `rpm.modulemd_obsolete` - rpm.modulemd_obsolete\n* `file.file` - file.file",
+                        "description": "Multiple values may be separated by commas.\n\n* `core.publishedmetadata` - core.publishedmetadata\n* `gem.gem` - gem.gem\n* `ostree.object` - ostree.object\n* `ostree.commit` - ostree.commit\n* `ostree.refs` - ostree.refs\n* `ostree.content` - ostree.content\n* `ostree.config` - ostree.config\n* `ostree.summary` - ostree.summary\n* `python.python` - python.python\n* `rpm.advisory` - rpm.advisory\n* `rpm.packagegroup` - rpm.packagegroup\n* `rpm.packagecategory` - rpm.packagecategory\n* `rpm.packageenvironment` - rpm.packageenvironment\n* `rpm.packagelangpacks` - rpm.packagelangpacks\n* `rpm.repo_metadata_file` - rpm.repo_metadata_file\n* `rpm.distribution_tree` - rpm.distribution_tree\n* `rpm.package` - rpm.package\n* `rpm.modulemd` - rpm.modulemd\n* `rpm.modulemd_defaults` - rpm.modulemd_defaults\n* `rpm.modulemd_obsolete` - rpm.modulemd_obsolete\n* `file.file` - file.file",
                         "explode": false,
                         "style": "form"
                     },
@@ -5345,6 +5348,587 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ostree.OstreeSummaryResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/content/python/packages/": {
+            "get": {
+                "operationId": "content_python_packages_list",
+                "description": "\nPythonPackageContent represents each individually installable Python package. In the Python\necosystem, this is called a Python Distribution, sometimes (ambiguously) refered to as a\npackage. In Pulp Python, we refer to it as PythonPackageContent. Each\nPythonPackageContent corresponds to a single filename, for example\n`pulpcore-3.0.0rc1-py3-none-any.whl` or `pulpcore-3.0.0rc1.tar.gz`.",
+                "summary": "List python package contents",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "author",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where author matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "author__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Filter results where author is in a comma-separated list of values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "filename",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where filename matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "filename__contains",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where filename contains value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "filename__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Filter results where filename is in a comma-separated list of values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "keywords__contains",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where keywords contains value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "keywords__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Filter results where keywords is in a comma-separated list of values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "name": "limit",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Filter results where name is in a comma-separated list of values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "name": "offset",
+                        "required": false,
+                        "in": "query",
+                        "description": "The initial index from which to return the results.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "ordering",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "-author",
+                                    "-author_email",
+                                    "-classifiers",
+                                    "-description",
+                                    "-description_content_type",
+                                    "-download_url",
+                                    "-filename",
+                                    "-home_page",
+                                    "-keywords",
+                                    "-license",
+                                    "-maintainer",
+                                    "-maintainer_email",
+                                    "-metadata_version",
+                                    "-name",
+                                    "-obsoletes_dist",
+                                    "-packagetype",
+                                    "-pk",
+                                    "-platform",
+                                    "-project_url",
+                                    "-project_urls",
+                                    "-provides_dist",
+                                    "-pulp_created",
+                                    "-pulp_id",
+                                    "-pulp_last_updated",
+                                    "-pulp_type",
+                                    "-python_version",
+                                    "-requires_dist",
+                                    "-requires_external",
+                                    "-requires_python",
+                                    "-sha256",
+                                    "-summary",
+                                    "-supported_platform",
+                                    "-timestamp_of_interest",
+                                    "-upstream_id",
+                                    "-version",
+                                    "author",
+                                    "author_email",
+                                    "classifiers",
+                                    "description",
+                                    "description_content_type",
+                                    "download_url",
+                                    "filename",
+                                    "home_page",
+                                    "keywords",
+                                    "license",
+                                    "maintainer",
+                                    "maintainer_email",
+                                    "metadata_version",
+                                    "name",
+                                    "obsoletes_dist",
+                                    "packagetype",
+                                    "pk",
+                                    "platform",
+                                    "project_url",
+                                    "project_urls",
+                                    "provides_dist",
+                                    "pulp_created",
+                                    "pulp_id",
+                                    "pulp_last_updated",
+                                    "pulp_type",
+                                    "python_version",
+                                    "requires_dist",
+                                    "requires_external",
+                                    "requires_python",
+                                    "sha256",
+                                    "summary",
+                                    "supported_platform",
+                                    "timestamp_of_interest",
+                                    "upstream_id",
+                                    "version"
+                                ]
+                            }
+                        },
+                        "description": "Ordering\n\n* `pulp_id` - Pulp id\n* `-pulp_id` - Pulp id (descending)\n* `pulp_created` - Pulp created\n* `-pulp_created` - Pulp created (descending)\n* `pulp_last_updated` - Pulp last updated\n* `-pulp_last_updated` - Pulp last updated (descending)\n* `pulp_type` - Pulp type\n* `-pulp_type` - Pulp type (descending)\n* `upstream_id` - Upstream id\n* `-upstream_id` - Upstream id (descending)\n* `timestamp_of_interest` - Timestamp of interest\n* `-timestamp_of_interest` - Timestamp of interest (descending)\n* `filename` - Filename\n* `-filename` - Filename (descending)\n* `packagetype` - Packagetype\n* `-packagetype` - Packagetype (descending)\n* `name` - Name\n* `-name` - Name (descending)\n* `version` - Version\n* `-version` - Version (descending)\n* `sha256` - Sha256\n* `-sha256` - Sha256 (descending)\n* `python_version` - Python version\n* `-python_version` - Python version (descending)\n* `metadata_version` - Metadata version\n* `-metadata_version` - Metadata version (descending)\n* `summary` - Summary\n* `-summary` - Summary (descending)\n* `description` - Description\n* `-description` - Description (descending)\n* `keywords` - Keywords\n* `-keywords` - Keywords (descending)\n* `home_page` - Home page\n* `-home_page` - Home page (descending)\n* `download_url` - Download url\n* `-download_url` - Download url (descending)\n* `author` - Author\n* `-author` - Author (descending)\n* `author_email` - Author email\n* `-author_email` - Author email (descending)\n* `maintainer` - Maintainer\n* `-maintainer` - Maintainer (descending)\n* `maintainer_email` - Maintainer email\n* `-maintainer_email` - Maintainer email (descending)\n* `license` - License\n* `-license` - License (descending)\n* `requires_python` - Requires python\n* `-requires_python` - Requires python (descending)\n* `project_url` - Project url\n* `-project_url` - Project url (descending)\n* `platform` - Platform\n* `-platform` - Platform (descending)\n* `supported_platform` - Supported platform\n* `-supported_platform` - Supported platform (descending)\n* `requires_dist` - Requires dist\n* `-requires_dist` - Requires dist (descending)\n* `provides_dist` - Provides dist\n* `-provides_dist` - Provides dist (descending)\n* `obsoletes_dist` - Obsoletes dist\n* `-obsoletes_dist` - Obsoletes dist (descending)\n* `requires_external` - Requires external\n* `-requires_external` - Requires external (descending)\n* `classifiers` - Classifiers\n* `-classifiers` - Classifiers (descending)\n* `project_urls` - Project urls\n* `-project_urls` - Project urls (descending)\n* `description_content_type` - Description content type\n* `-description_content_type` - Description content type (descending)\n* `pk` - Pk\n* `-pk` - Pk (descending)",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "orphaned_for",
+                        "schema": {
+                            "type": "number"
+                        },
+                        "description": "Minutes Content has been orphaned for. -1 uses ORPHAN_PROTECTION_TIME."
+                    },
+                    {
+                        "in": "query",
+                        "name": "packagetype",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "bdist_dmg",
+                                "bdist_dumb",
+                                "bdist_egg",
+                                "bdist_msi",
+                                "bdist_rpm",
+                                "bdist_wheel",
+                                "bdist_wininst",
+                                "sdist"
+                            ]
+                        },
+                        "description": "Filter results where packagetype matches value\n\n* `bdist_dmg` - bdist_dmg\n* `bdist_dumb` - bdist_dumb\n* `bdist_egg` - bdist_egg\n* `bdist_msi` - bdist_msi\n* `bdist_rpm` - bdist_rpm\n* `bdist_wheel` - bdist_wheel\n* `bdist_wininst` - bdist_wininst\n* `sdist` - sdist"
+                    },
+                    {
+                        "in": "query",
+                        "name": "packagetype__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Filter results where packagetype is in a comma-separated list of values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_href__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Multiple values may be separated by commas.",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_id__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "Multiple values may be separated by commas.",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "q",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "repository_version",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Repository Version referenced by HREF"
+                    },
+                    {
+                        "in": "query",
+                        "name": "repository_version_added",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Repository Version referenced by HREF"
+                    },
+                    {
+                        "in": "query",
+                        "name": "repository_version_removed",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Repository Version referenced by HREF"
+                    },
+                    {
+                        "in": "query",
+                        "name": "requires_python",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where requires_python matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "requires_python__contains",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where requires_python contains value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "requires_python__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Filter results where requires_python is in a comma-separated list of values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "sha256",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where sha256 matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "sha256__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Filter results where sha256 is in a comma-separated list of values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "version",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where version matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "version__gt",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where version is greater than value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "version__gte",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where version is greater than or equal to value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "version__lt",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where version is less than value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "version__lte",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where version is less than or equal to value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Content: Packages"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Paginatedpython.PythonPackageContentResponseList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "content_python_packages_create",
+                "description": "Trigger an asynchronous task to create content,optionally create new repository version.",
+                "summary": "Create a python package content",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    }
+                ],
+                "tags": [
+                    "Content: Packages"
+                ],
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonPackageContent"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonPackageContent"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AsyncOperationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/content/python/packages/{pulp_id}/": {
+            "get": {
+                "operationId": "content_python_packages_read",
+                "description": "\nPythonPackageContent represents each individually installable Python package. In the Python\necosystem, this is called a Python Distribution, sometimes (ambiguously) refered to as a\npackage. In Pulp Python, we refer to it as PythonPackageContent. Each\nPythonPackageContent corresponds to a single filename, for example\n`pulpcore-3.0.0rc1-py3-none-any.whl` or `pulpcore-3.0.0rc1.tar.gz`.",
+                "summary": "Inspect a python package content",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python package content.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Content: Packages"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/python.PythonPackageContentResponse"
                                 }
                             }
                         },
@@ -14044,10 +14628,11 @@
                                 "file.file",
                                 "gem.gem",
                                 "ostree.ostree",
+                                "python.python",
                                 "rpm.rpm"
                             ]
                         },
-                        "description": "Pulp type\n\n* `core.artifact` - core.artifact\n* `gem.gem` - gem.gem\n* `ostree.ostree` - ostree.ostree\n* `rpm.rpm` - rpm.rpm\n* `file.file` - file.file"
+                        "description": "Pulp type\n\n* `core.artifact` - core.artifact\n* `gem.gem` - gem.gem\n* `ostree.ostree` - ostree.ostree\n* `python.python` - python.python\n* `rpm.rpm` - rpm.rpm\n* `file.file` - file.file"
                     },
                     {
                         "in": "query",
@@ -14061,11 +14646,12 @@
                                     "file.file",
                                     "gem.gem",
                                     "ostree.ostree",
+                                    "python.python",
                                     "rpm.rpm"
                                 ]
                             }
                         },
-                        "description": "Multiple values may be separated by commas.\n\n* `core.artifact` - core.artifact\n* `gem.gem` - gem.gem\n* `ostree.ostree` - ostree.ostree\n* `rpm.rpm` - rpm.rpm\n* `file.file` - file.file",
+                        "description": "Multiple values may be separated by commas.\n\n* `core.artifact` - core.artifact\n* `gem.gem` - gem.gem\n* `ostree.ostree` - ostree.ostree\n* `python.python` - python.python\n* `rpm.rpm` - rpm.rpm\n* `file.file` - file.file",
                         "explode": false,
                         "style": "form"
                     },
@@ -17750,6 +18336,1092 @@
                 ],
                 "tags": [
                     "Distributions: Ostree"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UnsetLabel"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UnsetLabel"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UnsetLabel"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UnsetLabelResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/distributions/python/pypi/": {
+            "get": {
+                "operationId": "distributions_python_pypi_list",
+                "description": "\nPulp Python Distributions are used to distribute Python content from\nPython Repositories or\nPython Publications.  Pulp Python\nDistributions should not be confused with \"Python Distribution\" as defined by the Python\ncommunity. In Pulp usage, Python content is referred to as Python Package Content.",
+                "summary": "List python distributions",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "base_path",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where base_path matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "base_path__contains",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where base_path contains value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "base_path__icontains",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where base_path contains value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "base_path__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Filter results where base_path is in a comma-separated list of values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "name": "limit",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__contains",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name contains value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__icontains",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name contains value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__iexact",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Filter results where name is in a comma-separated list of values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__iregex",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name matches regex value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__istartswith",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name starts with value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__regex",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name matches regex value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__startswith",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name starts with value"
+                    },
+                    {
+                        "name": "offset",
+                        "required": false,
+                        "in": "query",
+                        "description": "The initial index from which to return the results.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "ordering",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "-base_path",
+                                    "-hidden",
+                                    "-name",
+                                    "-pk",
+                                    "-pulp_created",
+                                    "-pulp_id",
+                                    "-pulp_labels",
+                                    "-pulp_last_updated",
+                                    "-pulp_type",
+                                    "base_path",
+                                    "hidden",
+                                    "name",
+                                    "pk",
+                                    "pulp_created",
+                                    "pulp_id",
+                                    "pulp_labels",
+                                    "pulp_last_updated",
+                                    "pulp_type"
+                                ]
+                            }
+                        },
+                        "description": "Ordering\n\n* `pulp_id` - Pulp id\n* `-pulp_id` - Pulp id (descending)\n* `pulp_created` - Pulp created\n* `-pulp_created` - Pulp created (descending)\n* `pulp_last_updated` - Pulp last updated\n* `-pulp_last_updated` - Pulp last updated (descending)\n* `pulp_type` - Pulp type\n* `-pulp_type` - Pulp type (descending)\n* `name` - Name\n* `-name` - Name (descending)\n* `pulp_labels` - Pulp labels\n* `-pulp_labels` - Pulp labels (descending)\n* `base_path` - Base path\n* `-base_path` - Base path (descending)\n* `hidden` - Hidden\n* `-hidden` - Hidden (descending)\n* `pk` - Pk\n* `-pk` - Pk (descending)",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_href__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Multiple values may be separated by commas.",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_id__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "Multiple values may be separated by commas.",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_label_select",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter labels by search string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "q",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "repository",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "Filter results where repository matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "repository__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "Filter results where repository is in a comma-separated list of values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "with_content",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter distributions based on the content served by them"
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Distributions: Pypi"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Paginatedpython.PythonDistributionResponseList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "distributions_python_pypi_create",
+                "description": "Trigger an asynchronous create task",
+                "summary": "Create a python distribution",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    }
+                ],
+                "tags": [
+                    "Distributions: Pypi"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonDistribution"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonDistribution"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonDistribution"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AsyncOperationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/distributions/python/pypi/{pulp_id}/": {
+            "get": {
+                "operationId": "distributions_python_pypi_read",
+                "description": "\nPulp Python Distributions are used to distribute Python content from\nPython Repositories or\nPython Publications.  Pulp Python\nDistributions should not be confused with \"Python Distribution\" as defined by the Python\ncommunity. In Pulp usage, Python content is referred to as Python Package Content.",
+                "summary": "Inspect a python distribution",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python distribution.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Distributions: Pypi"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/python.PythonDistributionResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "distributions_python_pypi_update",
+                "description": "Trigger an asynchronous update task",
+                "summary": "Update a python distribution",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python distribution.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Distributions: Pypi"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonDistribution"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonDistribution"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonDistribution"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AsyncOperationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "distributions_python_pypi_partial_update",
+                "description": "Trigger an asynchronous partial update task",
+                "summary": "Update a python distribution",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python distribution.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Distributions: Pypi"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Patchedpython.PythonDistribution"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Patchedpython.PythonDistribution"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Patchedpython.PythonDistribution"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AsyncOperationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "distributions_python_pypi_delete",
+                "description": "Trigger an asynchronous delete task",
+                "summary": "Delete a python distribution",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python distribution.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Distributions: Pypi"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AsyncOperationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/distributions/python/pypi/{pulp_id}/add_role/": {
+            "post": {
+                "operationId": "distributions_python_pypi_add_role",
+                "description": "Add a role for this object to users/groups.",
+                "summary": "Add a role",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python distribution.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Distributions: Pypi"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NestedRoleResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/distributions/python/pypi/{pulp_id}/list_roles/": {
+            "get": {
+                "operationId": "distributions_python_pypi_list_roles",
+                "description": "List roles assigned to this object.",
+                "summary": "List roles",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python distribution.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Distributions: Pypi"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ObjectRolesResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/distributions/python/pypi/{pulp_id}/my_permissions/": {
+            "get": {
+                "operationId": "distributions_python_pypi_my_permissions",
+                "description": "List permissions available to the current user on this object.",
+                "summary": "List user permissions",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python distribution.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Distributions: Pypi"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MyPermissionsResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/distributions/python/pypi/{pulp_id}/remove_role/": {
+            "post": {
+                "operationId": "distributions_python_pypi_remove_role",
+                "description": "Remove a role for this object from users/groups.",
+                "summary": "Remove a role",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python distribution.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Distributions: Pypi"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NestedRoleResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/distributions/python/pypi/{pulp_id}/set_label/": {
+            "post": {
+                "operationId": "distributions_python_pypi_set_label",
+                "description": "Set a single pulp_label on the object to a specific value or null.",
+                "summary": "Set a label",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python distribution.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Distributions: Pypi"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SetLabel"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SetLabel"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SetLabel"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SetLabelResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/distributions/python/pypi/{pulp_id}/unset_label/": {
+            "post": {
+                "operationId": "distributions_python_pypi_unset_label",
+                "description": "Unset a single pulp_label on the object.",
+                "summary": "Unset a label",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python distribution.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Distributions: Pypi"
                 ],
                 "requestBody": {
                     "content": {
@@ -23816,10 +25488,11 @@
                             "enum": [
                                 "file.file",
                                 "gem.gem",
+                                "python.python",
                                 "rpm.rpm"
                             ]
                         },
-                        "description": "Pulp type\n\n* `gem.gem` - gem.gem\n* `rpm.rpm` - rpm.rpm\n* `file.file` - file.file"
+                        "description": "Pulp type\n\n* `gem.gem` - gem.gem\n* `python.python` - python.python\n* `rpm.rpm` - rpm.rpm\n* `file.file` - file.file"
                     },
                     {
                         "in": "query",
@@ -23831,11 +25504,12 @@
                                 "enum": [
                                     "file.file",
                                     "gem.gem",
+                                    "python.python",
                                     "rpm.rpm"
                                 ]
                             }
                         },
-                        "description": "Multiple values may be separated by commas.\n\n* `gem.gem` - gem.gem\n* `rpm.rpm` - rpm.rpm\n* `file.file` - file.file",
+                        "description": "Multiple values may be separated by commas.\n\n* `gem.gem` - gem.gem\n* `python.python` - python.python\n* `rpm.rpm` - rpm.rpm\n* `file.file` - file.file",
                         "explode": false,
                         "style": "form"
                     },
@@ -25358,6 +27032,728 @@
                 }
             }
         },
+        "/api/pulp/{pulp_domain}/api/v3/publications/python/pypi/": {
+            "get": {
+                "operationId": "publications_python_pypi_list",
+                "description": "\nPython Publications refer to the Python Package content in a repository version, and include\nmetadata about that content.",
+                "summary": "List python publications",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "content",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Content Unit referenced by HREF"
+                    },
+                    {
+                        "in": "query",
+                        "name": "content__in",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Content Unit referenced by HREF"
+                    },
+                    {
+                        "name": "limit",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "required": false,
+                        "in": "query",
+                        "description": "The initial index from which to return the results.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "ordering",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "-complete",
+                                    "-pass_through",
+                                    "-pk",
+                                    "-pulp_created",
+                                    "-pulp_id",
+                                    "-pulp_last_updated",
+                                    "-pulp_type",
+                                    "complete",
+                                    "pass_through",
+                                    "pk",
+                                    "pulp_created",
+                                    "pulp_id",
+                                    "pulp_last_updated",
+                                    "pulp_type"
+                                ]
+                            }
+                        },
+                        "description": "Ordering\n\n* `pulp_id` - Pulp id\n* `-pulp_id` - Pulp id (descending)\n* `pulp_created` - Pulp created\n* `-pulp_created` - Pulp created (descending)\n* `pulp_last_updated` - Pulp last updated\n* `-pulp_last_updated` - Pulp last updated (descending)\n* `pulp_type` - Pulp type\n* `-pulp_type` - Pulp type (descending)\n* `complete` - Complete\n* `-complete` - Complete (descending)\n* `pass_through` - Pass through\n* `-pass_through` - Pass through (descending)\n* `pk` - Pk\n* `-pk` - Pk (descending)",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_created",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Filter results where pulp_created matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_created__gt",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Filter results where pulp_created is greater than value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_created__gte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Filter results where pulp_created is greater than or equal to value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_created__lt",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Filter results where pulp_created is less than value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_created__lte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Filter results where pulp_created is less than or equal to value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_created__range",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        },
+                        "description": "Filter results where pulp_created is between two comma separated values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_href__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Multiple values may be separated by commas.",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_id__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "Multiple values may be separated by commas.",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "q",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "repository",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Repository referenced by HREF"
+                    },
+                    {
+                        "in": "query",
+                        "name": "repository_version",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "Repository Version referenced by HREF"
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Publications: Pypi"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Paginatedpython.PythonPublicationResponseList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "publications_python_pypi_create",
+                "description": "\nDispatches a publish task, which generates metadata that will be used by pip.",
+                "summary": "Create a python publication",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    }
+                ],
+                "tags": [
+                    "Publications: Pypi"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonPublication"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonPublication"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonPublication"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AsyncOperationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/publications/python/pypi/{pulp_id}/": {
+            "get": {
+                "operationId": "publications_python_pypi_read",
+                "description": "\nPython Publications refer to the Python Package content in a repository version, and include\nmetadata about that content.",
+                "summary": "Inspect a python publication",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python publication.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Publications: Pypi"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/python.PythonPublicationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "publications_python_pypi_delete",
+                "description": "\nPython Publications refer to the Python Package content in a repository version, and include\nmetadata about that content.",
+                "summary": "Delete a python publication",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python publication.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Publications: Pypi"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/publications/python/pypi/{pulp_id}/add_role/": {
+            "post": {
+                "operationId": "publications_python_pypi_add_role",
+                "description": "Add a role for this object to users/groups.",
+                "summary": "Add a role",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python publication.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Publications: Pypi"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NestedRoleResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/publications/python/pypi/{pulp_id}/list_roles/": {
+            "get": {
+                "operationId": "publications_python_pypi_list_roles",
+                "description": "List roles assigned to this object.",
+                "summary": "List roles",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python publication.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Publications: Pypi"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ObjectRolesResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/publications/python/pypi/{pulp_id}/my_permissions/": {
+            "get": {
+                "operationId": "publications_python_pypi_my_permissions",
+                "description": "List permissions available to the current user on this object.",
+                "summary": "List user permissions",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python publication.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Publications: Pypi"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MyPermissionsResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/publications/python/pypi/{pulp_id}/remove_role/": {
+            "post": {
+                "operationId": "publications_python_pypi_remove_role",
+                "description": "Remove a role for this object from users/groups.",
+                "summary": "Remove a role",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python publication.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Publications: Pypi"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NestedRoleResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/api/pulp/{pulp_domain}/api/v3/publications/rpm/rpm/": {
             "get": {
                 "operationId": "publications_rpm_rpm_list",
@@ -26360,11 +28756,12 @@
                                 "file.file",
                                 "gem.gem",
                                 "ostree.ostree",
+                                "python.python",
                                 "rpm.rpm",
                                 "rpm.uln"
                             ]
                         },
-                        "description": "Pulp type\n\n* `gem.gem` - gem.gem\n* `ostree.ostree` - ostree.ostree\n* `rpm.rpm` - rpm.rpm\n* `rpm.uln` - rpm.uln\n* `file.file` - file.file"
+                        "description": "Pulp type\n\n* `gem.gem` - gem.gem\n* `ostree.ostree` - ostree.ostree\n* `python.python` - python.python\n* `rpm.rpm` - rpm.rpm\n* `rpm.uln` - rpm.uln\n* `file.file` - file.file"
                     },
                     {
                         "in": "query",
@@ -26377,12 +28774,13 @@
                                     "file.file",
                                     "gem.gem",
                                     "ostree.ostree",
+                                    "python.python",
                                     "rpm.rpm",
                                     "rpm.uln"
                                 ]
                             }
                         },
-                        "description": "Multiple values may be separated by commas.\n\n* `gem.gem` - gem.gem\n* `ostree.ostree` - ostree.ostree\n* `rpm.rpm` - rpm.rpm\n* `rpm.uln` - rpm.uln\n* `file.file` - file.file",
+                        "description": "Multiple values may be separated by commas.\n\n* `gem.gem` - gem.gem\n* `ostree.ostree` - ostree.ostree\n* `python.python` - python.python\n* `rpm.rpm` - rpm.rpm\n* `rpm.uln` - rpm.uln\n* `file.file` - file.file",
                         "explode": false,
                         "style": "form"
                     },
@@ -29777,6 +32175,1176 @@
                 }
             }
         },
+        "/api/pulp/{pulp_domain}/api/v3/remotes/python/python/": {
+            "get": {
+                "operationId": "remotes_python_python_list",
+                "description": "\nPython Remotes are representations of an external repository of Python content, eg.\nPyPI.  Fields include upstream repository config. Python Remotes are also used to `sync` from\nupstream repositories, and contains sync settings.",
+                "summary": "List python remotes",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__contains",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name contains value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__icontains",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name contains value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__iexact",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Filter results where name is in a comma-separated list of values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__iregex",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name matches regex value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__istartswith",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name starts with value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__regex",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name matches regex value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__startswith",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name starts with value"
+                    },
+                    {
+                        "name": "offset",
+                        "required": false,
+                        "in": "query",
+                        "description": "The initial index from which to return the results.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "ordering",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "-ca_cert",
+                                    "-client_cert",
+                                    "-client_key",
+                                    "-connect_timeout",
+                                    "-download_concurrency",
+                                    "-headers",
+                                    "-max_retries",
+                                    "-name",
+                                    "-password",
+                                    "-pk",
+                                    "-policy",
+                                    "-proxy_password",
+                                    "-proxy_url",
+                                    "-proxy_username",
+                                    "-pulp_created",
+                                    "-pulp_id",
+                                    "-pulp_labels",
+                                    "-pulp_last_updated",
+                                    "-pulp_type",
+                                    "-rate_limit",
+                                    "-sock_connect_timeout",
+                                    "-sock_read_timeout",
+                                    "-tls_validation",
+                                    "-total_timeout",
+                                    "-url",
+                                    "-username",
+                                    "ca_cert",
+                                    "client_cert",
+                                    "client_key",
+                                    "connect_timeout",
+                                    "download_concurrency",
+                                    "headers",
+                                    "max_retries",
+                                    "name",
+                                    "password",
+                                    "pk",
+                                    "policy",
+                                    "proxy_password",
+                                    "proxy_url",
+                                    "proxy_username",
+                                    "pulp_created",
+                                    "pulp_id",
+                                    "pulp_labels",
+                                    "pulp_last_updated",
+                                    "pulp_type",
+                                    "rate_limit",
+                                    "sock_connect_timeout",
+                                    "sock_read_timeout",
+                                    "tls_validation",
+                                    "total_timeout",
+                                    "url",
+                                    "username"
+                                ]
+                            }
+                        },
+                        "description": "Ordering\n\n* `pulp_id` - Pulp id\n* `-pulp_id` - Pulp id (descending)\n* `pulp_created` - Pulp created\n* `-pulp_created` - Pulp created (descending)\n* `pulp_last_updated` - Pulp last updated\n* `-pulp_last_updated` - Pulp last updated (descending)\n* `pulp_type` - Pulp type\n* `-pulp_type` - Pulp type (descending)\n* `name` - Name\n* `-name` - Name (descending)\n* `pulp_labels` - Pulp labels\n* `-pulp_labels` - Pulp labels (descending)\n* `url` - Url\n* `-url` - Url (descending)\n* `ca_cert` - Ca cert\n* `-ca_cert` - Ca cert (descending)\n* `client_cert` - Client cert\n* `-client_cert` - Client cert (descending)\n* `client_key` - Client key\n* `-client_key` - Client key (descending)\n* `tls_validation` - Tls validation\n* `-tls_validation` - Tls validation (descending)\n* `username` - Username\n* `-username` - Username (descending)\n* `password` - Password\n* `-password` - Password (descending)\n* `proxy_url` - Proxy url\n* `-proxy_url` - Proxy url (descending)\n* `proxy_username` - Proxy username\n* `-proxy_username` - Proxy username (descending)\n* `proxy_password` - Proxy password\n* `-proxy_password` - Proxy password (descending)\n* `download_concurrency` - Download concurrency\n* `-download_concurrency` - Download concurrency (descending)\n* `max_retries` - Max retries\n* `-max_retries` - Max retries (descending)\n* `policy` - Policy\n* `-policy` - Policy (descending)\n* `total_timeout` - Total timeout\n* `-total_timeout` - Total timeout (descending)\n* `connect_timeout` - Connect timeout\n* `-connect_timeout` - Connect timeout (descending)\n* `sock_connect_timeout` - Sock connect timeout\n* `-sock_connect_timeout` - Sock connect timeout (descending)\n* `sock_read_timeout` - Sock read timeout\n* `-sock_read_timeout` - Sock read timeout (descending)\n* `headers` - Headers\n* `-headers` - Headers (descending)\n* `rate_limit` - Rate limit\n* `-rate_limit` - Rate limit (descending)\n* `pk` - Pk\n* `-pk` - Pk (descending)",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_href__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Multiple values may be separated by commas.",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_id__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "Multiple values may be separated by commas.",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_label_select",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter labels by search string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_last_updated",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Filter results where pulp_last_updated matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_last_updated__gt",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Filter results where pulp_last_updated is greater than value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_last_updated__gte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Filter results where pulp_last_updated is greater than or equal to value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_last_updated__lt",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Filter results where pulp_last_updated is less than value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_last_updated__lte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Filter results where pulp_last_updated is less than or equal to value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_last_updated__range",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        },
+                        "description": "Filter results where pulp_last_updated is between two comma separated values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "q",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Remotes: Python"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Paginatedpython.PythonRemoteResponseList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "remotes_python_python_create",
+                "description": "\nPython Remotes are representations of an external repository of Python content, eg.\nPyPI.  Fields include upstream repository config. Python Remotes are also used to `sync` from\nupstream repositories, and contains sync settings.",
+                "summary": "Create a python remote",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    }
+                ],
+                "tags": [
+                    "Remotes: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonRemote"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonRemote"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonRemote"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/python.PythonRemoteResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/remotes/python/python/{pulp_id}/": {
+            "get": {
+                "operationId": "remotes_python_python_read",
+                "description": "\nPython Remotes are representations of an external repository of Python content, eg.\nPyPI.  Fields include upstream repository config. Python Remotes are also used to `sync` from\nupstream repositories, and contains sync settings.",
+                "summary": "Inspect a python remote",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python remote.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Remotes: Python"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/python.PythonRemoteResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "remotes_python_python_update",
+                "description": "Trigger an asynchronous update task",
+                "summary": "Update a python remote",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python remote.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Remotes: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonRemote"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonRemote"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonRemote"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AsyncOperationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "remotes_python_python_partial_update",
+                "description": "Trigger an asynchronous partial update task",
+                "summary": "Update a python remote",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python remote.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Remotes: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Patchedpython.PythonRemote"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Patchedpython.PythonRemote"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Patchedpython.PythonRemote"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AsyncOperationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "remotes_python_python_delete",
+                "description": "Trigger an asynchronous delete task",
+                "summary": "Delete a python remote",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python remote.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Remotes: Python"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AsyncOperationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/remotes/python/python/{pulp_id}/add_role/": {
+            "post": {
+                "operationId": "remotes_python_python_add_role",
+                "description": "Add a role for this object to users/groups.",
+                "summary": "Add a role",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python remote.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Remotes: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NestedRoleResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/remotes/python/python/{pulp_id}/list_roles/": {
+            "get": {
+                "operationId": "remotes_python_python_list_roles",
+                "description": "List roles assigned to this object.",
+                "summary": "List roles",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python remote.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Remotes: Python"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ObjectRolesResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/remotes/python/python/{pulp_id}/my_permissions/": {
+            "get": {
+                "operationId": "remotes_python_python_my_permissions",
+                "description": "List permissions available to the current user on this object.",
+                "summary": "List user permissions",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python remote.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Remotes: Python"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MyPermissionsResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/remotes/python/python/{pulp_id}/remove_role/": {
+            "post": {
+                "operationId": "remotes_python_python_remove_role",
+                "description": "Remove a role for this object from users/groups.",
+                "summary": "Remove a role",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python remote.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Remotes: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NestedRoleResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/remotes/python/python/{pulp_id}/set_label/": {
+            "post": {
+                "operationId": "remotes_python_python_set_label",
+                "description": "Set a single pulp_label on the object to a specific value or null.",
+                "summary": "Set a label",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python remote.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Remotes: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SetLabel"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SetLabel"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SetLabel"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SetLabelResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/remotes/python/python/{pulp_id}/unset_label/": {
+            "post": {
+                "operationId": "remotes_python_python_unset_label",
+                "description": "Unset a single pulp_label on the object.",
+                "summary": "Unset a label",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python remote.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Remotes: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UnsetLabel"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UnsetLabel"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UnsetLabel"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UnsetLabelResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/remotes/python/python/from_bandersnatch/": {
+            "post": {
+                "operationId": "remotes_python_python_from_bandersnatch",
+                "description": "\nTakes the fields specified in the Bandersnatch config and creates a Python Remote from it.",
+                "summary": "Create from Bandersnatch",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    }
+                ],
+                "tags": [
+                    "Remotes: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PythonBanderRemote"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PythonBanderRemote"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/python.PythonRemoteResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/api/pulp/{pulp_domain}/api/v3/remotes/rpm/rpm/": {
             "get": {
                 "operationId": "remotes_rpm_rpm_list",
@@ -32262,10 +35830,11 @@
                                 "file.file",
                                 "gem.gem",
                                 "ostree.ostree",
+                                "python.python",
                                 "rpm.rpm"
                             ]
                         },
-                        "description": "Pulp type\n\n* `gem.gem` - gem.gem\n* `ostree.ostree` - ostree.ostree\n* `rpm.rpm` - rpm.rpm\n* `file.file` - file.file"
+                        "description": "Pulp type\n\n* `gem.gem` - gem.gem\n* `ostree.ostree` - ostree.ostree\n* `python.python` - python.python\n* `rpm.rpm` - rpm.rpm\n* `file.file` - file.file"
                     },
                     {
                         "in": "query",
@@ -32278,11 +35847,12 @@
                                     "file.file",
                                     "gem.gem",
                                     "ostree.ostree",
+                                    "python.python",
                                     "rpm.rpm"
                                 ]
                             }
                         },
-                        "description": "Multiple values may be separated by commas.\n\n* `gem.gem` - gem.gem\n* `ostree.ostree` - ostree.ostree\n* `rpm.rpm` - rpm.rpm\n* `file.file` - file.file",
+                        "description": "Multiple values may be separated by commas.\n\n* `gem.gem` - gem.gem\n* `ostree.ostree` - ostree.ostree\n* `python.python` - python.python\n* `rpm.rpm` - rpm.rpm\n* `file.file` - file.file",
                         "explode": false,
                         "style": "form"
                     },
@@ -37797,6 +41367,1761 @@
                 ],
                 "tags": [
                     "Repositories: Ostree Versions"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Repair"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Repair"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Repair"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AsyncOperationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/repositories/python/python/": {
+            "get": {
+                "operationId": "repositories_python_python_list",
+                "description": "PythonRepository represents a single Python repository, to which content can be\nsynced, added, or removed.",
+                "summary": "List python repositorys",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "latest_with_content",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Content Unit referenced by HREF"
+                    },
+                    {
+                        "name": "limit",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__contains",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name contains value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__icontains",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name contains value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__iexact",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Filter results where name is in a comma-separated list of values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__iregex",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name matches regex value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__istartswith",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name starts with value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__regex",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name matches regex value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__startswith",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter results where name starts with value"
+                    },
+                    {
+                        "name": "offset",
+                        "required": false,
+                        "in": "query",
+                        "description": "The initial index from which to return the results.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "ordering",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "-description",
+                                    "-name",
+                                    "-next_version",
+                                    "-pk",
+                                    "-pulp_created",
+                                    "-pulp_id",
+                                    "-pulp_labels",
+                                    "-pulp_last_updated",
+                                    "-pulp_type",
+                                    "-retain_repo_versions",
+                                    "-user_hidden",
+                                    "description",
+                                    "name",
+                                    "next_version",
+                                    "pk",
+                                    "pulp_created",
+                                    "pulp_id",
+                                    "pulp_labels",
+                                    "pulp_last_updated",
+                                    "pulp_type",
+                                    "retain_repo_versions",
+                                    "user_hidden"
+                                ]
+                            }
+                        },
+                        "description": "Ordering\n\n* `pulp_id` - Pulp id\n* `-pulp_id` - Pulp id (descending)\n* `pulp_created` - Pulp created\n* `-pulp_created` - Pulp created (descending)\n* `pulp_last_updated` - Pulp last updated\n* `-pulp_last_updated` - Pulp last updated (descending)\n* `pulp_type` - Pulp type\n* `-pulp_type` - Pulp type (descending)\n* `name` - Name\n* `-name` - Name (descending)\n* `pulp_labels` - Pulp labels\n* `-pulp_labels` - Pulp labels (descending)\n* `description` - Description\n* `-description` - Description (descending)\n* `next_version` - Next version\n* `-next_version` - Next version (descending)\n* `retain_repo_versions` - Retain repo versions\n* `-retain_repo_versions` - Retain repo versions (descending)\n* `user_hidden` - User hidden\n* `-user_hidden` - User hidden (descending)\n* `pk` - Pk\n* `-pk` - Pk (descending)",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_href__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Multiple values may be separated by commas.",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_id__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "Multiple values may be separated by commas.",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_label_select",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter labels by search string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "q",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "remote",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "Foreign Key referenced by HREF"
+                    },
+                    {
+                        "in": "query",
+                        "name": "retain_repo_versions",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter results where retain_repo_versions matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "retain_repo_versions__gt",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter results where retain_repo_versions is greater than value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "retain_repo_versions__gte",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter results where retain_repo_versions is greater than or equal to value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "retain_repo_versions__isnull",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "Filter results where retain_repo_versions has a null value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "retain_repo_versions__lt",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter results where retain_repo_versions is less than value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "retain_repo_versions__lte",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter results where retain_repo_versions is less than or equal to value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "retain_repo_versions__ne",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter results where retain_repo_versions not equal to value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "retain_repo_versions__range",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "description": "Filter results where retain_repo_versions is between two comma separated values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "with_content",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Content Unit referenced by HREF"
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Paginatedpython.PythonRepositoryResponseList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "repositories_python_python_create",
+                "description": "PythonRepository represents a single Python repository, to which content can be\nsynced, added, or removed.",
+                "summary": "Create a python repository",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonRepository"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonRepository"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonRepository"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/python.PythonRepositoryResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/repositories/python/python/{pulp_id}/": {
+            "get": {
+                "operationId": "repositories_python_python_read",
+                "description": "PythonRepository represents a single Python repository, to which content can be\nsynced, added, or removed.",
+                "summary": "Inspect a python repository",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python repository.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/python.PythonRepositoryResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "repositories_python_python_update",
+                "description": "Trigger an asynchronous update task",
+                "summary": "Update a python repository",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python repository.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonRepository"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonRepository"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/python.PythonRepository"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AsyncOperationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "repositories_python_python_partial_update",
+                "description": "Trigger an asynchronous partial update task",
+                "summary": "Update a python repository",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python repository.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Patchedpython.PythonRepository"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Patchedpython.PythonRepository"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Patchedpython.PythonRepository"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AsyncOperationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "repositories_python_python_delete",
+                "description": "Trigger an asynchronous delete task",
+                "summary": "Delete a python repository",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python repository.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AsyncOperationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/repositories/python/python/{pulp_id}/add_role/": {
+            "post": {
+                "operationId": "repositories_python_python_add_role",
+                "description": "Add a role for this object to users/groups.",
+                "summary": "Add a role",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python repository.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NestedRoleResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/repositories/python/python/{pulp_id}/list_roles/": {
+            "get": {
+                "operationId": "repositories_python_python_list_roles",
+                "description": "List roles assigned to this object.",
+                "summary": "List roles",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python repository.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ObjectRolesResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/repositories/python/python/{pulp_id}/modify/": {
+            "post": {
+                "operationId": "repositories_python_python_modify",
+                "description": "Trigger an asynchronous task to create a new repository version.",
+                "summary": "Modify Repository Content",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python repository.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RepositoryAddRemoveContent"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RepositoryAddRemoveContent"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RepositoryAddRemoveContent"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AsyncOperationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/repositories/python/python/{pulp_id}/my_permissions/": {
+            "get": {
+                "operationId": "repositories_python_python_my_permissions",
+                "description": "List permissions available to the current user on this object.",
+                "summary": "List user permissions",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python repository.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MyPermissionsResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/repositories/python/python/{pulp_id}/remove_role/": {
+            "post": {
+                "operationId": "repositories_python_python_remove_role",
+                "description": "Remove a role for this object from users/groups.",
+                "summary": "Remove a role",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python repository.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NestedRole"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NestedRoleResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/repositories/python/python/{pulp_id}/set_label/": {
+            "post": {
+                "operationId": "repositories_python_python_set_label",
+                "description": "Set a single pulp_label on the object to a specific value or null.",
+                "summary": "Set a label",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python repository.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SetLabel"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SetLabel"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SetLabel"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SetLabelResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/repositories/python/python/{pulp_id}/sync/": {
+            "post": {
+                "operationId": "repositories_python_python_sync",
+                "description": "\nTrigger an asynchronous task to sync python content. The sync task will retrieve Python\ncontent from the specified `Remote` and update the specified `Respository`, creating a\nnew  `RepositoryVersion`.",
+                "summary": "Sync from remote",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python repository.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RepositorySyncURL"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RepositorySyncURL"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RepositorySyncURL"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AsyncOperationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/repositories/python/python/{pulp_id}/unset_label/": {
+            "post": {
+                "operationId": "repositories_python_python_unset_label",
+                "description": "Unset a single pulp_label on the object.",
+                "summary": "Unset a label",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this python repository.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UnsetLabel"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UnsetLabel"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UnsetLabel"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UnsetLabelResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/repositories/python/python/{repository_pk}/versions/": {
+            "get": {
+                "operationId": "repositories_python_python_versions_list",
+                "description": "PythonRepositoryVersion represents a single Python repository version.",
+                "summary": "List repository versions",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "content",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Content Unit referenced by HREF"
+                    },
+                    {
+                        "in": "query",
+                        "name": "content__in",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Content Unit referenced by HREF"
+                    },
+                    {
+                        "name": "limit",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "number",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter results where number matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "number__gt",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter results where number is greater than value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "number__gte",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter results where number is greater than or equal to value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "number__lt",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter results where number is less than value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "number__lte",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Filter results where number is less than or equal to value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "number__range",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "description": "Filter results where number is between two comma separated values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "name": "offset",
+                        "required": false,
+                        "in": "query",
+                        "description": "The initial index from which to return the results.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "ordering",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "-complete",
+                                    "-info",
+                                    "-number",
+                                    "-pk",
+                                    "-pulp_created",
+                                    "-pulp_id",
+                                    "-pulp_last_updated",
+                                    "complete",
+                                    "info",
+                                    "number",
+                                    "pk",
+                                    "pulp_created",
+                                    "pulp_id",
+                                    "pulp_last_updated"
+                                ]
+                            }
+                        },
+                        "description": "Ordering\n\n* `pulp_id` - Pulp id\n* `-pulp_id` - Pulp id (descending)\n* `pulp_created` - Pulp created\n* `-pulp_created` - Pulp created (descending)\n* `pulp_last_updated` - Pulp last updated\n* `-pulp_last_updated` - Pulp last updated (descending)\n* `number` - Number\n* `-number` - Number (descending)\n* `complete` - Complete\n* `-complete` - Complete (descending)\n* `info` - Info\n* `-info` - Info (descending)\n* `pk` - Pk\n* `-pk` - Pk (descending)",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_created",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Filter results where pulp_created matches value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_created__gt",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Filter results where pulp_created is greater than value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_created__gte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Filter results where pulp_created is greater than or equal to value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_created__lt",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Filter results where pulp_created is less than value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_created__lte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Filter results where pulp_created is less than or equal to value"
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_created__range",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        },
+                        "description": "Filter results where pulp_created is between two comma separated values",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "pulp_href__in",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Multiple values may be separated by commas.",
+                        "explode": false,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "q",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "repository_pk",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python Versions"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedRepositoryVersionResponseList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/repositories/python/python/{repository_pk}/versions/{number}/": {
+            "get": {
+                "operationId": "repositories_python_python_versions_read",
+                "description": "PythonRepositoryVersion represents a single Python repository version.",
+                "summary": "Inspect a repository version",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "number",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "repository_pk",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python Versions"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RepositoryVersionResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "repositories_python_python_versions_delete",
+                "description": "Trigger an asynchronous task to delete a repository version.",
+                "summary": "Delete a repository version",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "number",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "repository_pk",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python Versions"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AsyncOperationResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/pulp/{pulp_domain}/api/v3/repositories/python/python/{repository_pk}/versions/{number}/repair/": {
+            "post": {
+                "operationId": "repositories_python_python_versions_repair",
+                "description": "Trigger an asynchronous task to repair a repository version.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "number",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "repository_pk",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Repositories: Python Versions"
                 ],
                 "requestBody": {
                     "content": {
@@ -46079,6 +51404,436 @@
                     }
                 }
             }
+        },
+        "/pypi/{pulp_domain}/{path}/": {
+            "get": {
+                "operationId": "pypi_read",
+                "description": "Gets package summary stats of index.",
+                "summary": "Get index summary",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "path",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Pypi"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SummaryResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/pypi/{pulp_domain}/{path}/legacy/": {
+            "post": {
+                "operationId": "pypi_legacy_create",
+                "description": "Upload package to the index.\n\nThis is the endpoint that tools like Twine and Poetry use for their upload commands.",
+                "summary": "Upload a package",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "path",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    }
+                ],
+                "tags": [
+                    "Pypi: Legacy"
+                ],
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PackageUpload"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PackageUpload"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PackageUploadTaskResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/pypi/{pulp_domain}/{path}/pypi/{meta}/": {
+            "get": {
+                "operationId": "pypi_pypi_read",
+                "description": "Retrieves the package's core-metadata specified by\nhttps://packaging.python.org/specifications/core-metadata/.\n`meta` must be a path in form of `{package}/json/` or `{package}/{version}/json/`",
+                "summary": "Get package metadata",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "meta",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "path",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Pypi: Metadata"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PackageMetadataResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/pypi/{pulp_domain}/{path}/simple/": {
+            "get": {
+                "operationId": "pypi_simple_read",
+                "description": "Gets the simple api html page for the index.",
+                "summary": "Get index simple page",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "path",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Pypi: Simple"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "pypi_simple_create",
+                "description": "Upload package to the index.\nThis endpoint has the same functionality as the upload endpoint at the `/legacy` url of the\nindex. This is provided for convenience for users who want a single index url for all their\nPython tools. (pip, twine, poetry, pipenv, ...)",
+                "summary": "Upload a package",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "path",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    }
+                ],
+                "tags": [
+                    "Pypi: Simple"
+                ],
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PackageUpload"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PackageUpload"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PackageUploadTaskResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/pypi/{pulp_domain}/{path}/simple/{package}/": {
+            "get": {
+                "operationId": "pypi_simple_package_read",
+                "description": "Retrieves the simple api html page for a package.",
+                "summary": "Get package simple page",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "package",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "path",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "pulp_domain",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "x-isDomain": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude_fields",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "A list of fields to exclude from the response."
+                    }
+                ],
+                "tags": [
+                    "Pypi: Simple"
+                ],
+                "security": [
+                    {
+                        "basicAuth": []
+                    },
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "json_header_remote_authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                }
+            }
         }
     },
     "components": {
@@ -46296,30 +52051,21 @@
                 "type": "object",
                 "description": "A serializer for ArtifactDistribution.",
                 "properties": {
-                    "content_guard": {
+                    "pulp_created": {
                         "type": "string",
-                        "format": "uri",
-                        "nullable": true,
-                        "description": "An optional content-guard."
-                    },
-                    "base_url": {
-                        "type": "string",
+                        "format": "date-time",
                         "readOnly": true,
-                        "description": "The URL for accessing the publication as defined by this distribution."
+                        "description": "Timestamp of creation."
                     },
                     "base_path": {
                         "type": "string",
                         "description": "The base (relative) path component of the published url. Avoid paths that                     overlap with other distribution base paths (e.g. \"foo\" and \"foo/bar\")"
                     },
-                    "pulp_href": {
+                    "content_guard": {
                         "type": "string",
                         "format": "uri",
-                        "readOnly": true
-                    },
-                    "hidden": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Whether this distribution should be shown in the content app."
+                        "nullable": true,
+                        "description": "An optional content-guard."
                     },
                     "pulp_last_updated": {
                         "type": "string",
@@ -46327,15 +52073,10 @@
                         "readOnly": true,
                         "description": "Timestamp of the last time this resource was updated. Note: for immutable resources - like content, repository versions, and publication - pulp_created and pulp_last_updated dates will be the same."
                     },
-                    "pulp_created": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "description": "Timestamp of creation."
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "A unique name. Ex, `rawhide` and `stable`."
+                    "hidden": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Whether this distribution should be shown in the content app."
                     },
                     "pulp_labels": {
                         "type": "object",
@@ -46343,6 +52084,20 @@
                             "type": "string",
                             "nullable": true
                         }
+                    },
+                    "base_url": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The URL for accessing the publication as defined by this distribution."
+                    },
+                    "pulp_href": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "A unique name. Ex, `rawhide` and `stable`."
                     }
                 },
                 "required": [
@@ -46937,6 +52692,16 @@
                     "is_valid",
                     "messages"
                 ]
+            },
+            "ExcludePlatformsEnum": {
+                "enum": [
+                    "windows",
+                    "macos",
+                    "freebsd",
+                    "linux"
+                ],
+                "type": "string",
+                "description": "* `windows` - windows\n* `macos` - macos\n* `freebsd` - freebsd\n* `linux` - linux"
             },
             "FilesystemExport": {
                 "type": "object",
@@ -47682,6 +53447,99 @@
                 ],
                 "type": "string",
                 "description": "* `unknown` - unknown\n* `md5` - md5\n* `sha1` - sha1\n* `sha224` - sha224\n* `sha256` - sha256\n* `sha384` - sha384\n* `sha512` - sha512"
+            },
+            "PackageMetadataResponse": {
+                "type": "object",
+                "description": "A Serializer for a package's metadata.",
+                "properties": {
+                    "last_serial": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Cache value from last PyPI sync"
+                    },
+                    "info": {
+                        "type": "object",
+                        "description": "Core metadata of the package"
+                    },
+                    "releases": {
+                        "type": "object",
+                        "description": "List of all the releases of the package"
+                    },
+                    "urls": {
+                        "type": "object"
+                    }
+                },
+                "required": [
+                    "info",
+                    "last_serial",
+                    "releases",
+                    "urls"
+                ]
+            },
+            "PackageTypesEnum": {
+                "enum": [
+                    "bdist_dmg",
+                    "bdist_dumb",
+                    "bdist_egg",
+                    "bdist_msi",
+                    "bdist_rpm",
+                    "bdist_wheel",
+                    "bdist_wininst",
+                    "sdist"
+                ],
+                "type": "string",
+                "description": "* `bdist_dmg` - bdist_dmg\n* `bdist_dumb` - bdist_dumb\n* `bdist_egg` - bdist_egg\n* `bdist_msi` - bdist_msi\n* `bdist_rpm` - bdist_rpm\n* `bdist_wheel` - bdist_wheel\n* `bdist_wininst` - bdist_wininst\n* `sdist` - sdist"
+            },
+            "PackageUpload": {
+                "type": "object",
+                "description": "A Serializer for Python packages being uploaded to the index.",
+                "properties": {
+                    "content": {
+                        "type": "string",
+                        "format": "binary",
+                        "writeOnly": true,
+                        "description": "A Python package release file to upload to the index."
+                    },
+                    "action": {
+                        "type": "string",
+                        "minLength": 1,
+                        "default": "file_upload",
+                        "description": "Defaults to `file_upload`, don't change it or request will fail!"
+                    },
+                    "sha256_digest": {
+                        "type": "string",
+                        "minLength": 64,
+                        "description": "SHA256 of package to validate upload integrity.",
+                        "maxLength": 64
+                    }
+                },
+                "required": [
+                    "content",
+                    "sha256_digest"
+                ]
+            },
+            "PackageUploadTaskResponse": {
+                "type": "object",
+                "description": "A Serializer for responding to a package upload task.",
+                "properties": {
+                    "session": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "task": {
+                        "type": "string"
+                    },
+                    "task_start_time": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    }
+                },
+                "required": [
+                    "session",
+                    "task",
+                    "task_start_time"
+                ]
             },
             "PaginatedAccessPolicyResponseList": {
                 "type": "object",
@@ -49415,6 +55273,161 @@
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/ostree.OstreeSummaryResponse"
+                        }
+                    }
+                }
+            },
+            "Paginatedpython.PythonDistributionResponseList": {
+                "type": "object",
+                "required": [
+                    "count",
+                    "results"
+                ],
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?offset=400&limit=100"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?offset=200&limit=100"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/python.PythonDistributionResponse"
+                        }
+                    }
+                }
+            },
+            "Paginatedpython.PythonPackageContentResponseList": {
+                "type": "object",
+                "required": [
+                    "count",
+                    "results"
+                ],
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?offset=400&limit=100"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?offset=200&limit=100"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/python.PythonPackageContentResponse"
+                        }
+                    }
+                }
+            },
+            "Paginatedpython.PythonPublicationResponseList": {
+                "type": "object",
+                "required": [
+                    "count",
+                    "results"
+                ],
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?offset=400&limit=100"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?offset=200&limit=100"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/python.PythonPublicationResponse"
+                        }
+                    }
+                }
+            },
+            "Paginatedpython.PythonRemoteResponseList": {
+                "type": "object",
+                "required": [
+                    "count",
+                    "results"
+                ],
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?offset=400&limit=100"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?offset=200&limit=100"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/python.PythonRemoteResponse"
+                        }
+                    }
+                }
+            },
+            "Paginatedpython.PythonRepositoryResponseList": {
+                "type": "object",
+                "required": [
+                    "count",
+                    "results"
+                ],
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?offset=400&limit=100"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?offset=200&limit=100"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/python.PythonRepositoryResponse"
                         }
                     }
                 }
@@ -51165,6 +57178,288 @@
                     }
                 }
             },
+            "Patchedpython.PythonDistribution": {
+                "type": "object",
+                "description": "Serializer for Pulp distributions for the Python type.",
+                "properties": {
+                    "base_path": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "The base (relative) path component of the published url. Avoid paths that                     overlap with other distribution base paths (e.g. \"foo\" and \"foo/bar\")"
+                    },
+                    "content_guard": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "An optional content-guard."
+                    },
+                    "hidden": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Whether this distribution should be shown in the content app."
+                    },
+                    "pulp_labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "nullable": true
+                        }
+                    },
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "A unique name. Ex, `rawhide` and `stable`."
+                    },
+                    "repository": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "The latest RepositoryVersion for this Repository will be served."
+                    },
+                    "publication": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "Publication to be served"
+                    },
+                    "allow_uploads": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Allow packages to be uploaded to this index."
+                    },
+                    "remote": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "Remote that can be used to fetch content when using pull-through caching."
+                    }
+                }
+            },
+            "Patchedpython.PythonRemote": {
+                "type": "object",
+                "description": "A Serializer for PythonRemote.",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "A unique name for this remote."
+                    },
+                    "url": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "The URL of an external content source."
+                    },
+                    "ca_cert": {
+                        "type": "string",
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "A PEM encoded CA certificate used to validate the server certificate presented by the remote server."
+                    },
+                    "client_cert": {
+                        "type": "string",
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "A PEM encoded client certificate used for authentication."
+                    },
+                    "client_key": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "A PEM encoded private key used for authentication."
+                    },
+                    "tls_validation": {
+                        "type": "boolean",
+                        "description": "If True, TLS peer validation must be performed."
+                    },
+                    "proxy_url": {
+                        "type": "string",
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "The proxy URL. Format: scheme://host:port"
+                    },
+                    "proxy_username": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "The username to authenticte to the proxy."
+                    },
+                    "proxy_password": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "The password to authenticate to the proxy. Extra leading and trailing whitespace characters are not trimmed."
+                    },
+                    "username": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "The username to be used for authentication when syncing."
+                    },
+                    "password": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "The password to be used for authentication when syncing. Extra leading and trailing whitespace characters are not trimmed."
+                    },
+                    "pulp_labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "nullable": true
+                        }
+                    },
+                    "download_concurrency": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true,
+                        "description": "Total number of simultaneous connections. If not set then the default value will be used.",
+                        "minimum": 1
+                    },
+                    "max_retries": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true,
+                        "description": "Maximum number of retry attempts after a download failure. If not set then the default value (3) will be used."
+                    },
+                    "policy": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/Policy762Enum"
+                            }
+                        ],
+                        "default": "on_demand",
+                        "description": "The policy to use when downloading content. The possible values include: 'immediate', 'on_demand', and 'streamed'. 'on_demand' is the default.\n\n* `immediate` - When syncing, download all metadata and content now.\n* `on_demand` - When syncing, download metadata, but do not download content now. Instead, download content as clients request it, and save it in Pulp to be served for future client requests.\n* `streamed` - When syncing, download metadata, but do not download content now. Instead,download content as clients request it, but never save it in Pulp. This causes future requests for that same content to have to be downloaded again."
+                    },
+                    "total_timeout": {
+                        "type": "number",
+                        "format": "double",
+                        "minimum": 0.0,
+                        "nullable": true,
+                        "description": "aiohttp.ClientTimeout.total (q.v.) for download-connections. The default is null, which will cause the default from the aiohttp library to be used."
+                    },
+                    "connect_timeout": {
+                        "type": "number",
+                        "format": "double",
+                        "minimum": 0.0,
+                        "nullable": true,
+                        "description": "aiohttp.ClientTimeout.connect (q.v.) for download-connections. The default is null, which will cause the default from the aiohttp library to be used."
+                    },
+                    "sock_connect_timeout": {
+                        "type": "number",
+                        "format": "double",
+                        "minimum": 0.0,
+                        "nullable": true,
+                        "description": "aiohttp.ClientTimeout.sock_connect (q.v.) for download-connections. The default is null, which will cause the default from the aiohttp library to be used."
+                    },
+                    "sock_read_timeout": {
+                        "type": "number",
+                        "format": "double",
+                        "minimum": 0.0,
+                        "nullable": true,
+                        "description": "aiohttp.ClientTimeout.sock_read (q.v.) for download-connections. The default is null, which will cause the default from the aiohttp library to be used."
+                    },
+                    "headers": {
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        },
+                        "description": "Headers for aiohttp.Clientsession"
+                    },
+                    "rate_limit": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true,
+                        "description": "Limits requests per second for each concurrent downloader"
+                    },
+                    "includes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "description": "A list containing project specifiers for Python packages to include."
+                    },
+                    "excludes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "description": "A list containing project specifiers for Python packages to exclude."
+                    },
+                    "prereleases": {
+                        "type": "boolean",
+                        "description": "Whether or not to include pre-release packages in the sync."
+                    },
+                    "package_types": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PackageTypesEnum"
+                        },
+                        "description": "The package types to sync for Python content. Leave blank to get everypackage type."
+                    },
+                    "keep_latest_packages": {
+                        "type": "integer",
+                        "format": "int64",
+                        "default": 0,
+                        "description": "The amount of latest versions of a package to keep on sync, includespre-releases if synced. Default 0 keeps all versions."
+                    },
+                    "exclude_platforms": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ExcludePlatformsEnum"
+                        },
+                        "description": "List of platforms to exclude syncing Python packages for. Possible valuesinclude: windows, macos, freebsd, and linux."
+                    }
+                }
+            },
+            "Patchedpython.PythonRepository": {
+                "type": "object",
+                "description": "Serializer for Python Repositories.",
+                "properties": {
+                    "pulp_labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "nullable": true
+                        }
+                    },
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "A unique name for this repository."
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "An optional description."
+                    },
+                    "retain_repo_versions": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true,
+                        "description": "Retain X versions of the repository. Default is null which retains all versions.",
+                        "minimum": 1
+                    },
+                    "remote": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "An optional remote to use by default when syncing."
+                    },
+                    "autopublish": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Whether to automatically create publications for new repository versions, and update any distributions pointing to this repository."
+                    }
+                }
+            },
             "Patchedrpm.RpmAlternateContentSource": {
                 "type": "object",
                 "description": "Serializer for RPM alternate content source.",
@@ -52063,7 +58358,7 @@
                     "finished_before": {
                         "type": "string",
                         "format": "date-time",
-                        "default": "2024-05-20",
+                        "default": "2024-06-11",
                         "description": "Purge tasks completed earlier than this timestamp. Format '%Y-%m-%d[T%H:%M:%S]'"
                     },
                     "states": {
@@ -52077,6 +58372,36 @@
                         "description": "List of task-states to be purged. Only 'final' states are allowed."
                     }
                 }
+            },
+            "PythonBanderRemote": {
+                "type": "object",
+                "description": "A Serializer for the initial step of creating a Python Remote from a Bandersnatch config file",
+                "properties": {
+                    "config": {
+                        "type": "string",
+                        "format": "binary",
+                        "writeOnly": true,
+                        "description": "A Bandersnatch config that may be used to construct a Python Remote."
+                    },
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "A unique name for this remote"
+                    },
+                    "policy": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/Policy762Enum"
+                            }
+                        ],
+                        "default": "on_demand",
+                        "description": "The policy to use when downloading content. The possible values include: 'immediate', 'on_demand', and 'streamed'. 'on_demand' is the default.\n\n* `immediate` - When syncing, download all metadata and content now.\n* `on_demand` - When syncing, download metadata, but do not download content now. Instead, download content as clients request it, and save it in Pulp to be served for future client requests.\n* `streamed` - When syncing, download metadata, but do not download content now. Instead,download content as clients request it, but never save it in Pulp. This causes future requests for that same content to have to be downloaded again."
+                    }
+                },
+                "required": [
+                    "config",
+                    "name"
+                ]
             },
             "RBACContentGuard": {
                 "type": "object",
@@ -52831,6 +59156,32 @@
                     "free",
                     "total",
                     "used"
+                ]
+            },
+            "SummaryResponse": {
+                "type": "object",
+                "description": "A Serializer for summary information of an index.",
+                "properties": {
+                    "projects": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Number of Python projects in index"
+                    },
+                    "releases": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Number of Python distribution releases in index"
+                    },
+                    "files": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Number of files for all distributions in index"
+                    }
+                },
+                "required": [
+                    "files",
+                    "projects",
+                    "releases"
                 ]
             },
             "SyncPolicyEnum": {
@@ -56332,6 +62683,957 @@
                 "required": [
                     "artifact",
                     "relative_path"
+                ]
+            },
+            "python.PythonDistribution": {
+                "type": "object",
+                "description": "Serializer for Pulp distributions for the Python type.",
+                "properties": {
+                    "base_path": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "The base (relative) path component of the published url. Avoid paths that                     overlap with other distribution base paths (e.g. \"foo\" and \"foo/bar\")"
+                    },
+                    "content_guard": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "An optional content-guard."
+                    },
+                    "hidden": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Whether this distribution should be shown in the content app."
+                    },
+                    "pulp_labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "nullable": true
+                        }
+                    },
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "A unique name. Ex, `rawhide` and `stable`."
+                    },
+                    "repository": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "The latest RepositoryVersion for this Repository will be served."
+                    },
+                    "publication": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "Publication to be served"
+                    },
+                    "allow_uploads": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Allow packages to be uploaded to this index."
+                    },
+                    "remote": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "Remote that can be used to fetch content when using pull-through caching."
+                    }
+                },
+                "required": [
+                    "base_path",
+                    "name"
+                ]
+            },
+            "python.PythonDistributionResponse": {
+                "type": "object",
+                "description": "Serializer for Pulp distributions for the Python type.",
+                "properties": {
+                    "pulp_href": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "pulp_created": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "Timestamp of creation."
+                    },
+                    "pulp_last_updated": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "Timestamp of the last time this resource was updated. Note: for immutable resources - like content, repository versions, and publication - pulp_created and pulp_last_updated dates will be the same."
+                    },
+                    "base_path": {
+                        "type": "string",
+                        "description": "The base (relative) path component of the published url. Avoid paths that                     overlap with other distribution base paths (e.g. \"foo\" and \"foo/bar\")"
+                    },
+                    "base_url": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "content_guard": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "An optional content-guard."
+                    },
+                    "hidden": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Whether this distribution should be shown in the content app."
+                    },
+                    "pulp_labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "nullable": true
+                        }
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "A unique name. Ex, `rawhide` and `stable`."
+                    },
+                    "repository": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "The latest RepositoryVersion for this Repository will be served."
+                    },
+                    "publication": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "Publication to be served"
+                    },
+                    "allow_uploads": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Allow packages to be uploaded to this index."
+                    },
+                    "remote": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "Remote that can be used to fetch content when using pull-through caching."
+                    }
+                },
+                "required": [
+                    "base_path",
+                    "name"
+                ]
+            },
+            "python.PythonPackageContent": {
+                "type": "object",
+                "description": "A Serializer for PythonPackageContent.",
+                "properties": {
+                    "repository": {
+                        "type": "string",
+                        "format": "uri",
+                        "writeOnly": true,
+                        "description": "A URI of a repository the new content unit should be associated with."
+                    },
+                    "artifact": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "Artifact file representing the physical content"
+                    },
+                    "relative_path": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "minLength": 1,
+                        "description": "Path where the artifact is located relative to distributions base_path"
+                    },
+                    "file": {
+                        "type": "string",
+                        "format": "binary",
+                        "writeOnly": true,
+                        "description": "An uploaded file that may be turned into the content unit."
+                    },
+                    "upload": {
+                        "type": "string",
+                        "format": "uri",
+                        "writeOnly": true,
+                        "description": "An uncommitted upload that may be turned into the content unit."
+                    },
+                    "sha256": {
+                        "type": "string",
+                        "minLength": 1,
+                        "default": "",
+                        "description": "The SHA256 digest of this package."
+                    },
+                    "summary": {
+                        "type": "string",
+                        "description": "A one-line summary of what the package does."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A longer description of the package that can run to several paragraphs."
+                    },
+                    "description_content_type": {
+                        "type": "string",
+                        "description": "A string stating the markup syntax (if any) used in the distribution’s description, so that tools can intelligently render the description."
+                    },
+                    "keywords": {
+                        "type": "string",
+                        "description": "Additional keywords to be used to assist searching for the package in a larger catalog."
+                    },
+                    "home_page": {
+                        "type": "string",
+                        "description": "The URL for the package's home page."
+                    },
+                    "download_url": {
+                        "type": "string",
+                        "description": "Legacy field denoting the URL from which this package can be downloaded."
+                    },
+                    "author": {
+                        "type": "string",
+                        "description": "Text containing the author's name. Contact information can also be added, separated with newlines."
+                    },
+                    "author_email": {
+                        "type": "string",
+                        "description": "The author's e-mail address. "
+                    },
+                    "maintainer": {
+                        "type": "string",
+                        "description": "The maintainer's name at a minimum; additional contact information may be provided."
+                    },
+                    "maintainer_email": {
+                        "type": "string",
+                        "description": "The maintainer's e-mail address."
+                    },
+                    "license": {
+                        "type": "string",
+                        "description": "Text indicating the license covering the distribution"
+                    },
+                    "requires_python": {
+                        "type": "string",
+                        "description": "The Python version(s) that the distribution is guaranteed to be compatible with."
+                    },
+                    "project_url": {
+                        "type": "string",
+                        "description": "A browsable URL for the project and a label for it, separated by a comma."
+                    },
+                    "project_urls": {
+                        "type": "object",
+                        "description": "A dictionary of labels and URLs for the project."
+                    },
+                    "platform": {
+                        "type": "string",
+                        "description": "A comma-separated list of platform specifications, summarizing the operating systems supported by the package."
+                    },
+                    "supported_platform": {
+                        "type": "string",
+                        "description": "Field to specify the OS and CPU for which the binary package was compiled. "
+                    },
+                    "requires_dist": {
+                        "type": "object",
+                        "description": "A JSON list containing names of some other distutils project required by this distribution."
+                    },
+                    "provides_dist": {
+                        "type": "object",
+                        "description": "A JSON list containing names of a Distutils project which is contained within this distribution."
+                    },
+                    "obsoletes_dist": {
+                        "type": "object",
+                        "description": "A JSON list containing names of a distutils project's distribution which this distribution renders obsolete, meaning that the two projects should not be installed at the same time."
+                    },
+                    "requires_external": {
+                        "type": "object",
+                        "description": "A JSON list containing some dependency in the system that the distribution is to be used."
+                    },
+                    "classifiers": {
+                        "type": "object",
+                        "description": "A JSON list containing classification values for a Python package."
+                    }
+                },
+                "required": [
+                    "relative_path"
+                ]
+            },
+            "python.PythonPackageContentResponse": {
+                "type": "object",
+                "description": "A Serializer for PythonPackageContent.",
+                "properties": {
+                    "pulp_href": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "pulp_created": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "Timestamp of creation."
+                    },
+                    "pulp_last_updated": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "Timestamp of the last time this resource was updated. Note: for immutable resources - like content, repository versions, and publication - pulp_created and pulp_last_updated dates will be the same."
+                    },
+                    "artifact": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "Artifact file representing the physical content"
+                    },
+                    "filename": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The name of the distribution package, usually of the format: {distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.{packagetype}"
+                    },
+                    "packagetype": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The type of the distribution package (e.g. sdist, bdist_wheel, bdist_egg, etc)"
+                    },
+                    "name": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The name of the python project."
+                    },
+                    "version": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The packages version number."
+                    },
+                    "sha256": {
+                        "type": "string",
+                        "default": "",
+                        "description": "The SHA256 digest of this package."
+                    },
+                    "metadata_version": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "Version of the file format"
+                    },
+                    "summary": {
+                        "type": "string",
+                        "description": "A one-line summary of what the package does."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A longer description of the package that can run to several paragraphs."
+                    },
+                    "description_content_type": {
+                        "type": "string",
+                        "description": "A string stating the markup syntax (if any) used in the distribution’s description, so that tools can intelligently render the description."
+                    },
+                    "keywords": {
+                        "type": "string",
+                        "description": "Additional keywords to be used to assist searching for the package in a larger catalog."
+                    },
+                    "home_page": {
+                        "type": "string",
+                        "description": "The URL for the package's home page."
+                    },
+                    "download_url": {
+                        "type": "string",
+                        "description": "Legacy field denoting the URL from which this package can be downloaded."
+                    },
+                    "author": {
+                        "type": "string",
+                        "description": "Text containing the author's name. Contact information can also be added, separated with newlines."
+                    },
+                    "author_email": {
+                        "type": "string",
+                        "description": "The author's e-mail address. "
+                    },
+                    "maintainer": {
+                        "type": "string",
+                        "description": "The maintainer's name at a minimum; additional contact information may be provided."
+                    },
+                    "maintainer_email": {
+                        "type": "string",
+                        "description": "The maintainer's e-mail address."
+                    },
+                    "license": {
+                        "type": "string",
+                        "description": "Text indicating the license covering the distribution"
+                    },
+                    "requires_python": {
+                        "type": "string",
+                        "description": "The Python version(s) that the distribution is guaranteed to be compatible with."
+                    },
+                    "project_url": {
+                        "type": "string",
+                        "description": "A browsable URL for the project and a label for it, separated by a comma."
+                    },
+                    "project_urls": {
+                        "type": "object",
+                        "description": "A dictionary of labels and URLs for the project."
+                    },
+                    "platform": {
+                        "type": "string",
+                        "description": "A comma-separated list of platform specifications, summarizing the operating systems supported by the package."
+                    },
+                    "supported_platform": {
+                        "type": "string",
+                        "description": "Field to specify the OS and CPU for which the binary package was compiled. "
+                    },
+                    "requires_dist": {
+                        "type": "object",
+                        "description": "A JSON list containing names of some other distutils project required by this distribution."
+                    },
+                    "provides_dist": {
+                        "type": "object",
+                        "description": "A JSON list containing names of a Distutils project which is contained within this distribution."
+                    },
+                    "obsoletes_dist": {
+                        "type": "object",
+                        "description": "A JSON list containing names of a distutils project's distribution which this distribution renders obsolete, meaning that the two projects should not be installed at the same time."
+                    },
+                    "requires_external": {
+                        "type": "object",
+                        "description": "A JSON list containing some dependency in the system that the distribution is to be used."
+                    },
+                    "classifiers": {
+                        "type": "object",
+                        "description": "A JSON list containing classification values for a Python package."
+                    }
+                }
+            },
+            "python.PythonPublication": {
+                "type": "object",
+                "description": "A Serializer for PythonPublication.",
+                "properties": {
+                    "repository_version": {
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    "repository": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "A URI of the repository to be published."
+                    }
+                }
+            },
+            "python.PythonPublicationResponse": {
+                "type": "object",
+                "description": "A Serializer for PythonPublication.",
+                "properties": {
+                    "pulp_href": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "pulp_created": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "Timestamp of creation."
+                    },
+                    "pulp_last_updated": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "Timestamp of the last time this resource was updated. Note: for immutable resources - like content, repository versions, and publication - pulp_created and pulp_last_updated dates will be the same."
+                    },
+                    "repository_version": {
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    "repository": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "A URI of the repository to be published."
+                    },
+                    "distributions": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "readOnly": true,
+                        "description": "This publication is currently being hosted as configured by these distributions."
+                    }
+                }
+            },
+            "python.PythonRemote": {
+                "type": "object",
+                "description": "A Serializer for PythonRemote.",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "A unique name for this remote."
+                    },
+                    "url": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "The URL of an external content source."
+                    },
+                    "ca_cert": {
+                        "type": "string",
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "A PEM encoded CA certificate used to validate the server certificate presented by the remote server."
+                    },
+                    "client_cert": {
+                        "type": "string",
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "A PEM encoded client certificate used for authentication."
+                    },
+                    "client_key": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "A PEM encoded private key used for authentication."
+                    },
+                    "tls_validation": {
+                        "type": "boolean",
+                        "description": "If True, TLS peer validation must be performed."
+                    },
+                    "proxy_url": {
+                        "type": "string",
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "The proxy URL. Format: scheme://host:port"
+                    },
+                    "proxy_username": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "The username to authenticte to the proxy."
+                    },
+                    "proxy_password": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "The password to authenticate to the proxy. Extra leading and trailing whitespace characters are not trimmed."
+                    },
+                    "username": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "The username to be used for authentication when syncing."
+                    },
+                    "password": {
+                        "type": "string",
+                        "writeOnly": true,
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "The password to be used for authentication when syncing. Extra leading and trailing whitespace characters are not trimmed."
+                    },
+                    "pulp_labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "nullable": true
+                        }
+                    },
+                    "download_concurrency": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true,
+                        "description": "Total number of simultaneous connections. If not set then the default value will be used.",
+                        "minimum": 1
+                    },
+                    "max_retries": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true,
+                        "description": "Maximum number of retry attempts after a download failure. If not set then the default value (3) will be used."
+                    },
+                    "policy": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/Policy762Enum"
+                            }
+                        ],
+                        "default": "on_demand",
+                        "description": "The policy to use when downloading content. The possible values include: 'immediate', 'on_demand', and 'streamed'. 'on_demand' is the default.\n\n* `immediate` - When syncing, download all metadata and content now.\n* `on_demand` - When syncing, download metadata, but do not download content now. Instead, download content as clients request it, and save it in Pulp to be served for future client requests.\n* `streamed` - When syncing, download metadata, but do not download content now. Instead,download content as clients request it, but never save it in Pulp. This causes future requests for that same content to have to be downloaded again."
+                    },
+                    "total_timeout": {
+                        "type": "number",
+                        "format": "double",
+                        "minimum": 0.0,
+                        "nullable": true,
+                        "description": "aiohttp.ClientTimeout.total (q.v.) for download-connections. The default is null, which will cause the default from the aiohttp library to be used."
+                    },
+                    "connect_timeout": {
+                        "type": "number",
+                        "format": "double",
+                        "minimum": 0.0,
+                        "nullable": true,
+                        "description": "aiohttp.ClientTimeout.connect (q.v.) for download-connections. The default is null, which will cause the default from the aiohttp library to be used."
+                    },
+                    "sock_connect_timeout": {
+                        "type": "number",
+                        "format": "double",
+                        "minimum": 0.0,
+                        "nullable": true,
+                        "description": "aiohttp.ClientTimeout.sock_connect (q.v.) for download-connections. The default is null, which will cause the default from the aiohttp library to be used."
+                    },
+                    "sock_read_timeout": {
+                        "type": "number",
+                        "format": "double",
+                        "minimum": 0.0,
+                        "nullable": true,
+                        "description": "aiohttp.ClientTimeout.sock_read (q.v.) for download-connections. The default is null, which will cause the default from the aiohttp library to be used."
+                    },
+                    "headers": {
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        },
+                        "description": "Headers for aiohttp.Clientsession"
+                    },
+                    "rate_limit": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true,
+                        "description": "Limits requests per second for each concurrent downloader"
+                    },
+                    "includes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "description": "A list containing project specifiers for Python packages to include."
+                    },
+                    "excludes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "description": "A list containing project specifiers for Python packages to exclude."
+                    },
+                    "prereleases": {
+                        "type": "boolean",
+                        "description": "Whether or not to include pre-release packages in the sync."
+                    },
+                    "package_types": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PackageTypesEnum"
+                        },
+                        "description": "The package types to sync for Python content. Leave blank to get everypackage type."
+                    },
+                    "keep_latest_packages": {
+                        "type": "integer",
+                        "format": "int64",
+                        "default": 0,
+                        "description": "The amount of latest versions of a package to keep on sync, includespre-releases if synced. Default 0 keeps all versions."
+                    },
+                    "exclude_platforms": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ExcludePlatformsEnum"
+                        },
+                        "description": "List of platforms to exclude syncing Python packages for. Possible valuesinclude: windows, macos, freebsd, and linux."
+                    }
+                },
+                "required": [
+                    "name",
+                    "url"
+                ]
+            },
+            "python.PythonRemoteResponse": {
+                "type": "object",
+                "description": "A Serializer for PythonRemote.",
+                "properties": {
+                    "pulp_href": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "pulp_created": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "Timestamp of creation."
+                    },
+                    "pulp_last_updated": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "Timestamp of the most recent update of the remote."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "A unique name for this remote."
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "The URL of an external content source."
+                    },
+                    "ca_cert": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "A PEM encoded CA certificate used to validate the server certificate presented by the remote server."
+                    },
+                    "client_cert": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "A PEM encoded client certificate used for authentication."
+                    },
+                    "tls_validation": {
+                        "type": "boolean",
+                        "description": "If True, TLS peer validation must be performed."
+                    },
+                    "proxy_url": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The proxy URL. Format: scheme://host:port"
+                    },
+                    "pulp_labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "nullable": true
+                        }
+                    },
+                    "download_concurrency": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true,
+                        "description": "Total number of simultaneous connections. If not set then the default value will be used.",
+                        "minimum": 1
+                    },
+                    "max_retries": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true,
+                        "description": "Maximum number of retry attempts after a download failure. If not set then the default value (3) will be used."
+                    },
+                    "policy": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/Policy762Enum"
+                            }
+                        ],
+                        "default": "on_demand",
+                        "description": "The policy to use when downloading content. The possible values include: 'immediate', 'on_demand', and 'streamed'. 'on_demand' is the default.\n\n* `immediate` - When syncing, download all metadata and content now.\n* `on_demand` - When syncing, download metadata, but do not download content now. Instead, download content as clients request it, and save it in Pulp to be served for future client requests.\n* `streamed` - When syncing, download metadata, but do not download content now. Instead,download content as clients request it, but never save it in Pulp. This causes future requests for that same content to have to be downloaded again."
+                    },
+                    "total_timeout": {
+                        "type": "number",
+                        "format": "double",
+                        "minimum": 0.0,
+                        "nullable": true,
+                        "description": "aiohttp.ClientTimeout.total (q.v.) for download-connections. The default is null, which will cause the default from the aiohttp library to be used."
+                    },
+                    "connect_timeout": {
+                        "type": "number",
+                        "format": "double",
+                        "minimum": 0.0,
+                        "nullable": true,
+                        "description": "aiohttp.ClientTimeout.connect (q.v.) for download-connections. The default is null, which will cause the default from the aiohttp library to be used."
+                    },
+                    "sock_connect_timeout": {
+                        "type": "number",
+                        "format": "double",
+                        "minimum": 0.0,
+                        "nullable": true,
+                        "description": "aiohttp.ClientTimeout.sock_connect (q.v.) for download-connections. The default is null, which will cause the default from the aiohttp library to be used."
+                    },
+                    "sock_read_timeout": {
+                        "type": "number",
+                        "format": "double",
+                        "minimum": 0.0,
+                        "nullable": true,
+                        "description": "aiohttp.ClientTimeout.sock_read (q.v.) for download-connections. The default is null, which will cause the default from the aiohttp library to be used."
+                    },
+                    "headers": {
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        },
+                        "description": "Headers for aiohttp.Clientsession"
+                    },
+                    "rate_limit": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true,
+                        "description": "Limits requests per second for each concurrent downloader"
+                    },
+                    "hidden_fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "is_set": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": [
+                                "is_set",
+                                "name"
+                            ]
+                        },
+                        "readOnly": true,
+                        "description": "List of hidden (write only) fields"
+                    },
+                    "includes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "A list containing project specifiers for Python packages to include."
+                    },
+                    "excludes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "A list containing project specifiers for Python packages to exclude."
+                    },
+                    "prereleases": {
+                        "type": "boolean",
+                        "description": "Whether or not to include pre-release packages in the sync."
+                    },
+                    "package_types": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PackageTypesEnum"
+                        },
+                        "description": "The package types to sync for Python content. Leave blank to get everypackage type."
+                    },
+                    "keep_latest_packages": {
+                        "type": "integer",
+                        "format": "int64",
+                        "default": 0,
+                        "description": "The amount of latest versions of a package to keep on sync, includespre-releases if synced. Default 0 keeps all versions."
+                    },
+                    "exclude_platforms": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ExcludePlatformsEnum"
+                        },
+                        "description": "List of platforms to exclude syncing Python packages for. Possible valuesinclude: windows, macos, freebsd, and linux."
+                    }
+                },
+                "required": [
+                    "name",
+                    "url"
+                ]
+            },
+            "python.PythonRepository": {
+                "type": "object",
+                "description": "Serializer for Python Repositories.",
+                "properties": {
+                    "pulp_labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "nullable": true
+                        }
+                    },
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "A unique name for this repository."
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true,
+                        "minLength": 1,
+                        "description": "An optional description."
+                    },
+                    "retain_repo_versions": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true,
+                        "description": "Retain X versions of the repository. Default is null which retains all versions.",
+                        "minimum": 1
+                    },
+                    "remote": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "An optional remote to use by default when syncing."
+                    },
+                    "autopublish": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Whether to automatically create publications for new repository versions, and update any distributions pointing to this repository."
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "python.PythonRepositoryResponse": {
+                "type": "object",
+                "description": "Serializer for Python Repositories.",
+                "properties": {
+                    "pulp_href": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "pulp_created": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "Timestamp of creation."
+                    },
+                    "pulp_last_updated": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "Timestamp of the last time this resource was updated. Note: for immutable resources - like content, repository versions, and publication - pulp_created and pulp_last_updated dates will be the same."
+                    },
+                    "versions_href": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "pulp_labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "nullable": true
+                        }
+                    },
+                    "latest_version_href": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "A unique name for this repository."
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "An optional description."
+                    },
+                    "retain_repo_versions": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true,
+                        "description": "Retain X versions of the repository. Default is null which retains all versions.",
+                        "minimum": 1
+                    },
+                    "remote": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "An optional remote to use by default when syncing."
+                    },
+                    "autopublish": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Whether to automatically create publications for new repository versions, and update any distributions pointing to this repository."
+                    }
+                },
+                "required": [
+                    "name"
                 ]
             },
             "rpm.DistributionTreeResponse": {

--- a/pkg/clients/pulp/repositories.go
+++ b/pkg/clients/pulp/repositories.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/redhatinsights/edge-api/pkg/ptr"
 )
 
 func (ps *PulpService) RepositoriesCreate(ctx context.Context, name string) (*OstreeOstreeRepositoryResponse, error) {
 	body := OstreeOstreeRepository{
-		Name: name,
+		Name:         name,
+		ComputeDelta: ptr.To(true),
 	}
 	resp, err := ps.cwr.RepositoriesOstreeOstreeCreateWithResponse(ctx, ps.dom, body, addAuthenticationHeader)
 
@@ -44,7 +46,7 @@ func (ps *PulpService) RepositoriesImport(ctx context.Context, id uuid.UUID, rep
 		return nil, err
 	}
 
-	result, err := ps.RepositoriesRead(ctx, ScanUUID(href))
+	result, err := ps.RepositoriesRead(ctx, ScanUUID(&href))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request adds content guards for Pulp to enhance security and access control. Content guards are created and ensured during the fixture creation process. The guards are associated with the distributions created for the repositories. This ensures that only authorized users can access and modify the content in the repositories.

Usage:

Use NewPulpServiceDefaultDomain method to create a default domain client and create a new domain if it does not exist yet for the OrgID.

Use NewPulpServiceWithDomain or NewPulpService to create a new client.

Use ArtifactsCreatePipe to stream TAR commit directly from IB S3 into Pulp. Make sure to not to buffer the whole file in memory or temporary file, use Reader and Writer interfaces.

Create repo with RepositoriesCreate and ensure content guards are created via ContentGuardEnsure. This method is idempotent and it corrects if content guards are misconfigured. It may not correct all possible states in that case it throws an error but normal cases like username change that will work automatically.

Use DistributionsCreate to create distribution and pass the existing repo and content guards into it.

Finally, use RepositoriesImport to perform a long running Pulp task to create distribution. This method will wait until the task is done in Pulp so it can block for quite some time.

All these methods are ment to be called from a background goroutine (job queue).