### PR TITLE
rhineng-19446: change rhel96 to rhel9.6

### DIFF
--- a/config/repo_config.go
+++ b/config/repo_config.go
@@ -18,7 +18,7 @@ const distRHEL92 = "rhel-92"
 const distRHEL93 = "rhel-93"
 const distRHEL94 = "rhel-94"
 const distRHEL95 = "rhel-95"
-const distRHEL96 = "rhel-96"
+const distRHEL96 = "rhel-9.6"
 
 // DefaultDistribution set the default image distribution in case miss it
 const DefaultDistribution = distRHEL96


### PR DESCRIPTION
# Description
Change rhel96 to rhel9.6 per Image Builder change

FIXES: RHINENG-19446

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->

## Summary by Sourcery

Enhancements:
- Use 'rhel-9.6' identifier for RHEL 9.6 instead of 'rhel-96' as the default distribution constant