### PR TITLE
HMS 8867 pkg no exist 2

### DIFF
--- a/pkg/clients/imagebuilder/client.go
+++ b/pkg/clients/imagebuilder/client.go
@@ -656,7 +656,12 @@ func (c *Client) SearchPackage(packageName string, arch string, dist string) (*m
 
 	// build the correct URL using the package name
 	url := fmt.Sprintf("%s/api/image-builder/v1/packages?distribution=%s&architecture=%s&search=%s", cfg.ImageBuilderConfig.URL, dist, arch, url.QueryEscape(packageName))
-	c.log.WithField("package", packageName).Info("Searching image builder for rhel package")
+	c.log.WithFields(log.Fields{
+		"package": packageName,
+		"url":     url,
+		"dist":    dist,
+		"arch":    arch,
+	}).Info("Searching image builder for rhel package")
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/pkg/services/repobuilder_test.go
+++ b/pkg/services/repobuilder_test.go
@@ -142,7 +142,10 @@ var _ = Describe("RepoBuilder Service Test", func() {
 		var mockFilesService *mock_services.MockFilesService
 		var mockDownloaderService *mock_services.MockDownloader
 		var downloadService services.RepoBuilder
-		var fileURL = "https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/bear-4.1-1.noarch.rpm"
+		// FIXME: this needs to be mock'd instead of using a live URL
+		// var fileURL = "https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/bear-4.1-1.noarch.rpm"
+		var fileURL = "https://www.fedorapeople.org"
+
 		var fileDest = "/tmp/download/"
 		var fileName = "repo.tar"
 		BeforeEach(func() {


### PR DESCRIPTION
# Description
Add additional logging enhancements and replace the broken test URL with a temp URL

FIXES: HMS-8867

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->

## Summary by Sourcery

Enhance structured logging in the ImageBuilder client and ImageService for better context and replace a broken test URL with a temporary one

Enhancements:
- Add structured log entries for package searches, error responses, and validation failures in the ImageBuilder client and ImageService

Tests:
- Update repobuilder_test.go to use a temporary URL instead of the broken RPM URL