### PR TITLE
pulp integration: fix bearer auth and remaining correlation headers

### DIFF
--- a/pkg/clients/pulp/artifacts.go
+++ b/pkg/clients/pulp/artifacts.go
@@ -117,7 +117,7 @@ func (ps *PulpService) ArtifactsCreatePipe(ctx context.Context, filename string)
 
 	if resp.JSON201 == nil {
 		return nil, fmt.Errorf("unexpected response: %d, correlation id: %s, bytes written/size: %d/%d, body: %s",
-			resp.StatusCode(), resp.HTTPResponse.Header.Get("Correlation-Id"), written, stat.Size(), string(resp.Body))
+			resp.StatusCode(), resp.HTTPResponse.Header.Get("Correlation-ID"), written, stat.Size(), string(resp.Body))
 	}
 
 	return resp.JSON201, nil
@@ -198,7 +198,7 @@ func (ps *PulpService) ArtifactsCreate(ctx context.Context, filename string) (*A
 	}
 
 	if resp.JSON201 == nil {
-		return nil, fmt.Errorf("unexpected response: %d, correlation id: %s, body: %s", resp.StatusCode(), resp.HTTPResponse.Header.Get("Correlation-Id"), string(resp.Body))
+		return nil, fmt.Errorf("unexpected response: %d, correlation id: %s, body: %s", resp.StatusCode(), resp.HTTPResponse.Header.Get("Correlation-ID"), string(resp.Body))
 	}
 
 	return resp.JSON201, nil

--- a/pkg/clients/pulp/identity.go
+++ b/pkg/clients/pulp/identity.go
@@ -21,10 +21,10 @@ func addAuthenticationHeader(ctx context.Context, req *http.Request) error {
 		if err != nil {
 			return err
 		}
+	} else {
+		// add service account mock header if we are
+		clients.AddBasicCredentialsHeader(ctx, req)
 	}
-
-	// add service account mock header if we are
-	clients.AddBasicCredentialsHeader(ctx, req)
 
 	return nil
 }


### PR DESCRIPTION
# Description
Fixes an issue where Authorization Bearer is overriden with Authorization Basic and Pulp requests fail as unauthorized because the user cannot be authenticated.

Also fixes some Correlation-ID header syntax.

FIXES: HMS-5490

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
