### PR TITLE
use imageset ID for pulp repo name

### DIFF
--- a/pkg/services/mock_services/repobuilder.go
+++ b/pkg/services/mock_services/repobuilder.go
@@ -137,16 +137,16 @@ func (mr *MockRepoBuilderInterfaceMockRecorder) RepoPullLocalStaticDeltas(u, o, 
 }
 
 // StoreRepo mocks base method.
-func (m *MockRepoBuilderInterface) StoreRepo(ctx context.Context, repo *models.Repo) (*models.Repo, error) {
+func (m *MockRepoBuilderInterface) StoreRepo(ctx context.Context, imagesetID uint, repo *models.Repo) (*models.Repo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreRepo", ctx, repo)
+	ret := m.ctrl.Call(m, "StoreRepo", ctx, imagesetID, repo)
 	ret0, _ := ret[0].(*models.Repo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // StoreRepo indicates an expected call of StoreRepo.
-func (mr *MockRepoBuilderInterfaceMockRecorder) StoreRepo(ctx, repo interface{}) *gomock.Call {
+func (mr *MockRepoBuilderInterfaceMockRecorder) StoreRepo(ctx, imagesetID, repo interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreRepo", reflect.TypeOf((*MockRepoBuilderInterface)(nil).StoreRepo), ctx, repo)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreRepo", reflect.TypeOf((*MockRepoBuilderInterface)(nil).StoreRepo), ctx, imagesetID, repo)
 }

--- a/pkg/services/repobuilder.go
+++ b/pkg/services/repobuilder.go
@@ -29,7 +29,7 @@ var BuildCommand = exec.Command
 // RepoBuilderInterface defines the interface of a repository builder
 type RepoBuilderInterface interface {
 	BuildUpdateRepo(ctx context.Context, id uint) (*models.UpdateTransaction, error)
-	StoreRepo(ctx context.Context, repo *models.Repo) (*models.Repo, error)
+	StoreRepo(ctx context.Context, imagesetID uint, repo *models.Repo) (*models.Repo, error)
 	ImportRepo(ctx context.Context, r *models.Repo) (*models.Repo, error)
 	CommitTarDownload(c *models.Commit, dest string) (string, error)
 	CommitTarExtract(c *models.Commit, tarFileName string, dest string) error
@@ -112,7 +112,7 @@ func (rb *RepoBuilder) BuildUpdateRepo(ctx context.Context, id uint) (*models.Up
 }
 
 // StoreRepo requests Pulp to create/update an ostree repo from an IB commit
-func (rb *RepoBuilder) StoreRepo(ctx context.Context, repo *models.Repo) (*models.Repo, error) {
+func (rb *RepoBuilder) StoreRepo(ctx context.Context, imagesetID uint, repo *models.Repo) (*models.Repo, error) {
 	var cmt models.Commit
 	cmtDB := db.DB.Where("repo_id = ?", repo.ID).First(&cmt)
 	if cmtDB.Error != nil {
@@ -121,7 +121,7 @@ func (rb *RepoBuilder) StoreRepo(ctx context.Context, repo *models.Repo) (*model
 
 	var err error
 	log.WithContext(ctx).Debug("Storing repo via Pulp")
-	repo.PulpID, repo.PulpURL, err = repostore.PulpRepoStore(ctx, cmt.OrgID, *cmt.RepoID, cmt.ImageBuildTarURL,
+	repo.PulpID, repo.PulpURL, err = repostore.PulpRepoStore(ctx, cmt.OrgID, imagesetID, cmt.ImageBuildTarURL,
 		repo.PulpID, repo.PulpURL, cmt.OSTreeParentRef)
 	if err != nil {
 		log.WithContext(ctx).WithField("error", err.Error()).Error("Error storing Image Builder commit in Pulp OSTree repo")

--- a/pkg/services/repostore/pulpstore.go
+++ b/pkg/services/repostore/pulpstore.go
@@ -14,7 +14,7 @@ import (
 )
 
 // PulpRepoStore imports an OSTree repo into a Pulp repository
-func PulpRepoStore(ctx context.Context, orgID string, edgeRepoID uint,
+func PulpRepoStore(ctx context.Context, orgID string, imagesetID uint,
 	imageBuilderTarURL string, pulpParentID string, pulpParentURL string,
 	pulpParentRef string) (string, string, error) {
 	// create a pulp service with a pre-defined name
@@ -59,7 +59,9 @@ func PulpRepoStore(ctx context.Context, orgID string, edgeRepoID uint,
 		).Info("Existing repo updated with a new commit")
 	} else {
 		// create a Pulp OSTree repository
-		repoName := fmt.Sprintf("repo-%s-%d", orgID, edgeRepoID)
+		repoName := fmt.Sprintf("repo-%s-%d", orgID, imagesetID)
+
+		log.WithContext(ctx).WithField("repo_name", repoName).Debug("Creating pulp ostree repo")
 
 		distBaseURL, pulpHref, err = createOSTreeRepository(ctx, pserv, orgID, repoName)
 		if err != nil {


### PR DESCRIPTION
# Description
The backing store Pulp repo should be named using the Edge API  imageset ID instead of Edge API repo ID.

Context: The Edge API Imageset is equivalent to a Pulp repo and references multiple Images which are equivalent to a Version in Pulp ostree repo speak and equivalent to a commit in OSTree speak. So the repo containing all commits/versions/images should reflect the Imageset ID.

FIXES: HMS-5554

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
