### PR TITLE
Make batchsize configurable

### DIFF
--- a/cmd/cleanup/cleanuporphancommits/cleanuporphancommits.go
+++ b/cmd/cleanup/cleanuporphancommits/cleanuporphancommits.go
@@ -212,7 +212,7 @@ func CleanupOrphanInstalledPackages(gormDB *gorm.DB) error {
 	}
 
 	// delete orphan installed packages
-	batchSize := 1000
+	batchSize := config.Get().CleanupBatchSize
 	var total int64
 	keepGoing := true
 	totalStartTime := time.Now()

--- a/config/config.go
+++ b/config/config.go
@@ -91,6 +91,7 @@ type EdgeConfig struct {
 	PulpS3Region               string                    `json:"pulp_s3_region,omitempty"`
 	PulpS3SecretKey            string                    `json:"pulp_s3_secret_key,omitempty"`
 	PulpS3AccessKey            string                    `json:"pulp_s3_access_key,omitempty"`
+	CleanupBatchSize           int                       `json:"cleanup_batch_size,omitempty"`
 }
 
 type dbConfig struct {
@@ -188,6 +189,7 @@ func CreateEdgeAPIConfig() (*EdgeConfig, error) {
 	options.SetDefault("PulpS3Region", "DummyRegion")
 	options.SetDefault("PulpS3SecretKey", "")
 	options.SetDefault("PulpS3AccessKey", "")
+	options.SetDefault("CleanupBatchSize", "500")
 	options.AutomaticEnv()
 
 	if options.GetBool("Debug") {
@@ -297,6 +299,7 @@ func CreateEdgeAPIConfig() (*EdgeConfig, error) {
 		PulpS3Region:               options.GetString("PulpS3Region"),
 		PulpS3SecretKey:            options.GetString("PulpS3SecretKey"),
 		PulpS3AccessKey:            options.GetString("PulpS3AccessKey"),
+		CleanupBatchSize:           options.GetInt("CleanupBatchSize"),
 	}
 	if edgeConfig.TenantTranslatorHost != "" && edgeConfig.TenantTranslatorPort != "" {
 		edgeConfig.TenantTranslatorURL = fmt.Sprintf("http://%s:%s", edgeConfig.TenantTranslatorHost, edgeConfig.TenantTranslatorPort)

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -216,6 +216,7 @@ objects:
         schedule: ${CLEANUP_SCHEDULE}
         restartPolicy: Never
         concurrencyPolicy: Forbid
+        backoffLimit: 1
         suspend: ${{CLEANUP_SUSPEND}}
         activeDeadlineSeconds: 259200
         podSpec:
@@ -225,6 +226,8 @@ objects:
           env:
             - name: CLOWDER_ENABLED
               value: ${CLOWDER_ENABLED}
+            - name: CLEANUPBATCHSIZE
+              value: ${CLEANUPBATCHSIZE}
             - name: ENABLE_CLOUDWATCH_LOGGING
               value: ${ENABLE_CLOUDWATCH_LOGGING}
             - name: AUTH
@@ -468,6 +471,10 @@ parameters:
   name: CLEANUP_SUSPEND
   required: false
   value: "false"
+- description: Batch size of package deletion.
+  name: CLEANUPBATCHSIZE
+  required: false
+  value: "500"
 - description: RBAC service base URL
   name: RBAC_BASE_URL
   required: false


### PR DESCRIPTION
This pull request adds the ability to configure the batch size for package deletion. Previously, the batch size was hardcoded to 1000, but now it can be set using the `CleanupBatchSize` configuration option. This allows for more flexibility and customization when performing cleanup operations.

The change also contains `backoffLimit` set to 1 according to [k8s docs](https://kubernetes.io/docs/concepts/workloads/controllers/job/). Jobs are supposed to be restarting until they return 0 regardless of the restart policy, it is a bit weird but this is how I understand it. We are unable to kill the old job it keeps poping back.
