### PR TITLE
add/update helpers for aws/pulp content and distribution urls (HMS-4121)

### DIFF
--- a/pkg/models/commits_test.go
+++ b/pkg/models/commits_test.go
@@ -2,9 +2,11 @@
 package models
 
 import (
+	"os"
 	"testing"
 
 	"github.com/bxcodec/faker/v3"
+	"github.com/redhatinsights/edge-api/config"
 	"github.com/redhatinsights/edge-api/pkg/db"
 	"github.com/stretchr/testify/assert"
 )
@@ -33,4 +35,66 @@ func TestCommitsBeforeCreate(t *testing.T) {
 			assert.Equal(t, test.Expected, got)
 		})
 	}
+}
+
+func TestDistributionURL(t *testing.T) {
+	var awsURL = "https://aws.repo.example.com/repo/is/here"
+	var pulpURL = "https://pulp.distribution.example.com/api/pulp-content/pulp/repo/is/here"
+	repo := Repo{
+		URL:        awsURL,
+		Status:     RepoStatusSuccess,
+		PulpURL:    pulpURL,
+		PulpStatus: RepoStatusSuccess,
+	}
+
+	t.Run("return AWS URL", func(t *testing.T) {
+		defer config.Cleanup()
+
+		os.Unsetenv("FEATURE_PULP_INTEGRATION")
+		os.Unsetenv("PULP_CONTENT_URL")
+
+		assert.Equal(t, awsURL, repo.DistributionURL())
+	})
+
+	t.Run("return pulp distribution url", func(t *testing.T) {
+		defer config.Cleanup()
+
+		os.Setenv("FEATURE_PULP_INTEGRATION", "true")
+		os.Setenv("PULP_CONTENT_URL", "http://internal.repo.example.com:8080")
+
+		assert.Equal(t, pulpURL, repo.DistributionURL())
+	})
+}
+
+func TestContentURL(t *testing.T) {
+	var awsURL = "https://aws.repo.example.com/repo/is/here"
+	var pulpURL = "https://pulp.distribution.example.com:3030/api/pulp-content/pulp/repo/is/here"
+	repo := Repo{
+		URL:        awsURL,
+		Status:     RepoStatusSuccess,
+		PulpURL:    pulpURL,
+		PulpStatus: RepoStatusSuccess,
+	}
+
+	t.Run("return pulp content url", func(t *testing.T) {
+		defer config.Cleanup()
+
+		os.Setenv("FEATURE_PULP_INTEGRATION", "true")
+		os.Setenv("PULP_CONTENT_URL", "http://internal.repo.example.com:8080")
+
+		var expectedURL = "https://internal.repo.example.com:8080/api/pulp-content/pulp/repo/is/here"
+
+		assert.Equal(t, expectedURL, repo.ContentURL())
+	})
+
+	t.Run("return aws content url", func(t *testing.T) {
+		defer config.Cleanup()
+
+		os.Unsetenv("FEATURE_PULP_INTEGRATION")
+		os.Unsetenv("PULP_CONTENT_URL")
+
+		var expectedURL = "https://aws.repo.example.com/repo/is/here"
+
+		assert.Equal(t, expectedURL, repo.ContentURL())
+	})
 }

--- a/pkg/routes/storage.go
+++ b/pkg/routes/storage.go
@@ -517,17 +517,17 @@ func ValidateStorageImage(w http.ResponseWriter, r *http.Request) string {
 		return ""
 	}
 
