### PR TITLE
build(deps): update stub make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,80 +214,80 @@ vet:
 	go install -a
 	go vet $(BUILD_TAGS) $$(go list $(BUILD_TAGS) ./... | grep -v /vendor/)
 
-pkg/services/mock_services/downloader.go: pkg/services/files/downloader.go
+pkg/services/mock_services/downloader.go: pkg/services/files/downloader.go go.mod
 	mockgen -source=$< -destination=$@ -package=mock_services
 
-pkg/services/mock_services/updates.go: pkg/services/updates.go
+pkg/services/mock_services/updates.go: pkg/services/updates.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/services/mock_services/thirdpartyrepo.go: pkg/services/thirdpartyrepo.go
+pkg/services/mock_services/thirdpartyrepo.go: pkg/services/thirdpartyrepo.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/services/mock_services/repobuilder.go: pkg/services/repobuilder.go
+pkg/services/mock_services/repobuilder.go: pkg/services/repobuilder.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/services/mock_services/imagesets.go: pkg/services/imagesets.go
+pkg/services/mock_services/imagesets.go: pkg/services/imagesets.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/services/mock_services/images.go: pkg/services/images.go
+pkg/services/mock_services/images.go: pkg/services/images.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/services/mock_services/devices.go: pkg/services/devices.go
+pkg/services/mock_services/devices.go: pkg/services/devices.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/services/mock_services/commits.go: pkg/services/commits.go
+pkg/services/mock_services/commits.go: pkg/services/commits.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/services/mock_services/repo.go: pkg/services/repo.go
+pkg/services/mock_services/repo.go: pkg/services/repo.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/services/mock_files/uploader.go: pkg/services/files/uploader.go
+pkg/services/mock_files/uploader.go: pkg/services/files/uploader.go go.mod
 	mockgen -source=$< -destination=$@
 
 # is a copy of the above, before this make target it was a manually created mess
-pkg/services/mock_services/uploader.go: pkg/services/files/uploader.go
+pkg/services/mock_services/uploader.go: pkg/services/files/uploader.go go.mod
 	mockgen -source=$< -destination=$@ -package=mock_services
 
-pkg/services/mock_services/files.go: pkg/services/files.go
+pkg/services/mock_services/files.go: pkg/services/files.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/services/mock_files/s3.go: pkg/services/files/s3.go
+pkg/services/mock_files/s3.go: pkg/services/files/s3.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/services/mock_services/devicegroups.go: pkg/services/devicegroups.go
+pkg/services/mock_services/devicegroups.go: pkg/services/devicegroups.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/services/mock_files/extrator.go: pkg/services/files/extractor.go
+pkg/services/mock_files/extrator.go: pkg/services/files/extractor.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/common/kafka/mock_kafka/mock_topics.go: pkg/common/kafka/topics.go
+pkg/common/kafka/mock_kafka/mock_topics.go: pkg/common/kafka/topics.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/common/kafka/mock_kafka/mock_producer.go: pkg/common/kafka/producer.go
+pkg/common/kafka/mock_kafka/mock_producer.go: pkg/common/kafka/producer.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/common/kafka/mock_kafka/mock_kafkaconfigmap.go: pkg/common/kafka/kafkaconfigmap.go
+pkg/common/kafka/mock_kafka/mock_kafkaconfigmap.go: pkg/common/kafka/kafkaconfigmap.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/common/kafka/mock_kafka/mock_consumer.go: pkg/common/kafka/consumer.go
+pkg/common/kafka/mock_kafka/mock_consumer.go: pkg/common/kafka/consumer.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/clients/repositories/mock_repositories/client.go: pkg/clients/repositories/client.go
+pkg/clients/repositories/mock_repositories/client.go: pkg/clients/repositories/client.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/clients/playbookdispatcher/mock_playbookdispatcher/playbookdispatcher.go: pkg/clients/playbookdispatcher/client.go
+pkg/clients/playbookdispatcher/mock_playbookdispatcher/playbookdispatcher.go: pkg/clients/playbookdispatcher/client.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/clients/rbac/mock_rbac/client.go: pkg/clients/rbac/client.go
+pkg/clients/rbac/mock_rbac/client.go: pkg/clients/rbac/client.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/clients/inventory/mock_inventory/inventory.go: pkg/clients/inventory/client.go
+pkg/clients/inventory/mock_inventory/inventory.go: pkg/clients/inventory/client.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/clients/inventorygroups/mock_inventorygroups/client.go: pkg/clients/inventorygroups/client.go
+pkg/clients/inventorygroups/mock_inventorygroups/client.go: pkg/clients/inventorygroups/client.go go.mod
 	mockgen -source=$< -destination=$@
 
-pkg/clients/imagebuilder/mock_imagebuilder/client.go: pkg/clients/imagebuilder/client.go
+pkg/clients/imagebuilder/mock_imagebuilder/client.go: pkg/clients/imagebuilder/client.go go.mod
 	mockgen -source=$< -destination=$@
 
 mockgen: \

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
 	go.openly.dev/pointy v1.3.0
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	gorm.io/driver/postgres v1.5.9
 	gorm.io/driver/sqlite v1.5.6
 	gorm.io/gorm v1.25.12
@@ -88,6 +87,7 @@ require (
 	go.mongodb.org/mongo-driver v1.16.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.25.0 // indirect
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect

--- a/pkg/clients/pulp/guards_rbac.go
+++ b/pkg/clients/pulp/guards_rbac.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/google/uuid"
 	"github.com/redhatinsights/edge-api/config"
 	"github.com/redhatinsights/edge-api/pkg/ptr"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 )
 
 var guardRbacName = "ROLE=readonly"


### PR DESCRIPTION
I made an attempt to upgrade `gomega`, it requires a manual step of regenerating stubs. But it cannot be done as it requires Go 1.22. So I am at least fixing the `Makefile` it was not regenerating properly when `go.mod` changed.

The second commit gets rid of `x/exp` dependency, no longer needed with Go 1.21.