### PR TITLE
add pulp distribution url to playbook

### DIFF
--- a/pkg/services/updates.go
+++ b/pkg/services/updates.go
@@ -462,6 +462,11 @@ func (s *UpdateService) WriteTemplate(templateInfo TemplateRemoteInfo, orgID str
 	}
 	repoURL := fmt.Sprintf("%s://%s/api/edge/v1/storage/update-repos/%d", edgeCertAPIBaseURL.Scheme, edgeCertAPIBaseURL.Host, templateInfo.UpdateTransactionID)
 
+	// override the repo URL with the Pulp Distribution URL
+	if feature.PulpIntegration.IsEnabledCtx(s.ctx) {
+		repoURL = templateInfo.RemoteURL
+	}
+
 	templateData := playbooks{
 		GoTemplateRemoteName: templateInfo.RemoteName,
 		UpdateNumber:         strconv.FormatUint(uint64(templateInfo.UpdateTransactionID), 10),


### PR DESCRIPTION
# Description
Override hardcoded repoURL with Pulp Distribution URL when Pulp Integration is enabled

FIXES: HMS-5471

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
