### PR TITLE
remove rbac pulp content user creds

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -31,12 +31,6 @@ objects:
 - apiVersion: v1
   kind: Secret
   metadata:
-    name: edge-pulp-content-password
-  stringData:
-    key: ${PULP_CONTENT_PASSWORD}
-- apiVersion: v1
-  kind: Secret
-  metadata:
     name: edge-pulp-test-s3
   stringData:
     region: ${PULP_S3_REGION}
@@ -176,13 +170,6 @@ objects:
               key: key
         - name : PULP_CONTENT_URL
           value: ${PULP_CONTENT_URL}
-        - name : PULP_CONTENT_USERNAME
-          value: ${PULP_CONTENT_USERNAME}
-        - name : PULP_CONTENT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: edge-pulp-content-password
-              key: key
         - name : PULP_S3_REGION
           valueFrom:
             secretKeyRef:
@@ -560,11 +547,6 @@ parameters:
 - name: PULP_CONTENT_URL
   description: Pulp service content URL
   value: "http://pulp-service:8080"
-- name: PULP_CONTENT_USERNAME
-  description: Username for Pulp Content API authentication
-  value: "pulp-content-user"
-- name: PULP_CONTENT_PASSWORD
-  description: Password for Pulp Content API authentication
 - name: PULP_GUARD_SUBJECT_DN
   description: Service account DN 
   value: "pulp/guard/subject/dn"


### PR DESCRIPTION
# Description
Remove RBAC credential config for Pulp RBAC ContentGuard
This will use mTLS instead.

FIXES: HMS-4121

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
