### PR TITLE
add helper function for switching between pulp and aws repos (HMS-4121)

### DIFF
--- a/pkg/models/commits.go
+++ b/pkg/models/commits.go
@@ -5,6 +5,7 @@ package models
 import (
 	"errors"
 
+	feature "github.com/redhatinsights/edge-api/unleash/features"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
@@ -62,6 +63,18 @@ type Repo struct {
 	Status     string `json:"RepoStatus"`
 	PulpURL    string `json:"pulp_repo_url"`
 	PulpStatus string `json:"pulp_repo_status"`
+}
+
+// GetURL is a temporary helper to return the URL of the preferred repo store
+//
+//	this avoids the feature flag everywhere repo.URL is used
+//	also using GetURL (not URL) to avoid changing the struct used by Gorm
+func (r Repo) GetURL() string {
+	if feature.PulpIntegration.IsEnabled() && r.PulpStatus == RepoStatusSuccess {
+		return r.PulpURL
+	}
+
+	return r.URL
 }
 
 // Package represents the packages a Commit can have

--- a/pkg/routes/storage.go
+++ b/pkg/routes/storage.go
@@ -517,17 +517,17 @@ func ValidateStorageImage(w http.ResponseWriter, r *http.Request) string {
 		return ""
 	}
 
-	if image.Commit.Repo == nil || image.Commit.Repo.URL == "" {
+	if image.Commit.Repo == nil || image.Commit.Repo.GetURL() == "" {
 		logger.Error("image repository does not exist")
 		respondWithAPIError(w, logger, errors.NewNotFound("image repository does not exist"))
 		return ""
 	}
 
-	RepoURL, err := url2.Parse(image.Commit.Repo.URL)
+	RepoURL, err := url2.Parse(image.Commit.Repo.GetURL())
 	if err != nil {
 		logger.WithFields(log.Fields{
 			"error": err.Error(),
-			"URL":   image.Commit.Repo.URL,
+			"URL":   image.Commit.Repo.GetURL(),
 		}).Error("error occurred when parsing repository url")
 		respondWithAPIError(w, logger, errors.NewBadRequest("bad image repository url"))
 		return ""

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -578,7 +578,7 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 				err := errors.NewBadRequest(fmt.Sprintf("Commit repo wasn't found in the database: #%v", image.Commit.ID))
 				return err
 			}
-			image.Commit.OSTreeParentCommit = repo.URL
+			image.Commit.OSTreeParentCommit = repo.GetURL()
 		}
 
 		if config.DistributionsRefs[previousSuccessfulImage.Distribution] != config.DistributionsRefs[image.Distribution] {

--- a/pkg/services/repobuilder.go
+++ b/pkg/services/repobuilder.go
@@ -350,11 +350,11 @@ func (rb *RepoBuilder) BuildUpdateRepo(id uint) (*models.UpdateTransaction, erro
 		if err != nil {
 			return nil, err
 		}
-		update.Repo.URL = updateCommit.Repo.URL
+		update.Repo.URL = updateCommit.Repo.GetURL()
 		rb.log.WithField("update_transaction", update).Info("UPGRADE: point update to commit repo")
 	}
 
-	rb.log.WithField("repo", update.Repo.URL).Info("Update repo URL")
+	rb.log.WithField("repo", update.Repo.GetURL()).Info("Update repo URL")
 	update.Repo.Status = models.RepoStatusSuccess
 	if err := db.DB.Omit("Devices.*").Save(&update).Error; err != nil {
 		return nil, err
@@ -405,7 +405,6 @@ func (rb *RepoBuilder) StoreRepo(ctx context.Context, repo *models.Repo) (*model
 
 // ImportRepo (unpack and upload) a single repo
 func (rb *RepoBuilder) ImportRepo(r *models.Repo) (*models.Repo, error) {
-	// FIXME: delete after Pulp Store Repo is stable
 	var cmt models.Commit
 	cmtDB := db.DB.Where("repo_id = ?", r.ID).First(&cmt)
 	if cmtDB.Error != nil {
@@ -476,7 +475,7 @@ func (rb *RepoBuilder) ImportRepo(r *models.Repo) (*models.Repo, error) {
 		return nil, fmt.Errorf("error saving status :: %s", result.Error.Error())
 	}
 
-	redactedURL, _ := url.Parse(r.URL)
+	redactedURL, _ := url.Parse(r.GetURL())
 	rb.log.WithField("repo_url", redactedURL.Redacted()).Info("Commit stored in AWS OSTree repo")
 
 	return r, nil

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -348,10 +348,7 @@ func (s *UpdateService) CreateUpdate(id uint) (*models.UpdateTransaction, error)
 // NewTemplateRemoteInfo contains the info for the ostree remote file to be written to the system
 func NewTemplateRemoteInfo(update *models.UpdateTransaction) TemplateRemoteInfo {
 
-	updateURL := update.Repo.URL
-	if feature.PulpIntegrationUpdateViaPulp.IsEnabled() {
-		updateURL = update.Repo.PulpURL
-	}
+	updateURL := update.Repo.GetURL()
 
 	return TemplateRemoteInfo{
 		RemoteURL:           updateURL,
@@ -1019,7 +1016,7 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 						return nil, result.Error
 					}
 					s.log.WithFields(log.Fields{
-						"repoURL": repo.URL,
+						"repoURL": repo.GetURL(),
 						"repoID":  repo.ID,
 					}).Debug("Getting repo info")
 				}


### PR DESCRIPTION
# Description
Add a helper method for requesting the correct repo URL when switching between AWS and Pulp as the backing store.
Reduce the feature flag call to one location and call the helper where the correct repo URL is needed.
Enables sending the URL of the Pulp parent repo to Image Builder when an update is requested

FIXES: HMS-4121

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