-	if image.Commit.Repo == nil || image.Commit.Repo.GetURL() == "" {
+	if image.Commit.Repo == nil || image.Commit.Repo.DistributionURL() == "" {
 		logger.Error("image repository does not exist")
 		respondWithAPIError(w, logger, errors.NewNotFound("image repository does not exist"))
 		return ""
 	}
 
-	RepoURL, err := url2.Parse(image.Commit.Repo.GetURL())
+	RepoURL, err := url2.Parse(image.Commit.Repo.DistributionURL())
 	if err != nil {
 		logger.WithFields(log.Fields{
 			"error": err.Error(),
-			"URL":   image.Commit.Repo.GetURL(),
+			"URL":   image.Commit.Repo.DistributionURL(),
 		}).Error("error occurred when parsing repository url")
 		respondWithAPIError(w, logger, errors.NewBadRequest("bad image repository url"))
 		return ""

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -578,7 +578,7 @@ func (s *ImageService) UpdateImage(image *models.Image, previousImage *models.Im
 				err := errors.NewBadRequest(fmt.Sprintf("Commit repo wasn't found in the database: #%v", image.Commit.ID))
 				return err
 			}
-			image.Commit.OSTreeParentCommit = repo.GetURL()
+			image.Commit.OSTreeParentCommit = repo.ContentURL()
 		}
 
 		if config.DistributionsRefs[previousSuccessfulImage.Distribution] != config.DistributionsRefs[image.Distribution] {

--- a/pkg/services/repobuilder.go
+++ b/pkg/services/repobuilder.go
@@ -350,11 +350,11 @@ func (rb *RepoBuilder) BuildUpdateRepo(id uint) (*models.UpdateTransaction, erro
 		if err != nil {
 			return nil, err
 		}
-		update.Repo.URL = updateCommit.Repo.GetURL()
+		update.Repo.URL = updateCommit.Repo.ContentURL()
 		rb.log.WithField("update_transaction", update).Info("UPGRADE: point update to commit repo")
 	}
 
-	rb.log.WithField("repo", update.Repo.GetURL()).Info("Update repo URL")
+	rb.log.WithField("repo", update.Repo.ContentURL()).Info("Update repo URL")
 	update.Repo.Status = models.RepoStatusSuccess
 	if err := db.DB.Omit("Devices.*").Save(&update).Error; err != nil {
 		return nil, err
@@ -475,8 +475,8 @@ func (rb *RepoBuilder) ImportRepo(r *models.Repo) (*models.Repo, error) {
 		return nil, fmt.Errorf("error saving status :: %s", result.Error.Error())
 	}
 
-	redactedURL, _ := url.Parse(r.GetURL())
-	rb.log.WithField("repo_url", redactedURL.Redacted()).Info("Commit stored in AWS OSTree repo")
+	logURL, _ := url.Parse(r.DistributionURL())
+	rb.log.WithField("repo_url", logURL.Redacted()).Info("Commit stored in AWS OSTree repo")
 
 	return r, nil
 }

--- a/pkg/services/repostore/pulpstore.go
+++ b/pkg/services/repostore/pulpstore.go
@@ -197,7 +197,7 @@ func fileRepoImport(ctx context.Context, pulpService *pulp.PulpService, sourceUR
 	return artifact, version, nil
 }
 
-// Import imports an artifact into a Pulp repo and deletes the tarfile artifact
+// ostreeRepoImport imports an artifact into a Pulp ostree repo
 func ostreeRepoImport(ctx context.Context, pulpService *pulp.PulpService, pulpHref string, pulpRepoName string,
 	distBaseURL string, fileRepoArtifact string) (string, error) {
 
@@ -213,16 +213,10 @@ func ostreeRepoImport(ctx context.Context, pulpService *pulp.PulpService, pulpHr
 	}
 	log.WithContext(ctx).WithField("repo_href", *repoImported.PulpHref).Info("Repository imported")
 
-	repoURL, err := distributionURL(ctx, pulpService.Domain(), pulpRepoName)
-	if err != nil {
-		log.WithContext(ctx).WithField("error", err.Error()).Error("Error getting distibution URL for Pulp repo")
-		return "", err
-	}
-
-	parsedURL, _ := url.Parse(repoURL)
+	parsedURL, _ := url.Parse(distBaseURL)
 	log.WithContext(ctx).WithFields(log.Fields{
 		"repo_distribution_url": parsedURL.Redacted(),
 	}).Debug("Repo import into Pulp complete")
 
-	return repoURL, nil
+	return distBaseURL, nil
 }

--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -348,7 +348,7 @@ func (s *UpdateService) CreateUpdate(id uint) (*models.UpdateTransaction, error)
 // NewTemplateRemoteInfo contains the info for the ostree remote file to be written to the system
 func NewTemplateRemoteInfo(update *models.UpdateTransaction) TemplateRemoteInfo {
 
-	updateURL := update.Repo.GetURL()
+	updateURL := update.Repo.DistributionURL()
 
 	return TemplateRemoteInfo{
 		RemoteURL:           updateURL,
@@ -1016,7 +1016,7 @@ func (s *UpdateService) BuildUpdateTransactions(devicesUpdate *models.DevicesUpd
 						return nil, result.Error
 					}
 					s.log.WithFields(log.Fields{
-						"repoURL": repo.GetURL(),
+						"repoURL": repo.DistributionURL(),
 						"repoID":  repo.ID,
 					}).Debug("Getting repo info")
 				}


### PR DESCRIPTION
# Description
To accommodate the creation of an update in a repo and the implementation of an update from that repo on a system, it is necessary to differentiate between external and internal hosts with the same repo paths.

* Change GetURL() to DistributionURL() for external Pulp distribution URL or AWS repo URL
* Add ContentURL() to retrieve the internal Distribution URL for Pulp or repo URL for AWS
* Add tests for both DistributionURL() and ContentURL()
* Update calling code with new methods.

FIXES: HMS-4121

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
