### PR TITLE
refactor: remove unleash-proxy dependency (HMS-4929)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -56,10 +56,8 @@ type EdgeConfig struct {
 	Local                      bool                      `json:"local,omitempty"`
 	Dev                        bool                      `json:"dev,omitempty"`
 	UnleashURL                 string                    `json:"unleash_url,omitempty"`
-	FeatureFlagsEnvironment    string                    `json:"featureflags_environment,omitempty"`
 	FeatureFlagsURL            string                    `json:"featureflags_url,omitempty"`
 	FeatureFlagsAPIToken       string                    `json:"featureflags_api_token,omitempty"`
-	FeatureFlagsService        string                    `json:"featureflags_service,omitempty"`
 	ContentSourcesURL          string                    `json:"content_sources_url,omitempty"`
 	TenantTranslatorHost       string                    `json:"tenant_translator_host,omitempty"`
 	TenantTranslatorPort       string                    `json:"tenant_translator_port,omitempty"`
@@ -152,6 +150,11 @@ var configMu = sync.Mutex{}
 // DevConfigFile is a wrapper for local dev kafka edgeConfig
 type DevConfigFile struct {
 	Kafka clowder.KafkaConfig
+}
+
+func FeatureFlagsConfigured() bool {
+	conf := Get()
+	return conf.FeatureFlagsURL != ""
 }
 
 // just a forward moving baby step to a full config refactor (pulp now)
@@ -260,19 +263,8 @@ func CreateEdgeAPIConfig() (*EdgeConfig, error) {
 		options.SetDefault("FeatureFlagsUrl", os.Getenv("UNLEASH_URL"))
 		options.SetDefault("FeatureFlagsAPIToken", os.Getenv("UNLEASH_TOKEN"))
 	}
-	options.SetDefault("FeatureFlagsService", os.Getenv("FEATURE_FLAGS_SERVICE"))
 
 	options.SetDefault("GpgVerify", "false")
-	if os.Getenv("SOURCES_ENV") == "prod" {
-		options.SetDefault("FeatureFlagsEnvironment", "production")
-	} else {
-		options.SetDefault("FeatureFlagsEnvironment", "development")
-	}
-
-	// check to see if you are running in ephemeral, the unleash server in ephemeral is empty
-	if strings.Contains(options.GetString("FeatureFlagsUrl"), "ephemeral") {
-		options.SetDefault("FeatureFlagsEnvironment", "ephemeral")
-	}
 
 	options.SetDefault("TenantTranslatorHost", os.Getenv("TENANT_TRANSLATOR_HOST"))
 	options.SetDefault("TenantTranslatorPort", os.Getenv("TENANT_TRANSLATOR_PORT"))
@@ -319,10 +311,8 @@ func CreateEdgeAPIConfig() (*EdgeConfig, error) {
 		Local:                      options.GetBool("Local"),
 		Dev:                        options.GetBool("Dev"),
 		UnleashURL:                 options.GetString("FeatureFlagsUrl"),
-		FeatureFlagsEnvironment:    options.GetString("FeatureFlagsEnvironment"),
 		FeatureFlagsURL:            options.GetString("FeatureFlagsUrl"),
 		FeatureFlagsAPIToken:       options.GetString("FeatureFlagsAPIToken"),
-		FeatureFlagsService:        options.GetString("FeatureFlagsService"),
 		TenantTranslatorHost:       options.GetString("TenantTranslatorHost"),
 		ContentSourcesURL:          options.GetString("CONTENT_SOURCES_URL"),
 		TenantTranslatorPort:       options.GetString("TenantTranslatorPort"),

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -362,8 +362,6 @@ objects:
     - replicas: 3
       partitions: 3
       topicName: platform.notifications.ingress
-    dependencies:
-    - unleash-proxy
     optionalDependencies:
     - host-inventory
     - playbook-dispatcher

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -155,13 +155,6 @@ objects:
           value: ${UPLOADWORKERS}
         - name: LOG_LEVEL
           value: ${LOG_LEVEL}
-        - name: UNLEASH_URL
-          value: ${UNLEASH_URL}
-        - name: UNLEASH_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: ${UNLEASH_SECRET_NAME}
-              key: CLIENT_ACCESS_TOKEN
         - name: TENANT_TRANSLATOR_HOST
           value: ${TENANT_TRANSLATOR_HOST}
         - name: TENANT_TRANSLATOR_PORT
@@ -261,13 +254,6 @@ objects:
           value: ${UPLOADWORKERS}
         - name: LOG_LEVEL
           value: ${LOG_LEVEL}
-        - name: UNLEASH_URL
-          value: ${UNLEASH_URL}
-        - name: UNLEASH_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: ${UNLEASH_SECRET_NAME}
-              key: CLIENT_ACCESS_TOKEN
         - name: TENANT_TRANSLATOR_HOST
           value: ${TENANT_TRANSLATOR_HOST}
         - name: TENANT_TRANSLATOR_PORT
@@ -336,13 +322,6 @@ objects:
               value: ${UPLOADWORKERS}
             - name: LOG_LEVEL
               value: ${LOG_LEVEL}
-            - name: UNLEASH_URL
-              value: ${UNLEASH_URL}
-            - name: UNLEASH_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: ${UNLEASH_SECRET_NAME}
-                  key: CLIENT_ACCESS_TOKEN
             - name: TENANT_TRANSLATOR_HOST
               value: ${TENANT_TRANSLATOR_HOST}
             - name: TENANT_TRANSLATOR_PORT
@@ -523,12 +502,6 @@ parameters:
   name: LOG_LEVEL
   required: false
   value: "DEBUG"
-- description: Unleash API url
-  name: UNLEASH_URL
-  value: ''
-- description: Unleash secret name
-  name: UNLEASH_SECRET_NAME
-  value: unleash-ephemeral
 - description: Host for the EAN to OrgId translator service.
   name: TENANT_TRANSLATOR_HOST
   required: false

--- a/main.go
+++ b/main.go
@@ -183,16 +183,6 @@ func gracefulTermination(server *http.Server, serviceName string) {
 	log.Infof("%s service shutdown complete", serviceName)
 }
 
-func featureFlagsConfigPresent() bool {
-	conf := config.Get()
-	return conf.FeatureFlagsURL != ""
-}
-
-func featureFlagsServiceUnleash() bool {
-	conf := config.Get()
-	return conf.FeatureFlagsService == "unleash"
-}
-
 func main() {
 	ctx := context.Background()
 	// this only catches interrupts for main
@@ -246,7 +236,7 @@ func main() {
 
 	config.LogConfigAtStartup(cfg)
 
-	if featureFlagsConfigPresent() {
+	if config.FeatureFlagsConfigured() {
 		err := unleash.Initialize(
 			unleash.WithListener(&edgeunleash.EdgeListener{}),
 			unleash.WithAppName("edge-api"),

--- a/unleash/features/feature.go
+++ b/unleash/features/feature.go
@@ -124,21 +124,22 @@ var PulpIntegrationUpdateViaPulp = &Flag{Name: "edge-management.pulp_integration
 
 // CheckFeature checks to see if a given feature is available
 func CheckFeature(feature string, options ...unleash.FeatureOption) bool {
-	cfg := config.Get()
-
-	if cfg.FeatureFlagsEnvironment != "ephemeral" && cfg.FeatureFlagsURL != "" {
-		if len(options) == 0 {
-			options = append(options, unleash.WithContext(unleashCTX.Context{}))
-		}
-		return unleash.IsEnabled(feature, options...)
+	if !config.FeatureFlagsConfigured() {
+		return false
 	}
 
-	return false
+	if len(options) == 0 {
+		options = append(options, unleash.WithContext(unleashCTX.Context{}))
+	}
+	return unleash.IsEnabled(feature, options...)
 }
 
 // CheckFeature checks to see if a given feature is available with context
 func CheckFeatureCtx(ctx context.Context, feature string, options ...unleash.FeatureOption) bool {
-	cfg := config.Get()
+	if !config.FeatureFlagsConfigured() {
+		return false
+	}
+
 	uctx := unleashCTX.Context{}
 	orgID := identity.GetIdentity(ctx).Identity.OrgID
 	if orgID != "" {
@@ -150,12 +151,8 @@ func CheckFeatureCtx(ctx context.Context, feature string, options ...unleash.Fea
 		}
 	}
 
-	if cfg.FeatureFlagsEnvironment != "ephemeral" && cfg.FeatureFlagsURL != "" {
-		options = append(options, unleash.WithContext(uctx))
-		return unleash.IsEnabled(feature, options...)
-	}
-
-	return false
+	options = append(options, unleash.WithContext(uctx))
+	return unleash.IsEnabled(feature, options...)
 }
 
 // IsEnabledLocal returns a bool directly from the environment. Use before Unleash is init'd


### PR DESCRIPTION
# Description

Moved validation function to `config` package.

Removed check for ephemeral environment as there will be instance of unleash with flags off, so no need to return for ephemeral.
`FeatureFlagsService` config was never actually used.

The unleash secrets were passed, but always overriden by clowder.

CheckFeature is now returning early when unleash is not configured.


Fixes: HMS-4929