### PR TITLE
Disabling parallel execution of tests

### DIFF
--- a/deploy/stage-post-deployment-tests.yaml
+++ b/deploy/stage-post-deployment-tests.yaml
@@ -24,3 +24,6 @@ parameters:
   description: "Unique CJI name suffix"
   generate: expression
   from: "[a-z0-9]{6}"
+- name: IQE_PARALLEL_ENABLED
+  value: "false"
+


### PR DESCRIPTION

Switching the flag in-order to have a sequential execution in the pipelines