### PR TITLE
Truncate packages table on stage

### DIFF
--- a/cmd/migrate/manual/000_truncate_packages.go
+++ b/cmd/migrate/manual/000_truncate_packages.go
@@ -1,0 +1,26 @@
+package manual
+
+import (
+	"github.com/redhatinsights/edge-api/pkg/db"
+	feature "github.com/redhatinsights/edge-api/unleash/features"
+	log "github.com/sirupsen/logrus"
+)
+
+func init() {
+	registerMigration("truncate packages if enabled (000)", truncatePackages)
+}
+
+func truncatePackages() error {
+	if feature.TruncatePackages.IsEnabled() {
+		log.Info("Truncating packages table ...")
+		if err := db.DB.Exec("TRUNCATE TABLE commit_installed_packages, installed_packages").Error; err != nil {
+			return err
+		}
+
+		if err := db.DB.Exec("VACUUM FULL").Error; err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -83,6 +83,9 @@ var CleanUPDevices = &Flag{Name: "edge-management.cleanup_devices", EnvVar: "FEA
 // CleanUPOrphanCommits is a feature flag to use for cleanup orphan commits
 var CleanUPOrphanCommits = &Flag{Name: "edge-management.cleanup_orphan_commits", EnvVar: "FEATURE_CLEANUP_ORPHAN_COMMITS"}
 
+// TruncatePackages enables the truncation of packages tables during migration
+var TruncatePackages = &Flag{Name: "edge-management.truncate_packages", EnvVar: "TRUNCATE_PACKAGES"}
+
 // STATIC DELTA FLAGS
 
 // SkipUpdateRepo is a feature flag to skip the process of download and re-upload of update repositories


### PR DESCRIPTION
This pull request includes a commit that adds the functionality to truncate the packages table during migration if the `TruncatePackages` feature flag is enabled. This allows for a clean start when migrating to a new stage.