### PR TITLE
pulp: get distribution url for system update

### DIFF
--- a/pkg/services/repobuilder.go
+++ b/pkg/services/repobuilder.go
@@ -350,11 +350,11 @@ func (rb *RepoBuilder) BuildUpdateRepo(ctx context.Context, id uint) (*models.Up
 		if err != nil {
 			return nil, err
 		}
-		update.Repo.URL = updateCommit.Repo.ContentURL(ctx)
+		update.Repo.URL = updateCommit.Repo.DistributionURL(ctx)
 		rb.log.WithField("update_transaction", update).Info("UPGRADE: point update to commit repo")
 	}
 
-	rb.log.WithField("repo", update.Repo.ContentURL(ctx)).Info("Update repo URL")
+	rb.log.WithField("repo", update.Repo.DistributionURL(ctx)).Info("Update repo URL")
 	update.Repo.Status = models.RepoStatusSuccess
 	if err := db.DB.Omit("Devices.*").Save(&update).Error; err != nil {
 		return nil, err


### PR DESCRIPTION
# Description
Get Pulp distribution URL for system updates.
It currently uses the content URL which is not exposed to the systems.

FIXES: HMS-5471

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
