### PR TITLE
parse only commitmeta extension

### DIFF
--- a/pkg/routes/storage.go
+++ b/pkg/routes/storage.go
@@ -423,7 +423,7 @@ func GetUpdateTransactionRepoFile(w http.ResponseWriter, r *http.Request) {
 
 	// workaround to serve 303 instead of 404 for optional ostree files
 	baseFilename := filepath.Base(requestPath)
-	if extension := filepath.Ext(baseFilename); extension != "" {
+	if extension := filepath.Ext(baseFilename); extension == ".commitmeta" {
 		baseFilename = extension
 	}
 
@@ -433,7 +433,7 @@ func GetUpdateTransactionRepoFile(w http.ResponseWriter, r *http.Request) {
 			"orgID":               updateRepo.OrgID,
 			"updateTransactionID": updateRepo.ID,
 			"path":                requestPath,
-		}).Debug("redirected possible missing optional ostree file")
+		}).Debug("redirected optional ostree file")
 		redirectToStorageSignedURL(w, r, requestPath)
 	default:
 		logger.WithFields(log.Fields{


### PR DESCRIPTION
# Description
Fixing redirect for optional files to only split on .commitmeta and not signature.sig

FIXES: <!-- THEEDGE-NNNN -->

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
