### PR TITLE
pass context through stack for feature flagging

### DIFF
--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -28,7 +28,7 @@ import (
 // ClientInterface is an Interface to make request to ImageBuilder
 type ClientInterface interface {
 	ComposeCommit(image *models.Image) (*models.Image, error)
-	ComposeInstaller(image *models.Image) (*models.Image, error)
+	ComposeInstaller(ctx context.Context, image *models.Image) (*models.Image, error)
 	GetCommitStatus(image *models.Image) (*models.Image, error)
 	GetInstallerStatus(image *models.Image) (*models.Image, error)
 	GetMetadata(image *models.Image) (*models.Image, error)
@@ -345,7 +345,7 @@ func (c *Client) ComposeCommit(image *models.Image) (*models.Image, error) {
 }
 
 // ComposeInstaller composes an Installer on ImageBuilder
-func (c *Client) ComposeInstaller(image *models.Image) (*models.Image, error) {
+func (c *Client) ComposeInstaller(ctx context.Context, image *models.Image) (*models.Image, error) {
 	c.log.Debug("COMPOSING INSTALLER")
 
 	pkgs := make([]string, 0)
@@ -359,8 +359,8 @@ func (c *Client) ComposeInstaller(image *models.Image) (*models.Image, error) {
 		rhsm = false
 	}
 
-	if feature.PulpIntegration.IsEnabled() && image.Commit.Repo.PulpURL != "" {
-		repoURL = image.Commit.Repo.ContentURL()
+	if feature.PulpIntegration.IsEnabledCtx(ctx) && image.Commit.Repo.ContentURL(ctx) != "" {
+		repoURL = image.Commit.Repo.ContentURL(ctx)
 		parsedURL, _ := url.Parse(repoURL)
 		c.log.WithField("redacted_url", parsedURL.Redacted()).Debug("Using Pulp repo URL for ISO installer request")
 	}

--- a/pkg/clients/imagebuilder/client_test.go
+++ b/pkg/clients/imagebuilder/client_test.go
@@ -713,7 +713,9 @@ var _ = Describe("Image Builder Client Test", func() {
 			},
 			Installer: &models.Installer{},
 		}
-		img, err := client.ComposeInstaller(img)
+		ctx := context.Background()
+
+		img, err := client.ComposeInstaller(ctx, img)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(img).ToNot(BeNil())
 		Expect(img.Installer.ComposeJobID).To(Equal("compose-job-id-returned-from-image-builder"))
@@ -750,7 +752,9 @@ var _ = Describe("Image Builder Client Test", func() {
 			Commit:       &models.Commit{Arch: "x86_64", Repo: &models.Repo{}},
 			Installer:    &installer,
 		}
-		img, err := client.ComposeInstaller(img)
+
+		ctx := context.Background()
+		img, err := client.ComposeInstaller(ctx, img)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(img).ToNot(BeNil())
 		Expect(img.Installer.ComposeJobID).To(Equal(composeJobID))
@@ -787,7 +791,9 @@ var _ = Describe("Image Builder Client Test", func() {
 			Commit:       &models.Commit{Arch: "x86_64", Repo: &models.Repo{}},
 			Installer:    &installer,
 		}
-		img, err := client.ComposeInstaller(img)
+		ctx := context.Background()
+
+		img, err := client.ComposeInstaller(ctx, img)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(img).ToNot(BeNil())
 		Expect(img.Installer.ComposeJobID).To(Equal(composeJobID))
@@ -831,7 +837,10 @@ var _ = Describe("Image Builder Client Test", func() {
 			Installer:     &installer,
 			ActivationKey: "test-key",
 		}
-		img, err := client.ComposeInstaller(img)
+
+		ctx := context.Background()
+
+		img, err := client.ComposeInstaller(ctx, img)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(img).ToNot(BeNil())
 		Expect(img.Installer.ComposeJobID).To(Equal(composeJobID))
@@ -866,7 +875,9 @@ var _ = Describe("Image Builder Client Test", func() {
 			Commit:       &models.Commit{Arch: "x86_64", Repo: &models.Repo{}},
 			Installer:    &installer,
 		}
-		img, err := client.ComposeInstaller(img)
+
+		ctx := context.Background()
+		img, err := client.ComposeInstaller(ctx, img)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(img).ToNot(BeNil())
 		Expect(img.Installer.ComposeJobID).To(Equal(composeJobID))
@@ -999,7 +1010,8 @@ var _ = Describe("Image Builder Client Test", func() {
 			defer ts.Close()
 			config.Get().ImageBuilderConfig.URL = ts.URL
 
-			image, err := client.ComposeInstaller(&img)
+			ctx := context.Background()
+			image, err := client.ComposeInstaller(ctx, &img)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(image).ToNot(BeNil())
 			Expect(image.Installer.ComposeJobID).To(Equal(composeJobID))

--- a/pkg/clients/imagebuilder/mock_imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/mock_imagebuilder/client.go
@@ -5,6 +5,7 @@
 package mock_imagebuilder
 
 import (
+	context "context"
 	http "net/http"
 	reflect "reflect"
 
@@ -51,18 +52,18 @@ func (mr *MockClientInterfaceMockRecorder) ComposeCommit(image interface{}) *gom
 }
 
 // ComposeInstaller mocks base method.
-func (m *MockClientInterface) ComposeInstaller(image *models.Image) (*models.Image, error) {
+func (m *MockClientInterface) ComposeInstaller(ctx context.Context, image *models.Image) (*models.Image, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ComposeInstaller", image)
+	ret := m.ctrl.Call(m, "ComposeInstaller", ctx, image)
 	ret0, _ := ret[0].(*models.Image)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ComposeInstaller indicates an expected call of ComposeInstaller.
-func (mr *MockClientInterfaceMockRecorder) ComposeInstaller(image interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) ComposeInstaller(ctx, image interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComposeInstaller", reflect.TypeOf((*MockClientInterface)(nil).ComposeInstaller), image)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComposeInstaller", reflect.TypeOf((*MockClientInterface)(nil).ComposeInstaller), ctx, image)
 }
 
 // GetCommitStatus mocks base method.

--- a/pkg/models/commits.go
+++ b/pkg/models/commits.go
@@ -3,6 +3,7 @@
 package models
 
 import (
+	"context"
 	"errors"
 	"net/url"
 
@@ -69,10 +70,10 @@ type Repo struct {
 }
 
 // ContentURL is the URL for internal and Image Builder access to the content in a Pulp repo
-func (r Repo) ContentURL() string {
+func (r Repo) ContentURL(ctx context.Context) string {
 	pulpConfig := config.Get().Pulp
 
-	if feature.PulpIntegration.IsEnabled() && r.PulpStatus == RepoStatusSuccess {
+	if feature.PulpIntegration.IsEnabledCtx(ctx) && r.PulpStatus == RepoStatusSuccess {
 		parsedURL, _ := url.Parse(r.PulpURL)
 		parsedConfigContentURL, _ := url.Parse(pulpConfig.ContentURL)
 		parsedURL.Host = parsedConfigContentURL.Host
@@ -84,8 +85,8 @@ func (r Repo) ContentURL() string {
 }
 
 // DistributionURL is the URL for external access to the content in a Pulp repo
-func (r Repo) DistributionURL() string {
-	if feature.PulpIntegration.IsEnabled() && r.PulpStatus == RepoStatusSuccess {
+func (r Repo) DistributionURL(ctx context.Context) string {
+	if feature.PulpIntegration.IsEnabledCtx(ctx) && r.PulpStatus == RepoStatusSuccess {
 		return r.PulpURL
 	}
 

--- a/pkg/models/commits_test.go
+++ b/pkg/models/commits_test.go
@@ -2,6 +2,7 @@
 package models
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -38,6 +39,7 @@ func TestCommitsBeforeCreate(t *testing.T) {
 }
 
 func TestDistributionURL(t *testing.T) {
+	ctx := context.Background()
 	var awsURL = "https://aws.repo.example.com/repo/is/here"
 	var pulpURL = "https://pulp.distribution.example.com/api/pulp-content/pulp/repo/is/here"
 	repo := Repo{
@@ -53,7 +55,7 @@ func TestDistributionURL(t *testing.T) {
 		os.Unsetenv("FEATURE_PULP_INTEGRATION")
 		os.Unsetenv("PULP_CONTENT_URL")
 
-		assert.Equal(t, awsURL, repo.DistributionURL())
+		assert.Equal(t, awsURL, repo.DistributionURL(ctx))
 	})
 
 	t.Run("return pulp distribution url", func(t *testing.T) {
@@ -62,11 +64,13 @@ func TestDistributionURL(t *testing.T) {
 		os.Setenv("FEATURE_PULP_INTEGRATION", "true")
 		os.Setenv("PULP_CONTENT_URL", "http://internal.repo.example.com:8080")
 
-		assert.Equal(t, pulpURL, repo.DistributionURL())
+		assert.Equal(t, pulpURL, repo.DistributionURL(ctx))
 	})
 }
 
 func TestContentURL(t *testing.T) {
+	ctx := context.Background()
+
 	var awsURL = "https://aws.repo.example.com/repo/is/here"
 	var pulpURL = "https://pulp.distribution.example.com:3030/api/pulp-content/pulp/repo/is/here"
 	repo := Repo{
@@ -84,7 +88,7 @@ func TestContentURL(t *testing.T) {
 
 		var expectedURL = "https://internal.repo.example.com:8080/api/pulp-content/pulp/repo/is/here"
 
-		assert.Equal(t, expectedURL, repo.ContentURL())
+		assert.Equal(t, expectedURL, repo.ContentURL(ctx))
 	})
 
 	t.Run("return aws content url", func(t *testing.T) {
@@ -95,6 +99,6 @@ func TestContentURL(t *testing.T) {
 
 		var expectedURL = "https://aws.repo.example.com/repo/is/here"
 
-		assert.Equal(t, expectedURL, repo.ContentURL())
+		assert.Equal(t, expectedURL, repo.ContentURL(ctx))
 	})
 }

--- a/pkg/routes/devicegroups.go
+++ b/pkg/routes/devicegroups.go
@@ -880,7 +880,7 @@ func UpdateAllDevicesFromGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// should be refactored to avoid performance issue with large volume
-	updates, err := ctxServices.UpdateService.BuildUpdateTransactions(&devicesUpdate, orgID, commit)
+	updates, err := ctxServices.UpdateService.BuildUpdateTransactions(r.Context(), &devicesUpdate, orgID, commit)
 	if err != nil {
 		ctxServices.Log.WithFields(log.Fields{
 			"error":  err.Error(),

--- a/pkg/routes/devicegroups_test.go
+++ b/pkg/routes/devicegroups_test.go
@@ -823,7 +823,7 @@ var _ = Describe("DeviceGroup routes", func() {
 					Return(commitID, nil)
 				mockCommitService.EXPECT().GetCommitByID(commitID, orgID).
 					Return(&commit, nil)
-				mockUpdateService.EXPECT().BuildUpdateTransactions(&devicesUpdate, orgID, &commit).
+				mockUpdateService.EXPECT().BuildUpdateTransactions(ctx, &devicesUpdate, orgID, &commit).
 					Return(&updTransactions, nil)
 				for _, trans := range updTransactions {
 					mockUpdateService.EXPECT().CreateUpdateAsync(trans.ID)

--- a/pkg/routes/images.go
+++ b/pkg/routes/images.go
@@ -266,7 +266,7 @@ func CreateImageUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctxServices.Log.Debug("Updating an image from API request")
-	err = ctxServices.ImageService.UpdateImage(image, previousImage)
+	err = ctxServices.ImageService.UpdateImage(r.Context(), image, previousImage)
 	if err != nil {
 		ctxServices.Log.WithField("error", err.Error()).Error("Failed creating an update to an image")
 		var apiError errors.APIError

--- a/pkg/routes/images_test.go
+++ b/pkg/routes/images_test.go
@@ -1313,7 +1313,6 @@ var _ = Describe("Images Route Tests", func() {
 
 			It("should update image successfully", func() {
 				Expect(res.Error).ToNot(HaveOccurred())
-
 				var buf bytes.Buffer
 				err := json.NewEncoder(&buf).Encode(&updateImage)
 				Expect(err).ToNot(HaveOccurred())
@@ -1324,7 +1323,7 @@ var _ = Describe("Images Route Tests", func() {
 				mockImagesService.EXPECT().GetImageByID(strconv.Itoa(int(image.ID))).Return(&image, nil)
 				// we cannot predict the instance value of first argument, we know that it's updateImage
 				// but as it's un-marshaled it's using an other pointer, most important assertions are those at the end of the test
-				mockImagesService.EXPECT().UpdateImage(gomock.Any(), &image).Return(nil)
+				mockImagesService.EXPECT().UpdateImage(gomock.Any(), gomock.Any(), &image).Return(nil)
 				// same here for context and updateImage
 				mockImagesService.EXPECT().ProcessImage(gomock.Any(), gomock.Any(), gomock.Any())
 				httpTestRecorder := httptest.NewRecorder()
@@ -1356,7 +1355,7 @@ var _ = Describe("Images Route Tests", func() {
 				// we cannot predict the instance value of first argument, we know that it's updateImage
 				// but as it's un-marshaled it's using an other pointer, most important assertions are those at the end of the test
 				expectedErr := new(services.PackageNameDoesNotExist)
-				mockImagesService.EXPECT().UpdateImage(gomock.Any(), &image).Return(expectedErr)
+				mockImagesService.EXPECT().UpdateImage(gomock.Any(), gomock.Any(), &image).Return(expectedErr)
 				httpTestRecorder := httptest.NewRecorder()
 				router.ServeHTTP(httpTestRecorder, req)
 
@@ -1378,7 +1377,7 @@ var _ = Describe("Images Route Tests", func() {
 				// we cannot predict the instance value of first argument, we know that it's updateImage
 				// but as it's un-marshaled it's using an other pointer, most important assertions are those at the end of the test
 				expectedErr := errors.New("unknown error occurred")
-				mockImagesService.EXPECT().UpdateImage(gomock.Any(), &image).Return(expectedErr)
+				mockImagesService.EXPECT().UpdateImage(gomock.Any(), gomock.Any(), &image).Return(expectedErr)
 				httpTestRecorder := httptest.NewRecorder()
 				router.ServeHTTP(httpTestRecorder, req)
 
@@ -1410,7 +1409,7 @@ var _ = Describe("Images Route Tests", func() {
 				mockImagesService.EXPECT().GetImageByID(strconv.Itoa(int(image.ID))).Return(&image, nil)
 				// we cannot predict the instance value of first argument, we know that it's updateImage
 				// but as it's un-marshaled it's using another pointer.
-				mockImagesService.EXPECT().UpdateImage(gomock.AssignableToTypeOf(&updateImage), &image).Return(nil)
+				mockImagesService.EXPECT().UpdateImage(gomock.Any(), gomock.AssignableToTypeOf(&updateImage), &image).Return(nil)
 				// same here for context and updateImage
 				mockImagesService.EXPECT().ProcessImage(gomock.Any(), gomock.AssignableToTypeOf(&updateImage), gomock.Any())
 
@@ -1454,7 +1453,7 @@ var _ = Describe("Images Route Tests", func() {
 				mockImagesService.EXPECT().GetImageByID(strconv.Itoa(int(image.ID))).Return(&image, nil)
 				// we cannot predict the instance value of first argument, we know that it's updateImage
 				// but as it's un-marshaled it's using another pointer.
-				mockImagesService.EXPECT().UpdateImage(gomock.AssignableToTypeOf(&updateImage), &image).Return(new(services.ImageNameChangeIsProhibited))
+				mockImagesService.EXPECT().UpdateImage(gomock.Any(), gomock.AssignableToTypeOf(&updateImage), &image).Return(new(services.ImageNameChangeIsProhibited))
 
 				httpTestRecorder := httptest.NewRecorder()
 				router.ServeHTTP(httpTestRecorder, req)

--- a/pkg/routes/storage.go
+++ b/pkg/routes/storage.go
@@ -517,17 +517,17 @@ func ValidateStorageImage(w http.ResponseWriter, r *http.Request) string {
 		return ""
 	}
 
-	if image.Commit.Repo == nil || image.Commit.Repo.DistributionURL() == "" {
+	if image.Commit.Repo == nil || image.Commit.Repo.DistributionURL(r.Context()) == "" {
 		logger.Error("image repository does not exist")
 		respondWithAPIError(w, logger, errors.NewNotFound("image repository does not exist"))
 		return ""
 	}
 
-	RepoURL, err := url2.Parse(image.Commit.Repo.DistributionURL())
+	RepoURL, err := url2.Parse(image.Commit.Repo.DistributionURL(r.Context()))
 	if err != nil {
 		logger.WithFields(log.Fields{
 			"error": err.Error(),
-			"URL":   image.Commit.Repo.DistributionURL(),
+			"URL":   image.Commit.Repo.DistributionURL(r.Context()),
 		}).Error("error occurred when parsing repository url")
 		respondWithAPIError(w, logger, errors.NewBadRequest("bad image repository url"))
 		return ""

--- a/pkg/routes/updates.go
+++ b/pkg/routes/updates.go
@@ -301,7 +301,7 @@ func updateFromHTTP(w http.ResponseWriter, r *http.Request) *[]models.UpdateTran
 		}
 	}
 	ctxServices.Log.WithField("commit", commit.ID).Debug("Commit retrieved from this update")
-	updates, err := ctxServices.UpdateService.BuildUpdateTransactions(&devicesUpdate, orgID, commit)
+	updates, err := ctxServices.UpdateService.BuildUpdateTransactions(r.Context(), &devicesUpdate, orgID, commit)
 	if err != nil {
 		ctxServices.Log.WithFields(log.Fields{
 			"error":  err.Error(),

--- a/pkg/routes/updates_test.go
+++ b/pkg/routes/updates_test.go
@@ -385,7 +385,7 @@ var _ = Describe("Update routes", func() {
 				ctx = dependencies.ContextWithServices(ctx, edgeAPIServices)
 				req = req.WithContext(ctx)
 
-				mockUpdateService.EXPECT().BuildUpdateTransactions(gomock.Any(), orgID, gomock.Any()).Return(&[]models.UpdateTransaction{}, nil)
+				mockUpdateService.EXPECT().BuildUpdateTransactions(ctx, gomock.Any(), orgID, gomock.Any()).Return(&[]models.UpdateTransaction{}, nil)
 
 				rr := httptest.NewRecorder()
 				handler := http.HandlerFunc(AddUpdate)
@@ -433,7 +433,7 @@ var _ = Describe("Update routes", func() {
 				ctx = dependencies.ContextWithServices(ctx, edgeAPIServices)
 				req = req.WithContext(ctx)
 
-				mockUpdateService.EXPECT().BuildUpdateTransactions(gomock.Any(), orgID, gomock.Any()).Return(&updateTransactions, nil)
+				mockUpdateService.EXPECT().BuildUpdateTransactions(ctx, gomock.Any(), orgID, gomock.Any()).Return(&updateTransactions, nil)
 				mockUpdateService.EXPECT().CreateUpdateAsync(updateTransactions[0].ID)
 
 				responseRecorder := httptest.NewRecorder()
@@ -453,7 +453,7 @@ var _ = Describe("Update routes", func() {
 				ctx = dependencies.ContextWithServices(ctx, edgeAPIServices)
 				req = req.WithContext(ctx)
 
-				mockUpdateService.EXPECT().BuildUpdateTransactions(gomock.Any(), orgID, gomock.Any()).Return(&updateTransactions, nil)
+				mockUpdateService.EXPECT().BuildUpdateTransactions(ctx, gomock.Any(), orgID, gomock.Any()).Return(&updateTransactions, nil)
 				mockUpdateService.EXPECT().CreateUpdateAsync(updateTransactions[0].ID)
 
 				responseRecorder := httptest.NewRecorder()
@@ -632,7 +632,7 @@ var _ = Describe("Update routes", func() {
 				req = req.WithContext(ctx)
 				var desiredCommit models.Commit
 				db.DB.First(&desiredCommit, &commits[2].ID)
-				mockUpdateService.EXPECT().BuildUpdateTransactions(&models.DevicesUpdate{DevicesUUID: []string{device.UUID}, CommitID: commits[2].ID},
+				mockUpdateService.EXPECT().BuildUpdateTransactions(ctx, &models.DevicesUpdate{DevicesUUID: []string{device.UUID}, CommitID: commits[2].ID},
 					orgID, &desiredCommit).
 					Return(&[]models.UpdateTransaction{}, nil)
 				rr := httptest.NewRecorder()
@@ -658,7 +658,7 @@ var _ = Describe("Update routes", func() {
 				req = req.WithContext(ctx)
 				var desiredCommit models.Commit
 				db.DB.First(&desiredCommit, &commits[3].ID)
-				mockUpdateService.EXPECT().BuildUpdateTransactions(&models.DevicesUpdate{DevicesUUID: []string{device.UUID}, CommitID: commits[3].ID},
+				mockUpdateService.EXPECT().BuildUpdateTransactions(ctx, &models.DevicesUpdate{DevicesUUID: []string{device.UUID}, CommitID: commits[3].ID},
 					orgID, &desiredCommit).
 					Return(&[]models.UpdateTransaction{}, nil)
 

--- a/pkg/services/images_test.go
+++ b/pkg/services/images_test.go
@@ -43,6 +43,8 @@ import (
 )
 
 var _ = Describe("Image Service Test", func() {
+	ctx := context.Background()
+
 	var ctrl *gomock.Controller
 	var service services.ImageService
 	var hash string
@@ -388,10 +390,12 @@ var _ = Describe("Image Service Test", func() {
 		})
 	})
 	Describe("update image", func() {
+		ctx := context.Background()
+
 		Context("when previous image does not exist", func() {
 			var err error
 			BeforeEach(func() {
-				err = service.UpdateImage(&models.Image{}, nil)
+				err = service.UpdateImage(ctx, &models.Image{}, nil)
 			})
 			It("should have an error", func() {
 				Expect(err).To(HaveOccurred())
@@ -400,6 +404,7 @@ var _ = Describe("Image Service Test", func() {
 		})
 		Context("when previous image has failed status", func() {
 			It("should have an error returned by image builder", func() {
+				ctx := context.Background()
 				id, _ := faker.RandomInt(1)
 				uid := uint(id[0])
 				orgID := faker.UUIDHyphenated()
@@ -428,7 +433,7 @@ var _ = Describe("Image Service Test", func() {
 				expectedErr := fmt.Errorf("Failed creating commit for image")
 				mockImageBuilderClient.EXPECT().ComposeCommit(image).Return(image, expectedErr)
 				mockRepoService.EXPECT().GetRepoByID(previousImage.Commit.RepoID).Return(&models.Repo{}, nil)
-				actualErr := service.UpdateImage(image, previousImage)
+				actualErr := service.UpdateImage(ctx, image, previousImage)
 
 				Expect(actualErr).To(HaveOccurred())
 				Expect(actualErr).To(MatchError(expectedErr))
@@ -478,7 +483,7 @@ var _ = Describe("Image Service Test", func() {
 				expectedErr := fmt.Errorf("failed creating commit for image")
 				mockImageBuilderClient.EXPECT().ComposeCommit(image).Return(image, expectedErr)
 
-				actualErr := service.UpdateImage(image, &previousImage2)
+				actualErr := service.UpdateImage(ctx, image, &previousImage2)
 				Expect(actualErr).To(HaveOccurred())
 				Expect(actualErr).To(MatchError(expectedErr))
 				Expect(image.Commit.OSTreeRef).To(Equal(config.DistributionsRefs[dist85]))
@@ -542,7 +547,7 @@ var _ = Describe("Image Service Test", func() {
 				mockRepoService.EXPECT().GetRepoByID(previousImage2.Commit.RepoID).Return(previousImage2.Commit.Repo, nil)
 
 				// the previous successful image is previousImage2
-				actualErr := service.UpdateImage(image, &previousImage3)
+				actualErr := service.UpdateImage(ctx, image, &previousImage3)
 				Expect(actualErr).To(HaveOccurred())
 				Expect(actualErr).To(MatchError(expectedErr))
 				Expect(image.Commit.OSTreeRef).To(Equal(config.DistributionsRefs[dist85]))
@@ -594,7 +599,7 @@ var _ = Describe("Image Service Test", func() {
 				expectedErr := fmt.Errorf("failed creating commit for image")
 				mockImageBuilderClient.EXPECT().ComposeCommit(image).Return(image, expectedErr)
 
-				actualErr := service.UpdateImage(image, &previousImage2)
+				actualErr := service.UpdateImage(ctx, image, &previousImage2)
 				Expect(actualErr).To(HaveOccurred())
 				Expect(actualErr).To(MatchError(expectedErr))
 				Expect(image.Commit.OSTreeRef).To(Equal(config.DistributionsRefs[dist90]))
@@ -660,7 +665,7 @@ var _ = Describe("Image Service Test", func() {
 				mockRepoService.EXPECT().GetRepoByID(previousImage2.Commit.RepoID).Return(previousImage2.Commit.Repo, nil)
 
 				// the previous successful image is previousImage2
-				actualErr := service.UpdateImage(image, &previousImage3)
+				actualErr := service.UpdateImage(ctx, image, &previousImage3)
 				Expect(actualErr).To(HaveOccurred())
 				Expect(actualErr).To(MatchError(expectedErr))
 				Expect(image.Commit.OSTreeRef).To(Equal(config.DistributionsRefs[dist90]))
@@ -701,7 +706,7 @@ var _ = Describe("Image Service Test", func() {
 				expectedErr := fmt.Errorf("Failed creating commit for image")
 				mockImageBuilderClient.EXPECT().ComposeCommit(image).Return(image, expectedErr)
 				mockRepoService.EXPECT().GetRepoByID(previousImage.Commit.RepoID).Return(parentRepo, nil)
-				actualErr := service.UpdateImage(image, previousImage)
+				actualErr := service.UpdateImage(ctx, image, previousImage)
 
 				Expect(actualErr).To(HaveOccurred())
 				Expect(actualErr).To(MatchError(expectedErr))
@@ -753,7 +758,7 @@ var _ = Describe("Image Service Test", func() {
 					expectedErr := fmt.Errorf("Failed creating commit for image")
 					mockImageBuilderClient.EXPECT().ComposeCommit(image).Return(image, expectedErr)
 					mockRepoService.EXPECT().GetRepoByID(previousImage.Commit.RepoID).Return(&repo, nil)
-					actualErr := service.UpdateImage(image, previousImage)
+					actualErr := service.UpdateImage(ctx, image, previousImage)
 					Expect(actualErr).To(HaveOccurred())
 					Expect(actualErr).To(MatchError(expectedErr))
 
@@ -779,7 +784,7 @@ var _ = Describe("Image Service Test", func() {
 						expectedErr := fmt.Errorf("Failed creating commit for image")
 						mockImageBuilderClient.EXPECT().ComposeCommit(image).Return(image, expectedErr)
 						mockRepoService.EXPECT().GetRepoByID(previousImage.Commit.RepoID).Return(&repo, nil)
-						actualErr := service.UpdateImage(image, previousImage)
+						actualErr := service.UpdateImage(ctx, image, previousImage)
 						Expect(actualErr).To(HaveOccurred())
 						Expect(actualErr).To(MatchError(expectedErr))
 
@@ -832,7 +837,7 @@ var _ = Describe("Image Service Test", func() {
 					expectedErr := fmt.Errorf("Failed creating commit for image")
 					mockImageBuilderClient.EXPECT().ComposeCommit(image).Return(image, expectedErr)
 					mockRepoService.EXPECT().GetRepoByID(previousImage.Commit.RepoID).Return(&repo, nil)
-					actualErr := service.UpdateImage(image, previousImage)
+					actualErr := service.UpdateImage(ctx, image, previousImage)
 					Expect(actualErr).To(HaveOccurred())
 					Expect(actualErr).To(MatchError(expectedErr))
 
@@ -879,7 +884,7 @@ var _ = Describe("Image Service Test", func() {
 				expectedErr := fmt.Errorf("Failed creating commit for image")
 				mockImageBuilderClient.EXPECT().ComposeCommit(image).Return(image, expectedErr)
 				mockRepoService.EXPECT().GetRepoByID(previousImage.Commit.RepoID).Return(parentRepo, nil)
-				actualErr := service.UpdateImage(image, previousImage)
+				actualErr := service.UpdateImage(ctx, image, previousImage)
 
 				Expect(actualErr).To(HaveOccurred())
 				Expect(actualErr).To(MatchError(expectedErr))
@@ -930,7 +935,7 @@ var _ = Describe("Image Service Test", func() {
 				expectedErr := fmt.Errorf("Failed creating commit for image")
 				mockImageBuilderClient.EXPECT().ComposeCommit(image).Return(image, expectedErr)
 
-				actualErr := service.UpdateImage(image, previousImage)
+				actualErr := service.UpdateImage(ctx, image, previousImage)
 
 				Expect(actualErr).To(HaveOccurred())
 				Expect(actualErr).To(MatchError(expectedErr))
@@ -977,7 +982,7 @@ var _ = Describe("Image Service Test", func() {
 				expectedErr := fmt.Errorf("failed creating commit for image")
 				mockImageBuilderClient.EXPECT().ComposeCommit(&updateImage).Return(&updateImage, expectedErr)
 
-				actualErr := service.UpdateImage(&updateImage, &image)
+				actualErr := service.UpdateImage(ctx, &updateImage, &image)
 				Expect(actualErr).To(HaveOccurred())
 				Expect(actualErr).To(MatchError(expectedErr))
 				Expect(updateImage.Name).To(Equal(image.Name))
@@ -996,7 +1001,7 @@ var _ = Describe("Image Service Test", func() {
 
 				expectedError := new(services.ImageNameChangeIsProhibited)
 
-				actualErr := service.UpdateImage(&updateImage, &image)
+				actualErr := service.UpdateImage(ctx, &updateImage, &image)
 				Expect(actualErr).To(HaveOccurred())
 				Expect(actualErr).To(MatchError(expectedError))
 			})
@@ -1487,7 +1492,7 @@ var _ = Describe("Image Service Test", func() {
 				mockRepositories.EXPECT().GetRepositoryByURL(emRepos[1].URL).Return(&csRepos[1], nil)
 				mockRepositories.EXPECT().GetRepositoryByURL(emRepos[2].URL).Return(&csRepos[2], nil)
 
-				err := service.UpdateImage(&image, &previousImage)
+				err := service.UpdateImage(ctx, &image, &previousImage)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(expectedError))
 				Expect(len(image.ThirdPartyRepositories)).To(Equal(3))
@@ -1506,7 +1511,7 @@ var _ = Describe("Image Service Test", func() {
 				expectedError := errors.New("expected unknown GetRepositoryByUUID error")
 				mockRepositories.EXPECT().GetRepositoryByURL(emRepos[0].URL).Return(nil, expectedError)
 
-				err := service.UpdateImage(&image, &previousImage)
+				err := service.UpdateImage(ctx, &image, &previousImage)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(expectedError))
 			})
@@ -2089,7 +2094,7 @@ var _ = Describe("Image Service Test", func() {
 			imageBuilder := &models.SearchPackageResult{}
 			imageBuilder.Meta.Count = 0
 			mockImageBuilderClient.EXPECT().SearchPackage("badrpm", "x86_64", "rhel-85").Return(imageBuilder, expectedErr)
-			actualErr := service.UpdateImage(image, previousImage)
+			actualErr := service.UpdateImage(ctx, image, previousImage)
 			Expect(actualErr).To(HaveOccurred())
 			Expect(actualErr).To(MatchError(expectedErr))
 		})
@@ -2594,7 +2599,7 @@ var _ = Describe("Image Service Test", func() {
 			}
 			err := db.DB.Create(&expectedRepo).Error
 			Expect(err).ToNot(HaveOccurred())
-			mockRepoBuilder.EXPECT().ImportRepo(gomock.AssignableToTypeOf(&models.Repo{})).Return(&expectedRepo, nil)
+			mockRepoBuilder.EXPECT().ImportRepo(ctx, gomock.AssignableToTypeOf(&models.Repo{})).Return(&expectedRepo, nil)
 			_, err = service.CreateRepoForImage(context.Background(), image)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -2608,7 +2613,7 @@ var _ = Describe("Image Service Test", func() {
 			}
 			err := db.DB.Create(&expectedRepo).Error
 			Expect(err).ToNot(HaveOccurred())
-			mockRepoBuilder.EXPECT().ImportRepo(gomock.AssignableToTypeOf(&models.Repo{})).Return(&expectedRepo, nil)
+			mockRepoBuilder.EXPECT().ImportRepo(ctx, gomock.AssignableToTypeOf(&models.Repo{})).Return(&expectedRepo, nil)
 			_, err = service.CreateRepoForImage(context.Background(), image)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -2621,7 +2626,7 @@ var _ = Describe("Image Service Test", func() {
 				PulpStatus: models.RepoStatusError,
 			}
 			expectedError := errors.New("No repo has been created")
-			mockRepoBuilder.EXPECT().ImportRepo(gomock.AssignableToTypeOf(&models.Repo{})).Return(&expectedRepo, expectedError)
+			mockRepoBuilder.EXPECT().ImportRepo(ctx, gomock.AssignableToTypeOf(&models.Repo{})).Return(&expectedRepo, expectedError)
 			_, err := service.CreateRepoForImage(context.Background(), image)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(expectedError))
@@ -2749,7 +2754,7 @@ var _ = Describe("Image Service Test", func() {
 		// for CreateInstallerForImage successfully test (when feature.ImageCreateISOEDA is disabled), please look at TestCreateInstallerForImageSuccessful
 
 		It("should run ComposeInstaller successfully and run GetInstallerStatus fails", func() {
-			mockImageBuilderClient.EXPECT().ComposeInstaller(image).Return(image, nil)
+			mockImageBuilderClient.EXPECT().ComposeInstaller(ctx, image).Return(image, nil)
 			expectedError := errors.New("expected installer status error")
 			mockImageBuilderClient.EXPECT().GetInstallerStatus(image).DoAndReturn(
 				func(builderImage *models.Image) (*models.Image, error) {
@@ -2771,7 +2776,7 @@ var _ = Describe("Image Service Test", func() {
 
 		It("should return error when ComposeInstaller fails", func() {
 			expectedError := errors.New("expected ComposeInstaller error")
-			mockImageBuilderClient.EXPECT().ComposeInstaller(image).Return(nil, expectedError)
+			mockImageBuilderClient.EXPECT().ComposeInstaller(ctx, image).Return(nil, expectedError)
 
 			_, err := service.CreateInstallerForImage(context.Background(), image)
 			Expect(err).To(HaveOccurred())
@@ -2779,7 +2784,7 @@ var _ = Describe("Image Service Test", func() {
 		})
 
 		It("should not restore a deleted image when building", func() {
-			mockImageBuilderClient.EXPECT().ComposeInstaller(image).Return(image, nil)
+			mockImageBuilderClient.EXPECT().ComposeInstaller(ctx, image).Return(image, nil)
 			mockImageBuilderClient.EXPECT().GetInstallerStatus(image).DoAndReturn(func(builderImage *models.Image) (*models.Image, error) {
 				builderImage.Installer.Status = models.ImageStatusBuilding
 				builderImage.Status = models.ImageStatusBuilding
@@ -2808,6 +2813,7 @@ var _ = Describe("Image Service Test", func() {
 
 func TestCreateInstallerForImageSuccessfully(t *testing.T) {
 	g := NewGomegaWithT(t)
+	ctx := context.Background()
 
 	currentDir, err := os.Getwd()
 	g.Expect(err).ToNot(HaveOccurred())
@@ -2856,7 +2862,7 @@ func TestCreateInstallerForImageSuccessfully(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	mockImageBuilderClient.EXPECT().ComposeInstaller(image).Return(image, nil)
+	mockImageBuilderClient.EXPECT().ComposeInstaller(ctx, image).Return(image, nil)
 	mockImageBuilderClient.EXPECT().GetInstallerStatus(image).DoAndReturn(func(builderImage *models.Image) (*models.Image, error) {
 		// simulate that Installer status was successful and set the appropriate statuses and data
 		builderImage.Status = models.ImageStatusSuccess

--- a/pkg/services/mock_services/images.go
+++ b/pkg/services/mock_services/images.go
@@ -439,17 +439,17 @@ func (mr *MockImageServiceInterfaceMockRecorder) SetLog(arg0 interface{}) *gomoc
 }
 
 // UpdateImage mocks base method.
-func (m *MockImageServiceInterface) UpdateImage(image, previousImage *models.Image) error {
+func (m *MockImageServiceInterface) UpdateImage(ctx context.Context, image, previousImage *models.Image) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateImage", image, previousImage)
+	ret := m.ctrl.Call(m, "UpdateImage", ctx, image, previousImage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateImage indicates an expected call of UpdateImage.
-func (mr *MockImageServiceInterfaceMockRecorder) UpdateImage(image, previousImage interface{}) *gomock.Call {
+func (mr *MockImageServiceInterfaceMockRecorder) UpdateImage(ctx, image, previousImage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateImage", reflect.TypeOf((*MockImageServiceInterface)(nil).UpdateImage), image, previousImage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateImage", reflect.TypeOf((*MockImageServiceInterface)(nil).UpdateImage), ctx, image, previousImage)
 }
 
 // UpdateImageStatus mocks base method.

--- a/pkg/services/mock_services/repobuilder.go
+++ b/pkg/services/mock_services/repobuilder.go
@@ -36,18 +36,18 @@ func (m *MockRepoBuilderInterface) EXPECT() *MockRepoBuilderInterfaceMockRecorde
 }
 
 // BuildUpdateRepo mocks base method.
-func (m *MockRepoBuilderInterface) BuildUpdateRepo(id uint) (*models.UpdateTransaction, error) {
+func (m *MockRepoBuilderInterface) BuildUpdateRepo(ctx context.Context, id uint) (*models.UpdateTransaction, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildUpdateRepo", id)
+	ret := m.ctrl.Call(m, "BuildUpdateRepo", ctx, id)
 	ret0, _ := ret[0].(*models.UpdateTransaction)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BuildUpdateRepo indicates an expected call of BuildUpdateRepo.
-func (mr *MockRepoBuilderInterfaceMockRecorder) BuildUpdateRepo(id interface{}) *gomock.Call {
+func (mr *MockRepoBuilderInterfaceMockRecorder) BuildUpdateRepo(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildUpdateRepo", reflect.TypeOf((*MockRepoBuilderInterface)(nil).BuildUpdateRepo), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildUpdateRepo", reflect.TypeOf((*MockRepoBuilderInterface)(nil).BuildUpdateRepo), ctx, id)
 }
 
 // CommitTarDelete mocks base method.
@@ -108,18 +108,18 @@ func (mr *MockRepoBuilderInterfaceMockRecorder) CommitTarUpload(c, tarFileName i
 }
 
 // ImportRepo mocks base method.
-func (m *MockRepoBuilderInterface) ImportRepo(r *models.Repo) (*models.Repo, error) {
+func (m *MockRepoBuilderInterface) ImportRepo(ctx context.Context, r *models.Repo) (*models.Repo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ImportRepo", r)
+	ret := m.ctrl.Call(m, "ImportRepo", ctx, r)
 	ret0, _ := ret[0].(*models.Repo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ImportRepo indicates an expected call of ImportRepo.
-func (mr *MockRepoBuilderInterfaceMockRecorder) ImportRepo(r interface{}) *gomock.Call {
+func (mr *MockRepoBuilderInterfaceMockRecorder) ImportRepo(ctx, r interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportRepo", reflect.TypeOf((*MockRepoBuilderInterface)(nil).ImportRepo), r)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportRepo", reflect.TypeOf((*MockRepoBuilderInterface)(nil).ImportRepo), ctx, r)
 }
 
 // RepoPullLocalStaticDeltas mocks base method.
@@ -137,16 +137,16 @@ func (mr *MockRepoBuilderInterfaceMockRecorder) RepoPullLocalStaticDeltas(u, o, 
 }
 
 // StoreRepo mocks base method.
-func (m *MockRepoBuilderInterface) StoreRepo(arg0 context.Context, arg1 *models.Repo) (*models.Repo, error) {
+func (m *MockRepoBuilderInterface) StoreRepo(ctx context.Context, repo *models.Repo) (*models.Repo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreRepo", arg0, arg1)
+	ret := m.ctrl.Call(m, "StoreRepo", ctx, repo)
 	ret0, _ := ret[0].(*models.Repo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // StoreRepo indicates an expected call of StoreRepo.
-func (mr *MockRepoBuilderInterfaceMockRecorder) StoreRepo(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRepoBuilderInterfaceMockRecorder) StoreRepo(ctx, repo interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreRepo", reflect.TypeOf((*MockRepoBuilderInterface)(nil).StoreRepo), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreRepo", reflect.TypeOf((*MockRepoBuilderInterface)(nil).StoreRepo), ctx, repo)
 }

--- a/pkg/services/mock_services/updates.go
+++ b/pkg/services/mock_services/updates.go
@@ -5,6 +5,7 @@
 package mock_services
 
 import (
+	context "context"
 	io "io"
 	reflect "reflect"
 
@@ -37,48 +38,48 @@ func (m *MockUpdateServiceInterface) EXPECT() *MockUpdateServiceInterfaceMockRec
 }
 
 // BuildUpdateRepo mocks base method.
-func (m *MockUpdateServiceInterface) BuildUpdateRepo(orgID string, updateID uint) (*models.UpdateTransaction, error) {
+func (m *MockUpdateServiceInterface) BuildUpdateRepo(ctx context.Context, orgID string, updateID uint) (*models.UpdateTransaction, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildUpdateRepo", orgID, updateID)
+	ret := m.ctrl.Call(m, "BuildUpdateRepo", ctx, orgID, updateID)
 	ret0, _ := ret[0].(*models.UpdateTransaction)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BuildUpdateRepo indicates an expected call of BuildUpdateRepo.
-func (mr *MockUpdateServiceInterfaceMockRecorder) BuildUpdateRepo(orgID, updateID interface{}) *gomock.Call {
+func (mr *MockUpdateServiceInterfaceMockRecorder) BuildUpdateRepo(ctx, orgID, updateID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildUpdateRepo", reflect.TypeOf((*MockUpdateServiceInterface)(nil).BuildUpdateRepo), orgID, updateID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildUpdateRepo", reflect.TypeOf((*MockUpdateServiceInterface)(nil).BuildUpdateRepo), ctx, orgID, updateID)
 }
 
 // BuildUpdateTransactions mocks base method.
-func (m *MockUpdateServiceInterface) BuildUpdateTransactions(devicesUpdate *models.DevicesUpdate, orgID string, commit *models.Commit) (*[]models.UpdateTransaction, error) {
+func (m *MockUpdateServiceInterface) BuildUpdateTransactions(ctx context.Context, devicesUpdate *models.DevicesUpdate, orgID string, commit *models.Commit) (*[]models.UpdateTransaction, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildUpdateTransactions", devicesUpdate, orgID, commit)
+	ret := m.ctrl.Call(m, "BuildUpdateTransactions", ctx, devicesUpdate, orgID, commit)
 	ret0, _ := ret[0].(*[]models.UpdateTransaction)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BuildUpdateTransactions indicates an expected call of BuildUpdateTransactions.
-func (mr *MockUpdateServiceInterfaceMockRecorder) BuildUpdateTransactions(devicesUpdate, orgID, commit interface{}) *gomock.Call {
+func (mr *MockUpdateServiceInterfaceMockRecorder) BuildUpdateTransactions(ctx, devicesUpdate, orgID, commit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildUpdateTransactions", reflect.TypeOf((*MockUpdateServiceInterface)(nil).BuildUpdateTransactions), devicesUpdate, orgID, commit)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildUpdateTransactions", reflect.TypeOf((*MockUpdateServiceInterface)(nil).BuildUpdateTransactions), ctx, devicesUpdate, orgID, commit)
 }
 
 // CreateUpdate mocks base method.
-func (m *MockUpdateServiceInterface) CreateUpdate(id uint) (*models.UpdateTransaction, error) {
+func (m *MockUpdateServiceInterface) CreateUpdate(ctx context.Context, id uint) (*models.UpdateTransaction, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateUpdate", id)
+	ret := m.ctrl.Call(m, "CreateUpdate", ctx, id)
 	ret0, _ := ret[0].(*models.UpdateTransaction)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateUpdate indicates an expected call of CreateUpdate.
-func (mr *MockUpdateServiceInterfaceMockRecorder) CreateUpdate(id interface{}) *gomock.Call {
+func (mr *MockUpdateServiceInterfaceMockRecorder) CreateUpdate(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUpdate", reflect.TypeOf((*MockUpdateServiceInterface)(nil).CreateUpdate), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUpdate", reflect.TypeOf((*MockUpdateServiceInterface)(nil).CreateUpdate), ctx, id)
 }
 
 // CreateUpdateAsync mocks base method.

--- a/pkg/services/repobuilder_test.go
+++ b/pkg/services/repobuilder_test.go
@@ -372,7 +372,7 @@ var _ = Describe("RepoBuilder Service Test", func() {
 				"public-read",
 			).Return(expectedRepoURL, nil)
 
-			repo, err := repoBuilder.ImportRepo(commit.Repo)
+			repo, err := repoBuilder.ImportRepo(ctx, commit.Repo)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(repo).ToNot(BeNil())
 			Expect(repo.URL).To(Equal(expectedRepoURL))
@@ -380,7 +380,7 @@ var _ = Describe("RepoBuilder Service Test", func() {
 		})
 
 		It("should return error when repo commit not found", func() {
-			_, err := repoBuilder.ImportRepo(&models.Repo{Model: models.Model{ID: 99999999999}})
+			_, err := repoBuilder.ImportRepo(ctx, &models.Repo{Model: models.Model{ID: 99999999999}})
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(Equal(gorm.ErrRecordNotFound))
 		})
@@ -391,7 +391,7 @@ var _ = Describe("RepoBuilder Service Test", func() {
 			mockFilesService.EXPECT().GetDownloader().Return(mockDownloader)
 			mockDownloader.EXPECT().DownloadToPath(commit.ImageBuildTarURL, repoTarFilePath).Return(expectedError)
 
-			_, err := repoBuilder.ImportRepo(commit.Repo)
+			_, err := repoBuilder.ImportRepo(ctx, commit.Repo)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("error downloading repo"))
 		})
@@ -406,7 +406,7 @@ var _ = Describe("RepoBuilder Service Test", func() {
 			mockFilesService.EXPECT().GetUploader().Return(mockUploader)
 			mockUploader.EXPECT().UploadFile(repoTarFilePath, expectedUploadPath).Return("", expectedError)
 
-			_, err := repoBuilder.ImportRepo(commit.Repo)
+			_, err := repoBuilder.ImportRepo(ctx, commit.Repo)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(expectedError.Error()))
 		})
@@ -425,7 +425,7 @@ var _ = Describe("RepoBuilder Service Test", func() {
 			mockFilesService.EXPECT().GetExtractor().Return(mockExtractor)
 			mockExtractor.EXPECT().Extract(gomock.AssignableToTypeOf(&os.File{}), repoWorkPath).Return(expectedError)
 
-			_, err := repoBuilder.ImportRepo(commit.Repo)
+			_, err := repoBuilder.ImportRepo(ctx, commit.Repo)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(expectedError.Error()))
 		})
@@ -451,7 +451,7 @@ var _ = Describe("RepoBuilder Service Test", func() {
 				"public-read",
 			).Return("", expectedError)
 
-			_, err := repoBuilder.ImportRepo(commit.Repo)
+			_, err := repoBuilder.ImportRepo(ctx, commit.Repo)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(expectedError.Error()))
 		})
@@ -541,7 +541,7 @@ var _ = Describe("RepoBuilder Service Test", func() {
 				"private",
 			).Return(expectedRepoURL, nil)
 
-			updateTransaction, err := repoBuilder.BuildUpdateRepo(update.ID)
+			updateTransaction, err := repoBuilder.BuildUpdateRepo(ctx, update.ID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updateTransaction).ToNot(BeNil())
 			Expect(updateTransaction.Repo.URL).To(Equal(expectedRepoURL))
@@ -549,7 +549,7 @@ var _ = Describe("RepoBuilder Service Test", func() {
 		})
 
 		It("should return error when update does not exist", func() {
-			_, err := repoBuilder.BuildUpdateRepo(999999999)
+			_, err := repoBuilder.BuildUpdateRepo(ctx, 999999999)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal(services.UpdateNotFoundErrorMsg))
 		})
@@ -559,7 +559,7 @@ var _ = Describe("RepoBuilder Service Test", func() {
 			err := db.DB.Create(update).Error
 			Expect(err).ToNot(HaveOccurred())
 
-			_, err = repoBuilder.BuildUpdateRepo(update.ID)
+			_, err = repoBuilder.BuildUpdateRepo(ctx, update.ID)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("invalid models.UpdateTransaction.Commit Provided: nil pointer"))
 		})
@@ -577,7 +577,7 @@ var _ = Describe("RepoBuilder Service Test", func() {
 			err := db.DB.Create(update).Error
 			Expect(err).ToNot(HaveOccurred())
 
-			_, err = repoBuilder.BuildUpdateRepo(update.ID)
+			_, err = repoBuilder.BuildUpdateRepo(ctx, update.ID)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("repo unavailable"))
 		})
@@ -588,7 +588,7 @@ var _ = Describe("RepoBuilder Service Test", func() {
 			mockFilesService.EXPECT().GetDownloader().Return(mockDownloader)
 			mockDownloader.EXPECT().DownloadToPath(update.Commit.ImageBuildTarURL, repoTarFilePath).Return(expectedError)
 
-			_, err := repoBuilder.BuildUpdateRepo(update.ID)
+			_, err := repoBuilder.BuildUpdateRepo(ctx, update.ID)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(expectedError.Error()))
 		})
@@ -602,7 +602,7 @@ var _ = Describe("RepoBuilder Service Test", func() {
 			mockFilesService.EXPECT().GetExtractor().Return(mockExtractor)
 			mockExtractor.EXPECT().Extract(gomock.AssignableToTypeOf(&os.File{}), updateWorkPath).Return(expectedError)
 
-			_, err := repoBuilder.BuildUpdateRepo(update.ID)
+			_, err := repoBuilder.BuildUpdateRepo(ctx, update.ID)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(expectedError.Error()))
 		})
@@ -623,7 +623,7 @@ var _ = Describe("RepoBuilder Service Test", func() {
 				"private",
 			).Return("", expectedError)
 
-			_, err := repoBuilder.BuildUpdateRepo(update.ID)
+			_, err := repoBuilder.BuildUpdateRepo(ctx, update.ID)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(expectedError.Error()))
 		})
@@ -807,7 +807,7 @@ func TestBuildUpdateRepoWithOldCommits(t *testing.T) {
 	// set the first exec command helper mock
 	services.BuildCommand = expectedExecCalls[0].TestHelper.MockExecCommand
 
-	updateTransaction, err := repoBuilder.BuildUpdateRepo(update.ID)
+	updateTransaction, err := repoBuilder.BuildUpdateRepo(ctx, update.ID)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(updateTransaction).ToNot(BeNil())
 	g.Expect(updateTransaction.Repo.URL).To(Equal(expectedRepoURL))
@@ -982,7 +982,7 @@ func TestBuildUpdateRepoWithOldCommitsStaticDeltaError(t *testing.T) {
 	// set the first exec command helper mock
 	services.BuildCommand = expectedExecCalls[0].TestHelper.MockExecCommand
 
-	_, err = repoBuilder.BuildUpdateRepo(update.ID)
+	_, err = repoBuilder.BuildUpdateRepo(ctx, update.ID)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(Equal(fmt.Sprintf("exit status %d", expectedExecCalls[3].ExpectedExistStatus)))
 
@@ -1105,7 +1105,7 @@ func TestBuildUpdateRepoWithOldCommitsCommitTarExtractError(t *testing.T) {
 
 	// we do not expect any command to be run
 
-	_, err = repoBuilder.BuildUpdateRepo(update.ID)
+	_, err = repoBuilder.BuildUpdateRepo(ctx, update.ID)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err).To(Equal(expectedOldCommitRepoExtractError))
 }
@@ -1218,7 +1218,7 @@ func TestBuildUpdateRepoWithOldCommitsCommitTarDownloadError(t *testing.T) {
 
 	// we do not expect any exec.Command to be run
 
-	_, err = repoBuilder.BuildUpdateRepo(update.ID)
+	_, err = repoBuilder.BuildUpdateRepo(ctx, update.ID)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring(expectedOldCommitRepoDownloadError.Error()))
 }

--- a/pkg/services/update/event_update_repo_requested.go
+++ b/pkg/services/update/event_update_repo_requested.go
@@ -79,7 +79,7 @@ func (ev EventUpdateRepoRequestedHandler) Consume(ctx context.Context) {
 
 	// get the services from the context
 	edgeAPIServices := dependencies.ServicesFromContext(ctx)
-	if _, err = edgeAPIServices.UpdateService.BuildUpdateRepo(updateTransaction.OrgID, updateTransaction.ID); err != nil {
+	if _, err = edgeAPIServices.UpdateService.BuildUpdateRepo(ctx, updateTransaction.OrgID, updateTransaction.ID); err != nil {
 		eventLog.WithFields(log.Fields{
 			"requestID": ev.Data.RequestID,
 			"orgID":     updateTransaction.OrgID,

--- a/pkg/services/update/event_update_repo_requested_test.go
+++ b/pkg/services/update/event_update_repo_requested_test.go
@@ -214,7 +214,7 @@ var _ = Describe("UpdateRepoRequested Event Consumer Test", func() {
 				event := &eventReq.EventUpdateRepoRequestedHandler{}
 				event.RedHatOrgID = ident.Identity.OrgID
 				event.Data = *edgePayload
-				mockUpdateService.EXPECT().BuildUpdateRepo(event.RedHatOrgID, updateTransaction.ID).Return(&updateTransaction, nil)
+				mockUpdateService.EXPECT().BuildUpdateRepo(ctx, event.RedHatOrgID, updateTransaction.ID).Return(&updateTransaction, nil)
 				mockProducerService.EXPECT().ProduceEvent(
 					kafkacommon.TopicFleetmgmtUpdateWriteTemplateRequested, models.EventTypeEdgeWriteTemplateRequested, gomock.Any(),
 				).Return(nil)
@@ -235,7 +235,7 @@ var _ = Describe("UpdateRepoRequested Event Consumer Test", func() {
 				event := &eventReq.EventUpdateRepoRequestedHandler{}
 				event.RedHatOrgID = ident.Identity.OrgID
 				event.Data = *edgePayload
-				mockUpdateService.EXPECT().BuildUpdateRepo(event.RedHatOrgID, updateTransaction.ID).Times(0)
+				mockUpdateService.EXPECT().BuildUpdateRepo(ctx, event.RedHatOrgID, updateTransaction.ID).Times(0)
 				mockProducerService.EXPECT().ProduceEvent(
 					kafkacommon.TopicFleetmgmtUpdateWriteTemplateRequested, models.EventTypeEdgeWriteTemplateRequested, gomock.Any(),
 				).Times(0)
@@ -258,7 +258,7 @@ var _ = Describe("UpdateRepoRequested Event Consumer Test", func() {
 				event := &eventReq.EventUpdateRepoRequestedHandler{}
 				event.RedHatOrgID = ident.Identity.OrgID
 				event.Data = *edgePayload
-				mockUpdateService.EXPECT().BuildUpdateRepo(event.RedHatOrgID, updateTransaction.ID).Times(0)
+				mockUpdateService.EXPECT().BuildUpdateRepo(ctx, event.RedHatOrgID, updateTransaction.ID).Times(0)
 				mockProducerService.EXPECT().ProduceEvent(
 					kafkacommon.TopicFleetmgmtUpdateWriteTemplateRequested, models.EventTypeEdgeWriteTemplateRequested, gomock.Any(),
 				).Times(0)
@@ -278,7 +278,7 @@ var _ = Describe("UpdateRepoRequested Event Consumer Test", func() {
 				event := &eventReq.EventUpdateRepoRequestedHandler{}
 				event.RedHatOrgID = ident.Identity.OrgID
 				event.Data = *edgePayload
-				mockUpdateService.EXPECT().BuildUpdateRepo(event.RedHatOrgID, updateTransaction.ID).Return(&updateTransaction, nil)
+				mockUpdateService.EXPECT().BuildUpdateRepo(ctx, event.RedHatOrgID, updateTransaction.ID).Return(&updateTransaction, nil)
 				expectedError := errors.New("producer error")
 				mockProducerService.EXPECT().ProduceEvent(
 					kafkacommon.TopicFleetmgmtUpdateWriteTemplateRequested, models.EventTypeEdgeWriteTemplateRequested, gomock.Any(),
@@ -304,7 +304,7 @@ var _ = Describe("UpdateRepoRequested Event Consumer Test", func() {
 				event.RedHatOrgID = ident.Identity.OrgID
 				event.Data = *edgePayload
 				expectedError := errors.New("BuildUpdateRepo error")
-				mockUpdateService.EXPECT().BuildUpdateRepo(event.RedHatOrgID, updateTransaction.ID).Return(nil, expectedError)
+				mockUpdateService.EXPECT().BuildUpdateRepo(ctx, event.RedHatOrgID, updateTransaction.ID).Return(nil, expectedError)
 				// ProduceEvent WriteTemplate should not be called
 				mockProducerService.EXPECT().ProduceEvent(
 					kafkacommon.TopicFleetmgmtUpdateWriteTemplateRequested, models.EventTypeEdgeWriteTemplateRequested, gomock.Any(),
@@ -326,7 +326,7 @@ var _ = Describe("UpdateRepoRequested Event Consumer Test", func() {
 				event.RedHatOrgID = ident.Identity.OrgID
 				event.Data = *edgePayload
 				// BuildUpdateRepo should not be called
-				mockUpdateService.EXPECT().BuildUpdateRepo(event.RedHatOrgID, updateTransaction.ID).Times(0)
+				mockUpdateService.EXPECT().BuildUpdateRepo(ctx, event.RedHatOrgID, updateTransaction.ID).Times(0)
 				event.Consume(ctx)
 				Expect(logBuffer.String()).To(ContainSubstring(eventReq.ErrEventHandlerMissingRequiredData.Error()))
 			})
@@ -344,7 +344,7 @@ var _ = Describe("UpdateRepoRequested Event Consumer Test", func() {
 				event.RedHatOrgID = ""
 				event.Data = *edgePayload
 				// BuildUpdateRepo should not be called
-				mockUpdateService.EXPECT().BuildUpdateRepo(event.RedHatOrgID, updateTransaction.ID).Times(0)
+				mockUpdateService.EXPECT().BuildUpdateRepo(ctx, event.RedHatOrgID, updateTransaction.ID).Times(0)
 				event.Consume(ctx)
 				Expect(logBuffer.String()).To(ContainSubstring(eventReq.ErrEventHandlerMissingRequiredData.Error()))
 			})
@@ -362,7 +362,7 @@ var _ = Describe("UpdateRepoRequested Event Consumer Test", func() {
 				event.RedHatOrgID = faker.UUIDHyphenated()
 				event.Data = *edgePayload
 				// BuildUpdateRepo should not be called
-				mockUpdateService.EXPECT().BuildUpdateRepo(event.RedHatOrgID, updateTransaction.ID).Times(0)
+				mockUpdateService.EXPECT().BuildUpdateRepo(ctx, event.RedHatOrgID, updateTransaction.ID).Times(0)
 				event.Consume(ctx)
 				Expect(logBuffer.String()).To(ContainSubstring(eventReq.ErrEventHandlerRequiredDataMismatch.Error()))
 			})
@@ -380,7 +380,7 @@ var _ = Describe("UpdateRepoRequested Event Consumer Test", func() {
 				event.RedHatOrgID = ident.Identity.OrgID
 				event.Data = *edgePayload
 				// BuildUpdateRepo should not be called
-				mockUpdateService.EXPECT().BuildUpdateRepo(event.RedHatOrgID, updateTransaction.ID).Times(0)
+				mockUpdateService.EXPECT().BuildUpdateRepo(ctx, event.RedHatOrgID, updateTransaction.ID).Times(0)
 				event.Consume(ctx)
 				Expect(logBuffer.String()).To(ContainSubstring(eventReq.ErrEventHandlerUpdateIDRequired.Error()))
 			})
@@ -401,7 +401,7 @@ var _ = Describe("UpdateRepoRequested Event Consumer Test", func() {
 				event.RedHatOrgID = ident.Identity.OrgID
 				event.Data = *edgePayload
 				// BuildUpdateRepo should not be called
-				mockUpdateService.EXPECT().BuildUpdateRepo(event.RedHatOrgID, updateTransaction.ID).Times(0)
+				mockUpdateService.EXPECT().BuildUpdateRepo(ctx, event.RedHatOrgID, updateTransaction.ID).Times(0)
 				event.Consume(ctx)
 				Expect(logBuffer.String()).To(ContainSubstring(eventReq.ErrEventHandlerUpdateOrgIDMismatch.Error()))
 			})

--- a/pkg/services/updates_test.go
+++ b/pkg/services/updates_test.go
@@ -34,6 +34,8 @@ import (
 )
 
 var _ = Describe("UpdateService Basic functions", func() {
+	ctx := context.Background()
+
 	f, _ := os.Getwd()
 	templatesPath := fmt.Sprintf("%s/../templates/", filepath.Dir(f))
 	Describe("creation of the service", func() {
@@ -318,8 +320,8 @@ var _ = Describe("UpdateService Basic functions", func() {
 			When("when build repo fail", func() {
 				It("should return error when can't build repo", func() {
 					expectedError := errors.New("error building repo")
-					mockRepoBuilder.EXPECT().BuildUpdateRepo(update.ID).Return(nil, expectedError)
-					actual, err := updateService.CreateUpdate(update.ID)
+					mockRepoBuilder.EXPECT().BuildUpdateRepo(ctx, update.ID).Return(nil, expectedError)
+					actual, err := updateService.CreateUpdate(ctx, update.ID)
 
 					Expect(err).To(HaveOccurred())
 					Expect(err).To(MatchError(expectedError))
@@ -339,7 +341,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 					fname := fmt.Sprintf("playbook_dispatcher_update_%s_%d.yml", update.OrgID, update.ID)
 					tmpfilepath := fmt.Sprintf("/tmp/v2/%s/%s", update.OrgID, fname)
 
-					mockRepoBuilder.EXPECT().BuildUpdateRepo(update.ID).Return(&update, nil)
+					mockRepoBuilder.EXPECT().BuildUpdateRepo(ctx, update.ID).Return(&update, nil)
 					mockUploader := mock_services.NewMockUploader(ctrl)
 					mockUploader.EXPECT().UploadFile(tmpfilepath, fmt.Sprintf("%s/playbooks/%s", update.OrgID, fname)).Return("url", nil)
 					mockFilesService.EXPECT().GetUploader().Return(mockUploader)
@@ -359,7 +361,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 						},
 					}, nil)
 
-					updateTransaction, err := updateService.CreateUpdate(update.ID)
+					updateTransaction, err := updateService.CreateUpdate(ctx, update.ID)
 
 					Expect(err).To(BeNil())
 					Expect(updateTransaction).ToNot(BeNil())
@@ -385,7 +387,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 					fname := fmt.Sprintf("playbook_dispatcher_update_%s_%d.yml", update.OrgID, update.ID)
 					tmpfilepath := fmt.Sprintf("/tmp/v2/%s/%s", update.OrgID, fname)
 
-					mockRepoBuilder.EXPECT().BuildUpdateRepo(update.ID).Return(&update, nil)
+					mockRepoBuilder.EXPECT().BuildUpdateRepo(ctx, update.ID).Return(&update, nil)
 					mockUploader := mock_services.NewMockUploader(ctrl)
 					mockUploader.EXPECT().UploadFile(tmpfilepath, fmt.Sprintf("%s/playbooks/%s", update.OrgID, fname)).Return("url", nil)
 					mockFilesService.EXPECT().GetUploader().Return(mockUploader)
@@ -405,7 +407,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 						},
 					}, nil)
 
-					updateTransaction, err := updateService.CreateUpdate(update.ID)
+					updateTransaction, err := updateService.CreateUpdate(ctx, update.ID)
 					Expect(updateTransaction).ToNot(BeNil())
 					Expect(err).To(BeNil())
 					Expect(updateTransaction).ToNot(BeNil())
@@ -430,7 +432,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 					fname := fmt.Sprintf("playbook_dispatcher_update_%s_%d.yml", update.OrgID, update.ID)
 					tmpfilepath := fmt.Sprintf("/tmp/v2/%s/%s", update.OrgID, fname)
 
-					mockRepoBuilder.EXPECT().BuildUpdateRepo(update.ID).Return(&update, nil)
+					mockRepoBuilder.EXPECT().BuildUpdateRepo(ctx, update.ID).Return(&update, nil)
 					mockUploader := mock_services.NewMockUploader(ctrl)
 					mockUploader.EXPECT().UploadFile(tmpfilepath, fmt.Sprintf("%s/playbooks/%s", update.OrgID, fname)).Return("url", nil)
 					mockFilesService.EXPECT().GetUploader().Return(mockUploader)
@@ -444,7 +446,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 						Principal:    common.DefaultPrincipal,
 					}).Return(nil, errors.New("error on playbook dispatcher client"))
 
-					_, err := updateService.CreateUpdate(update.ID)
+					_, err := updateService.CreateUpdate(ctx, update.ID)
 
 					Expect(err).ShouldNot(BeNil())
 
@@ -1020,7 +1022,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 				mockProducerService.EXPECT().GetProducerInstance().Return(mockProducer)
 				mockTopicService.EXPECT().GetTopic(services.NotificationTopic).Return(services.NotificationTopic, nil)
 
-				upd, err := updateService.BuildUpdateTransactions(&devicesUpdate, orgID, &latestCommit)
+				upd, err := updateService.BuildUpdateTransactions(ctx, &devicesUpdate, orgID, &latestCommit)
 				Expect(err).To(BeNil())
 				Expect(upd).ToNot(BeNil())
 				Expect(len(*upd) > 0).To(BeTrue())
@@ -1127,7 +1129,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 				mockProducerService.EXPECT().GetProducerInstance().Return(mockProducer)
 				mockTopicService.EXPECT().GetTopic(services.NotificationTopic).Return(services.NotificationTopic, nil)
 
-				upd, err := updateService.BuildUpdateTransactions(&devicesUpdate, orgID, &latestCommit)
+				upd, err := updateService.BuildUpdateTransactions(ctx, &devicesUpdate, orgID, &latestCommit)
 				Expect(err).To(BeNil())
 				Expect(upd).ToNot(BeNil())
 				Expect(len(*upd) > 0).To(BeTrue())
@@ -1228,7 +1230,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 				mockProducerService.EXPECT().GetProducerInstance().Return(mockProducer)
 				mockTopicService.EXPECT().GetTopic(services.NotificationTopic).Return(services.NotificationTopic, nil)
 
-				upd, err := updateService.BuildUpdateTransactions(&devicesUpdate, orgID, &commit)
+				upd, err := updateService.BuildUpdateTransactions(ctx, &devicesUpdate, orgID, &commit)
 				Expect(err).To(BeNil())
 				for _, u := range *upd {
 					Expect(u.ChangesRefs).To(BeTrue())
@@ -1332,7 +1334,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 				mockProducerService.EXPECT().GetProducerInstance().Return(mockProducer)
 				mockTopicService.EXPECT().GetTopic(services.NotificationTopic).Return(services.NotificationTopic, nil)
 
-				upd, err := updateService.BuildUpdateTransactions(&devicesUpdate, orgID, &commit)
+				upd, err := updateService.BuildUpdateTransactions(ctx, &devicesUpdate, orgID, &commit)
 				Expect(err).To(BeNil())
 				for _, u := range *upd {
 					Expect(u.ChangesRefs).To(BeFalse())
@@ -1417,7 +1419,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 				mockProducerService.EXPECT().GetProducerInstance().Return(mockProducer)
 				mockTopicService.EXPECT().GetTopic(services.NotificationTopic).Return(services.NotificationTopic, nil)
 
-				updates, err := updateService.BuildUpdateTransactions(&devicesUpdate, common.DefaultOrgID, &newCommit)
+				updates, err := updateService.BuildUpdateTransactions(ctx, &devicesUpdate, common.DefaultOrgID, &newCommit)
 
 				Expect(err).To(BeNil())
 				Expect(len(*updates)).Should(Equal(1))
@@ -1448,7 +1450,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 				mockProducerService.EXPECT().GetProducerInstance().Return(mockProducer)
 				mockTopicService.EXPECT().GetTopic(services.NotificationTopic).Return(services.NotificationTopic, nil)
 
-				updates, err := updateService.BuildUpdateTransactions(&devicesUpdate, orgID, &newCommit)
+				updates, err := updateService.BuildUpdateTransactions(ctx, &devicesUpdate, orgID, &newCommit)
 				Expect(err).To(BeNil())
 				Expect(len(*updates)).Should(Equal(1))
 				Expect((*updates)[0].ChangesRefs).To(BeFalse())
@@ -1478,7 +1480,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 				mockProducerService.EXPECT().GetProducerInstance().Return(mockProducer)
 				mockTopicService.EXPECT().GetTopic(services.NotificationTopic).Return(services.NotificationTopic, nil)
 
-				updates, err := updateService.BuildUpdateTransactions(&devicesUpdate, orgID, &newCommit2)
+				updates, err := updateService.BuildUpdateTransactions(ctx, &devicesUpdate, orgID, &newCommit2)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(*updates)).Should(Equal(1))
 				Expect((*updates)[0].ChangesRefs).To(BeTrue())
@@ -1499,7 +1501,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 				mockProducerService.EXPECT().GetProducerInstance().Return(mockProducer)
 				mockTopicService.EXPECT().GetTopic(services.NotificationTopic).Return(services.NotificationTopic, nil)
 
-				updates, err := updateService.BuildUpdateTransactions(&devicesUpdate, common.DefaultOrgID, &newCommit)
+				updates, err := updateService.BuildUpdateTransactions(ctx, &devicesUpdate, common.DefaultOrgID, &newCommit)
 
 				Expect(err).To(BeNil())
 				Expect(len(*updates)).Should(Equal(1))
@@ -1537,7 +1539,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 				mockProducerService.EXPECT().GetProducerInstance().Return(mockProducer)
 				mockTopicService.EXPECT().GetTopic(services.NotificationTopic).Return(services.NotificationTopic, nil).Times(2)
 
-				updates, err := updateService.BuildUpdateTransactions(&devicesUpdate, common.DefaultOrgID, &newCommit)
+				updates, err := updateService.BuildUpdateTransactions(ctx, &devicesUpdate, common.DefaultOrgID, &newCommit)
 
 				Expect(err).To(BeNil())
 				Expect(len(*updates)).Should(Equal(2))
@@ -1570,7 +1572,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 				mockInventory.EXPECT().ReturnDevicesByID(device.UUID).
 					Return(responseInventory, nil)
 
-				updates, err := updateService.BuildUpdateTransactions(&devicesUpdate, common.DefaultOrgID, &newCommit)
+				updates, err := updateService.BuildUpdateTransactions(ctx, &devicesUpdate, common.DefaultOrgID, &newCommit)
 
 				Expect(err).To(BeNil())
 				Expect(len(*updates)).Should(Equal(0))
@@ -1586,7 +1588,7 @@ var _ = Describe("UpdateService Basic functions", func() {
 				mockInventory.EXPECT().ReturnDevicesByID(device.UUID).
 					Return(responseInventory, errors.New(""))
 
-				updates, err := updateService.BuildUpdateTransactions(&devicesUpdate, common.DefaultOrgID, &newCommit)
+				updates, err := updateService.BuildUpdateTransactions(ctx, &devicesUpdate, common.DefaultOrgID, &newCommit)
 
 				Expect(err.(apiError.APIError).GetStatus()).To(Equal(404))
 				Expect(updates).Should(BeNil())
@@ -1611,12 +1613,12 @@ var _ = Describe("UpdateService Basic functions", func() {
 		})
 		It("should return template with gpg false", func() {
 			config.Get().GpgVerify = "false"
-			remoteInfo := services.NewTemplateRemoteInfo(update)
+			remoteInfo := services.NewTemplateRemoteInfo(ctx, update)
 			Expect(remoteInfo.GpgVerify).To(Equal("false"))
 		})
 		It("should return template with gpg true", func() {
 			config.Get().GpgVerify = "true"
-			remoteInfo := services.NewTemplateRemoteInfo(update)
+			remoteInfo := services.NewTemplateRemoteInfo(ctx, update)
 			Expect(remoteInfo.GpgVerify).To(Equal("true"))
 
 		})


### PR DESCRIPTION
# Description
For feature flagging to flag on identity, the context needs to be passed through the stack to the function calling the feature flag check.

FIXES: HMS-5364

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
