### PR TITLE
fix type conversion panic on job queue failure

### DIFF
--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -1415,8 +1415,8 @@ func ResumeCreateImageJobHandler(ctx context.Context, job *jobs.Job) {
 }
 
 func ResumeCreateImageFailHandler(ctx context.Context, job *jobs.Job) {
-	args := job.Args.(*ProcessImageJob)
-	db.DBx(ctx).Model(&models.Image{}).Where("ID = ?", args.ImageID).Update("Status", models.ImageStatusInterrupted)
+	args := job.Args.(*ResumeCreateImageJob)
+	db.DBx(ctx).Model(&models.Image{}).Where("ID = ?", args.Image.ID).Update("Status", models.ImageStatusError)
 }
 
 func init() {


### PR DESCRIPTION
# Description
Fix an interface conversion panic in the job queue failure handler for resume create image where it was passing ProcessImageJob instead of ResumeCreateImageJob

* Fixed interface conversion panic
* Changed failure state to Error instead of Interrupted to avoid infinite loop of resumed builds on repeatable errors

FIXES: HMS-5383

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
