### PR TITLE
remove pulp test vars from deployment

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -28,30 +28,6 @@ objects:
     name: edge-pulp-password
   stringData:
     key: ${PULP_PASSWORD}
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    name: edge-pulp-test-s3
-  stringData:
-    region: ${PULP_S3_REGION}
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    name: edge-pulp-test-s3
-  stringData:
-    bucketname: ${PULP_S3_BUCKETNAME}
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    name: edge-pulp-test-s3
-  stringData:
-    accesskey: ${PULP_S3_ACCESSKEY}
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    name: edge-pulp-test-s3
-  stringData:
-    secretkey: ${PULP_S3_SECRETKEY}
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:
@@ -170,26 +146,6 @@ objects:
               key: key
         - name : PULP_CONTENT_URL
           value: ${PULP_CONTENT_URL}
-        - name : PULP_S3_REGION
-          valueFrom:
-            secretKeyRef:
-              name: edge-pulp-test-s3
-              key: region
-        - name : PULP_S3_BUCKETNAME
-          valueFrom:
-            secretKeyRef:
-              name: edge-pulp-test-s3
-              key: bucketname
-        - name : PULP_S3_ACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: edge-pulp-test-s3
-              key: accesskey
-        - name : PULP_S3_SECRETKEY
-          valueFrom:
-            secretKeyRef:
-              name: edge-pulp-test-s3
-              key: secretkey
         - name : PULP_GUARD_SUBJECT_DN
           value: ${PULP_GUARD_SUBJECT_DN}
         resources:


### PR DESCRIPTION
# Description
Remove Pulp integration test vars

FIXES: <!-- THEEDGE-NNNN -->

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->
