### PR TITLE
swap pulp distribution url with mtls url

### DIFF
--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -360,7 +360,7 @@ func (c *Client) ComposeInstaller(image *models.Image) (*models.Image, error) {
 	}
 
 	if feature.PulpIntegration.IsEnabled() && image.Commit.Repo.PulpURL != "" {
-		repoURL = image.Commit.Repo.PulpURL
+		repoURL = image.Commit.Repo.ContentURL()
 		parsedURL, _ := url.Parse(repoURL)
 		c.log.WithField("redacted_url", parsedURL.Redacted()).Debug("Using Pulp repo URL for ISO installer request")
 	}


### PR DESCRIPTION
# Description
Need to use the mTLS URL for Image Builder to pull content from Pulp for creating an installer ISO.

FIXES: HMS-5363

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
