### PR TITLE
Revert "Disable constraint/trigger during cleanup (HMS-4477)"

### DIFF
--- a/cmd/cleanup/cleanuporphancommits/cleanuporphancommits.go
+++ b/cmd/cleanup/cleanuporphancommits/cleanuporphancommits.go
@@ -211,24 +211,7 @@ func CleanupOrphanInstalledPackages(gormDB *gorm.DB) error {
 		gormDB = db.DB
 	}
 
-	tx := gormDB.Unscoped().Exec(`alter table commit_installed_packages disable trigger all`)
-	if tx.Error != nil {
-		// only superuser can disable system triggers so this can actually fail
-		log.WithField("error", tx.Error.Error()).Warn("error while disabling triggers")
-	}
-
-	err := cleanupOrphanInstalledPackagesPlain(gormDB)
-	if err != nil {
-		log.WithField("error", err).Errorf("error cleaning up packages: %s", err.Error())
-		return tx.Error
-	}
-
-	tx = gormDB.Unscoped().Exec(`alter table commit_installed_packages enable trigger all`)
-	if tx.Error != nil {
-		// only superuser can disable system triggers so this can actually fail
-		log.WithField("error", tx.Error.Error()).Warn("error while enabling triggers")
-	}
-	return nil
+	return cleanupOrphanInstalledPackagesCTE(gormDB)
 }
 
 // Two implementation of the same function, one using subselect and the other using CTE
@@ -267,7 +250,7 @@ func CleanupOrphanInstalledPackages(gormDB *gorm.DB) error {
 // 	return nil
 // }
 
-func cleanupOrphanInstalledPackagesPlain(gormDB *gorm.DB) error {
+func cleanupOrphanInstalledPackagesCTE(gormDB *gorm.DB) error {
 	batchSize := config.Get().CleanupBatchSize
 	var total int64
 	keepGoing := true


### PR DESCRIPTION
Reverts RedHatInsights/edge-api#2685

We do not have permissions to do this, so this is actually only erroring out.