### PR TITLE
add turnpike content guard (HMS-4783)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,7 @@ type EdgeConfig struct {
 	SubscriptionServerURL      string                    `json:"subscription_server_url"`
 	SubscriptionBaseUrl        string                    `json:"subscription_base_url"`
 	PulpURL                    string                    `json:"pulp_url,omitempty"`
+	PulpContentURL             string                    `json:"pulp_content_url,omitempty"`
 	PulpUsername               string                    `json:"pulp_username,omitempty"`
 	PulpPassword               string                    `json:"pulp_password,omitempty"`
 	PulpContentUsername        string                    `json:"pulp_content_username,omitempty"`
@@ -130,6 +131,7 @@ type Pulp struct {
 	URL                string
 	Username           string
 	Password           string
+	ContentURL         string `mapstructure:"content_url,omitempty"`
 	ContentUsername    string `mapstructure:"content_username,omitempty"`
 	ContentPassword    string `mapstructure:"content_password,omitempty"`
 	IdentityName       string `mapstructure:"identity_name,omitempty"`
@@ -175,7 +177,8 @@ func readPulpConfig() (Pulp, error) {
 	options.SetDefault("url", "http://pulp-service:8080")
 	options.SetDefault("username", "edge-api-dev")
 	options.SetDefault("password", "")
-	options.SetDefault("content_username", "edge-content-dev")
+	options.SetDefault("content_url", "http://pulp-service:8080")
+	options.SetDefault("content_username", "")
 	options.SetDefault("content_password", "")
 	options.SetDefault("guard_subject_dn", "")
 	options.SetDefault("identity_name", "edge-api-dev")
@@ -331,6 +334,7 @@ func CreateEdgeAPIConfig() (*EdgeConfig, error) {
 		SubscriptionServerURL:      options.GetString("SUBSCRIPTION_SERVER_URL"),
 		SubscriptionBaseUrl:        options.GetString("SUBSCRIPTION_BASE_URL"),
 		PulpURL:                    pulpConfig.URL, // these pulp entries are temporary for backward compatibility
+		PulpContentURL:             pulpConfig.ContentURL,
 		PulpUsername:               pulpConfig.Username,
 		PulpPassword:               pulpConfig.Password,
 		PulpContentUsername:        pulpConfig.ContentUsername,
@@ -500,7 +504,7 @@ func Get() *EdgeConfig {
 	return config
 }
 
-func cleanup() {
+func Cleanup() {
 	configMu.Lock()
 	defer configMu.Unlock()
 
@@ -562,6 +566,7 @@ func LogConfigAtStartup(cfg *EdgeConfig) {
 		"RepoFileUploadDelay":      cfg.RepoFileUploadDelay,
 		"UploadWorkers":            cfg.UploadWorkers,
 		"PulpURL":                  cfg.PulpURL,
+		"PulpContentURL":           cfg.PulpContentURL,
 		"PulpGuardSubjectDN":       cfg.PulpGuardSubjectDN,
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -90,7 +90,7 @@ func TestKafkaBroker(t *testing.T) {
 
 	}(originalConfig, originalClowderEnvConfig, originalClowderLoadedConfig, originalClowderObjectBuckets, originalEDGETarBallsBucket)
 
-	defer cleanup()
+	defer Cleanup()
 
 	err := os.Setenv("ACG_CONFIG", "need some value only, as the config path is not needed here")
 	assert.NoError(t, err)
@@ -170,9 +170,9 @@ func TestKafkaBroker(t *testing.T) {
 			clowder.LoadedConfig = testCase.clowderConfig
 			clowder.KafkaServers = testCase.KafkaServers
 			// init the configuration
-			cleanup()
+			Cleanup()
 			Init()
-			defer cleanup()
+			defer Cleanup()
 			assert.Equal(t, config.KafkaBroker, testCase.ExpectedKafkaBroker)
 			assert.Equal(t, config.KafkaServers, testCase.ExpectedKafkaServers)
 			if testCase.ExpectedKafkaBroker != nil {

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -174,6 +174,8 @@ objects:
             secretKeyRef:
               name: edge-pulp-password
               key: key
+        - name : PULP_CONTENT_URL
+          value: ${PULP_CONTENT_URL}
         - name : PULP_CONTENT_USERNAME
           value: ${PULP_CONTENT_USERNAME}
         - name : PULP_CONTENT_PASSWORD
@@ -555,6 +557,9 @@ parameters:
   value: "pulp-user"
 - name: PULP_PASSWORD
   description: Password for Pulp API authentication
+- name: PULP_CONTENT_URL
+  description: Pulp service content URL
+  value: "http://pulp-service:8080"
 - name: PULP_CONTENT_USERNAME
   description: Username for Pulp Content API authentication
   value: "pulp-content-user"

--- a/pkg/clients/pulp/guards_composite_test.go
+++ b/pkg/clients/pulp/guards_composite_test.go
@@ -1,0 +1,91 @@
+package pulp
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/magiconair/properties/assert"
+)
+
+func TestContentGuardHrefsAreEqual(t *testing.T) {
+	var hrefTemplate = "/api/pulp/em%sd/api/v3/contentguards/core/%s/%s/"
+	var orgID = faker.UUIDDigit()
+
+	var href1 = fmt.Sprintf(hrefTemplate, orgID, "header", faker.UUIDHyphenated()) // id
+	var href2 = fmt.Sprintf(hrefTemplate, orgID, "rbac", faker.UUIDHyphenated())   // rbac
+	var href3 = fmt.Sprintf(hrefTemplate, orgID, "header", faker.UUIDHyphenated()) // turnpike
+	var href4 = fmt.Sprintf(hrefTemplate, orgID, "header", faker.UUIDHyphenated()) // different
+
+	var baseSlice = []string{href1, href2, href3}
+	var sameSizeDiffOrder = []string{href3, href2, href1}
+	var sameSizeSameOrder = []string{href1, href2, href3}
+	var sameSizeDiffContent = []string{href1, href2, href4}
+	var diffSmaller = []string{href1, href2}
+	var diffLarger = []string{href1, href2, href3, href4}
+	var sameSizeEmptyString = []string{href1, href2, ""}
+	var sameSizeEmptyStringDiffOrder = []string{"", href2, href1}
+	var sameSizeAllEmptyStrings = []string{"", "", ""}
+	var diffSizeSmallerAllEmptyStrings = []string{"", ""}
+	var diffSizeLargerAllEmptyStrings = []string{"", "", "", ""}
+
+	t.Run("sameslice", func(t *testing.T) {
+		assert.Equal(t, contentGuardHrefsAreEqual(baseSlice, baseSlice), true)
+	})
+
+	t.Run("samesize_differentorder", func(t *testing.T) {
+		assert.Equal(t, contentGuardHrefsAreEqual(baseSlice, sameSizeDiffOrder), true)
+	})
+
+	t.Run("samesize_sameorder", func(t *testing.T) {
+		assert.Equal(t, contentGuardHrefsAreEqual(baseSlice, sameSizeSameOrder), true)
+	})
+
+	t.Run("negative_samesize_differentcontent", func(t *testing.T) {
+		assert.Equal(t, contentGuardHrefsAreEqual(baseSlice, sameSizeDiffContent), false)
+	})
+
+	t.Run("negative_differentsizesmaller", func(t *testing.T) {
+		assert.Equal(t, contentGuardHrefsAreEqual(baseSlice, diffSmaller), false)
+	})
+
+	t.Run("negative_differentsizelarger", func(t *testing.T) {
+		assert.Equal(t, contentGuardHrefsAreEqual(baseSlice, diffLarger), false)
+	})
+
+	t.Run("empty_both", func(t *testing.T) {
+		assert.Equal(t, contentGuardHrefsAreEqual([]string{}, []string{}), true)
+	})
+
+	t.Run("negative_empty_a", func(t *testing.T) {
+		assert.Equal(t, contentGuardHrefsAreEqual([]string{}, baseSlice), false)
+	})
+
+	t.Run("negative_empty_b", func(t *testing.T) {
+		assert.Equal(t, contentGuardHrefsAreEqual(baseSlice, []string{}), false)
+	})
+
+	t.Run("negative_samesize_emptystring", func(t *testing.T) {
+		assert.Equal(t, contentGuardHrefsAreEqual(baseSlice, sameSizeEmptyString), false)
+	})
+
+	t.Run("samesize_oneemptystring_difforder", func(t *testing.T) {
+		assert.Equal(t, contentGuardHrefsAreEqual(sameSizeEmptyString, sameSizeEmptyStringDiffOrder), true)
+	})
+
+	t.Run("negative_samesize_allemptystrings", func(t *testing.T) {
+		assert.Equal(t, contentGuardHrefsAreEqual(baseSlice, sameSizeAllEmptyStrings), false)
+	})
+
+	t.Run("negative_differentsizesmaller_allemptystrings", func(t *testing.T) {
+		assert.Equal(t, contentGuardHrefsAreEqual(sameSizeAllEmptyStrings, diffSizeSmallerAllEmptyStrings), false)
+	})
+
+	t.Run("negative_differentsizelarger_allemptystrings", func(t *testing.T) {
+		assert.Equal(t, contentGuardHrefsAreEqual(sameSizeAllEmptyStrings, diffSizeLargerAllEmptyStrings), false)
+	})
+
+	t.Run("sameslice_allemptystrings", func(t *testing.T) {
+		assert.Equal(t, contentGuardHrefsAreEqual(sameSizeAllEmptyStrings, sameSizeAllEmptyStrings), true)
+	})
+}

--- a/pkg/clients/pulp/guards_turnpike.go
+++ b/pkg/clients/pulp/guards_turnpike.go
@@ -1,0 +1,179 @@
+// Package pulp implements routines for Edge API to interact with the Pulp OSTree service.
+//
+// The Turnpike Content Guard enables cert-based communication between services and the Pulp service.
+package pulp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/redhatinsights/edge-api/config"
+	"github.com/redhatinsights/edge-api/pkg/ptr"
+	"github.com/sirupsen/logrus"
+)
+
+const TurnpikeGuardName = "ostree_turnpike_guard"
+const TurnpikeJQFilter = ".identity.x509.subject_dn"
+
+// TurnpikeGuardList returns a list of header guards. The nameFilter can be used to filter the results.
+func (ps *PulpService) TurnpikeGuardList(ctx context.Context, nameFilter string) ([]HeaderContentGuardResponse, error) {
+	req := ContentguardsCoreHeaderListParams{
+		Limit: &DefaultPageSize,
+	}
+	if nameFilter != "" {
+		req.Name = &nameFilter
+	}
+
+	resp, err := ps.cwr.ContentguardsCoreHeaderListWithResponse(ctx, ps.dom, &req, addAuthenticationHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response: %d, body: %s", resp.StatusCode(), string(resp.Body))
+	}
+
+	if resp.JSON200.Count > DefaultPageSize {
+		return nil, fmt.Errorf("default page size too small: %d", resp.JSON200.Count)
+	}
+
+	if resp.JSON200.Count == 0 || resp.JSON200.Results[0].PulpHref == nil {
+		return nil, ErrRecordNotFound
+	}
+
+	return resp.JSON200.Results, nil
+}
+
+// TurnpikeGuardRead returns the Turnpike guard with the given ID.
+func (ps *PulpService) TurnpikeGuardRead(ctx context.Context, id uuid.UUID) (*HeaderContentGuardResponse, error) {
+	req := ContentguardsCoreHeaderReadParams{}
+	resp, err := ps.cwr.ContentguardsCoreHeaderReadWithResponse(ctx, ps.dom, id, &req, addAuthenticationHeader)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response: %d, body: %s", resp.StatusCode(), string(resp.Body))
+	}
+
+	return resp.JSON200, nil
+}
+
+// TurnpikeGuardFind returns the Turnpike guard.
+func (ps *PulpService) TurnpikeGuardFind(ctx context.Context) (*HeaderContentGuardResponse, error) {
+	hgl, err := ps.TurnpikeGuardList(ctx, TurnpikeGuardName)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"name":  TurnpikeGuardName,
+			"error": err.Error(),
+		}).Error("Turnpike content guard not found")
+
+		if errors.Is(err, ErrRecordNotFound) {
+			return nil, ErrRecordNotFound
+		}
+
+		return nil, err
+	}
+
+	id := ScanUUID(hgl[0].PulpHref)
+	return ps.TurnpikeGuardRead(ctx, id)
+}
+
+// TurnpikeGuardCreate creates a new Turnpike guard and returns it.
+func (ps *PulpService) TurnpikeGuardCreate(ctx context.Context) (*HeaderContentGuardResponse, error) {
+	cfg := config.Get()
+
+	if cfg.Pulp.GuardSubjectDN == "" {
+		return nil, fmt.Errorf("guard subject dn is not set")
+	}
+
+	req := HeaderContentGuard{
+		Name:        TurnpikeGuardName,
+		Description: ptr.To("EDGE"),
+		HeaderName:  "x-rh-identity",
+		HeaderValue: cfg.Pulp.GuardSubjectDN,
+		JqFilter:    ptr.To(TurnpikeJQFilter),
+	}
+
+	resp, err := ps.cwr.ContentguardsCoreHeaderCreateWithResponse(ctx, ps.dom, req, addAuthenticationHeader)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON201 == nil {
+		return nil, fmt.Errorf("unexpected response: %d, body: %s", resp.StatusCode(), string(resp.Body))
+	}
+
+	return resp.JSON201, nil
+}
+
+// TurnpikeGuardEnsure ensures that the Turnpike guard is created and returns it. The method is idempotent.
+func (ps *PulpService) TurnpikeGuardEnsure(ctx context.Context) (*HeaderContentGuardResponse, error) {
+	cg, err := ps.TurnpikeGuardFind(ctx)
+	if errors.Is(err, ErrRecordNotFound) {
+		// turnpike guard is not found, so create one
+		cg, err = ps.TurnpikeGuardCreate(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		return cg, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if cg == nil {
+		return nil, fmt.Errorf("unexpected nil guard")
+	}
+
+	return cg, nil
+}
+
+// TurnpikeGuardDelete deletes the Turnpike guard with the given ID.
+func (ps *PulpService) TurnpikeGuardDelete(ctx context.Context, id uuid.UUID) error {
+	listParams := ContentguardsCoreHeaderListRolesParams{}
+	roles, err := ps.cwr.ContentguardsCoreHeaderListRolesWithResponse(ctx, ps.dom, id, &listParams, addAuthenticationHeader)
+
+	if err != nil {
+		return err
+	}
+
+	if roles.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %d, body: %s", roles.StatusCode(), string(roles.Body))
+	}
+
+	for _, role := range roles.JSON200.Roles {
+		nr := NestedRole{
+			Role:  role.Role,
+			Users: &[]string{},
+		}
+
+		logrus.WithContext(ctx).Warnf("removing Turnpike guardrole: %s", role.Role)
+		removed, err := ps.cwr.ContentguardsCoreHeaderRemoveRoleWithResponse(ctx, ps.dom, id, nr, addAuthenticationHeader)
+
+		if err != nil {
+			return err
+		}
+
+		if removed.JSON201 == nil {
+			return fmt.Errorf("unexpected response: %d, body: %s", removed.StatusCode(), string(removed.Body))
+		}
+	}
+
+	resp, err := ps.cwr.ContentguardsCoreHeaderDelete(ctx, ps.dom, id, addAuthenticationHeader)
+
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != 204 {
+		return fmt.Errorf("unexpected response: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -958,7 +958,7 @@ func (s *ImageService) CreateRepoForImage(ctx context.Context, img *models.Image
 		"aws_status":  repo.Status,
 		"pulp_url":    parsedPulpURL.Redacted(),
 		"pulp_status": repo.PulpStatus,
-	}).Info("OSTree repo is ready")
+	}).Info("OSTree repo process complete")
 
 	if repo.Status != models.RepoStatusSuccess && repo.PulpStatus != models.RepoStatusSuccess {
 		return nil, goErrors.New("No repo has been created")

--- a/pkg/services/repostore/pulpstore_test.go
+++ b/pkg/services/repostore/pulpstore_test.go
@@ -1,0 +1,43 @@
+package repostore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/magiconair/properties/assert"
+	"github.com/redhatinsights/edge-api/config"
+)
+
+func TestDistributionURL(t *testing.T) {
+	var testURL = "https://example.com:8080"
+	var testURLWithPassword = "https://william:tell@example.com:8080"
+	var domain = faker.UUIDDigit()
+	var repoName = faker.UUIDDigit()
+
+	t.Run("without username", func(t *testing.T) {
+		defer config.Cleanup()
+		os.Setenv("PULP_CONTENT_URL", testURL)
+
+		var urlTemplate = "%s/api/pulp-content/%s/%s"
+		var expectedDistURL = fmt.Sprintf(urlTemplate, testURL, domain, repoName)
+
+		distURL, _ := distributionURL(context.Background(), domain, repoName)
+		assert.Equal(t, distURL, expectedDistURL)
+	})
+
+	t.Run("with username", func(t *testing.T) {
+		defer config.Cleanup()
+		os.Setenv("PULP_CONTENT_URL", testURL)
+		os.Setenv("PULP_CONTENT_USERNAME", "william")
+		os.Setenv("PULP_CONTENT_PASSWORD", "tell")
+
+		var urlTemplate = "%s/api/pulp-content/%s/%s"
+		var expectedDistURL = fmt.Sprintf(urlTemplate, testURLWithPassword, domain, repoName)
+
+		distURL, _ := distributionURL(context.Background(), domain, repoName)
+		assert.Equal(t, distURL, expectedDistURL)
+	})
+}


### PR DESCRIPTION
# Description
Add turnpike content guard for ostree and associated feature flag
Add mTLS URL swap to support turnpike switch
Switch RBAC to configurable option

FIXES: HMS-4783

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
