### PR TITLE
fix extra user group value in commit request

### DIFF
--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -369,7 +369,7 @@ func (c *Client) ComposeInstaller(ctx context.Context, image *models.Image) (*mo
 	if image.Installer != nil && image.Installer.Username != "" && image.Installer.SSHKey != "" {
 		users = append(users, User{Name: image.Installer.Username,
 			SSHKey: strings.TrimSpace(image.Installer.SSHKey),
-			Groups: []string{image.Installer.Username, "wheel"}})
+			Groups: []string{"wheel"}})
 	}
 
 	req := &ComposeRequest{


### PR DESCRIPTION
# Description
Anaconda is stopping when trying to process the username in the --group parm of the kickstart user call.
This fix removes the username from the group list, since it is currently being handled automatically by Anaconda.

FIXES: HMS-5457

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
