### PR TITLE
Ensure truncate command is executed on stage

### DIFF
--- a/cmd/migrate/manual/000_truncate_packages.go
+++ b/cmd/migrate/manual/000_truncate_packages.go
@@ -1,8 +1,10 @@
 package manual
 
 import (
+	"strings"
+
+	"github.com/redhatinsights/edge-api/config"
 	"github.com/redhatinsights/edge-api/pkg/db"
-	feature "github.com/redhatinsights/edge-api/unleash/features"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -11,7 +13,7 @@ func init() {
 }
 
 func truncatePackages() error {
-	if feature.TruncatePackages.IsEnabled() {
+	if strings.Contains(config.Get().EdgeAPIBaseURL, "stage") {
 		log.Info("Truncating packages table ...")
 		if err := db.DB.Exec("TRUNCATE TABLE commit_installed_packages, installed_packages").Error; err != nil {
 			return err


### PR DESCRIPTION
This pull request ensures that the truncate command is executed on the stage environment. Previously, the command was not being executed correctly. This fix ensures that the packages table is properly truncated when running on the stage environment.