### PR TITLE
RHINENG-19389: add 9.6 to allowed distros

### DIFF
--- a/config/repo_config.go
+++ b/config/repo_config.go
@@ -18,9 +18,10 @@ const distRHEL92 = "rhel-92"
 const distRHEL93 = "rhel-93"
 const distRHEL94 = "rhel-94"
 const distRHEL95 = "rhel-95"
+const distRHEL96 = "rhel-96"
 
 // DefaultDistribution set the default image distribution in case miss it
-const DefaultDistribution = distRHEL90
+const DefaultDistribution = distRHEL96
 
 // ostree ref for supported distributions
 const OstreeRefRHEL8 = "rhel/8/x86_64/edge"
@@ -44,34 +45,36 @@ var RHEL9 = []string{"ansible-core"}
 
 // DistributionsPackages add packages by image
 var DistributionsPackages = map[string][]string{
-	distRHEL84: RHEL8,
-	distRHEL85: RHEL8,
-	distRHEL86: RHEL8X,
-	distRHEL87: RHEL8X,
-	distRHEL88: RHEL8X,
-	distRHEL89: RHEL8X,
+	distRHEL84:  RHEL8,
+	distRHEL85:  RHEL8,
+	distRHEL86:  RHEL8X,
+	distRHEL87:  RHEL8X,
+	distRHEL88:  RHEL8X,
+	distRHEL89:  RHEL8X,
 	distRHEL810: RHEL8X,
-	distRHEL90: RHEL9,
-	distRHEL91: RHEL9,
-	distRHEL92: RHEL9,
-	distRHEL93: RHEL9,
-	distRHEL94: RHEL9,
-	distRHEL95: RHEL9,
+	distRHEL90:  RHEL9,
+	distRHEL91:  RHEL9,
+	distRHEL92:  RHEL9,
+	distRHEL93:  RHEL9,
+	distRHEL94:  RHEL9,
+	distRHEL95:  RHEL9,
+	distRHEL96:  RHEL9,
 }
 
 // DistributionsRefs set the ref to Images
 var DistributionsRefs = map[string]string{
-	distRHEL84: OstreeRefRHEL8,
-	distRHEL85: OstreeRefRHEL8,
-	distRHEL86: OstreeRefRHEL8,
-	distRHEL87: OstreeRefRHEL8,
-	distRHEL88: OstreeRefRHEL8,
-	distRHEL89: OstreeRefRHEL8,
+	distRHEL84:  OstreeRefRHEL8,
+	distRHEL85:  OstreeRefRHEL8,
+	distRHEL86:  OstreeRefRHEL8,
+	distRHEL87:  OstreeRefRHEL8,
+	distRHEL88:  OstreeRefRHEL8,
+	distRHEL89:  OstreeRefRHEL8,
 	distRHEL810: OstreeRefRHEL8,
-	distRHEL90: OstreeRefRHEL9,
-	distRHEL91: OstreeRefRHEL9,
-	distRHEL92: OstreeRefRHEL9,
-	distRHEL93: OstreeRefRHEL9,
-	distRHEL94: OstreeRefRHEL9,
-	distRHEL95: OstreeRefRHEL9,
+	distRHEL90:  OstreeRefRHEL9,
+	distRHEL91:  OstreeRefRHEL9,
+	distRHEL92:  OstreeRefRHEL9,
+	distRHEL93:  OstreeRefRHEL9,
+	distRHEL94:  OstreeRefRHEL9,
+	distRHEL95:  OstreeRefRHEL9,
+	distRHEL96:  OstreeRefRHEL9,
 }


### PR DESCRIPTION
# Description
Add 9.6 to allowed versions

FIXES: RHINENG-19389

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->

## Summary by Sourcery

Introduce support for RHEL 9.6 by defining a new distribution constant, adding it to the package and ostree reference mappings, and updating the default distribution to rhel-96.

New Features:
- Add RHEL 9.6 as a supported distribution constant
- Include rhel-96 in the distributions-to-packages mapping
- Include rhel-96 in the distributions-to-ostree refs mapping

Enhancements:
- Bump the default distribution to rhel-96