### PR TITLE
handle pulp commit update with aws parent

### DIFF
--- a/pkg/models/commits.go
+++ b/pkg/models/commits.go
@@ -62,11 +62,12 @@ type Commit struct {
 // Repo is the delivery mechanism of a Commit over HTTP
 type Repo struct {
 	Model
-	URL        string `json:"RepoURL"`          // AWS repo URL
-	Status     string `json:"RepoStatus"`       // AWS repo upload status
-	PulpID     string `json:"pulp_repo_id"`     // Pulp Repo ID (used for updates)
-	PulpURL    string `json:"pulp_repo_url"`    // Distribution URL returned from Pulp
-	PulpStatus string `json:"pulp_repo_status"` // Status of Pulp repo import
+	URL          string `json:"RepoURL"`          // AWS repo URL
+	Status       string `json:"RepoStatus"`       // AWS repo upload status
+	ParentTarURL string `json:"parent_tar_url"`   // AWS parent commit tarfile URL (for updates)
+	PulpID       string `json:"pulp_repo_id"`     // Pulp Repo ID (used for updates)
+	PulpURL      string `json:"pulp_repo_url"`    // Distribution URL returned from Pulp
+	PulpStatus   string `json:"pulp_repo_status"` // Status of Pulp repo import
 }
 
 // ContentURL is the URL for internal and Image Builder access to the content in a Pulp repo

--- a/pkg/services/images.go
+++ b/pkg/services/images.go
@@ -587,6 +587,13 @@ func (s *ImageService) UpdateImage(ctx context.Context, image *models.Image, pre
 				PulpID:  repo.PulpID,
 				PulpURL: repo.PulpURL,
 			}
+
+			// Storing the parent tarfile URL with the child repo
+			// because it is needed to import into Pulp
+			// (and the way the schema relationships currently work)
+			if repo.PulpID == "" {
+				image.Commit.Repo.ParentTarURL = previousSuccessfulImage.Commit.ImageBuildTarURL
+			}
 		}
 
 		if config.DistributionsRefs[previousSuccessfulImage.Distribution] != config.DistributionsRefs[image.Distribution] {


### PR DESCRIPTION
# Description
Handle a commit update stored in Pulp when the parent is stored in AWS

FIXES: HMS-2804

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
