### PR TITLE
add example image build blueprints

### DIFF
--- a/examples/example_request_compose_create.json
+++ b/examples/example_request_compose_create.json
@@ -1,0 +1,33 @@
+{
+    "image_name": "${IMAGE_NAME}",
+    "customizations": {
+        "packages": [
+            "rhc",
+            "rhc-worker-playbook",
+            "subscription-manager",
+            "subscription-manager-plugin-ostree",
+            "insights-client",
+            "ansible-core"
+        ],
+        "payload_repositories": [],
+        "subscription": {
+            "organization": ${ORG_ID_NUMBER},
+            "activation-key": "${ACTIVATION_KEY}",
+            "base-url": "https://cdn.redhat.com/",
+            "server-url": "subscription.rhsm.redhat.com",
+            "insights": true,
+            "rhc": true
+        }
+    },
+    "distribution": "rhel-9.6",
+    "image_requests": [
+        {
+            "architecture": "x86_64",
+            "image_type": "rhel-edge-commit",
+            "upload_request": {
+                "options": {},
+                "type": "aws.s3"
+            }
+        }
+    ]
+}

--- a/examples/example_request_compose_update.json
+++ b/examples/example_request_compose_update.json
@@ -1,0 +1,37 @@
+{
+    "image_name": "${IMAGE_NAME}",
+    "customizations": {
+        "packages": [
+            "rhc",
+            "rhc-worker-playbook",
+            "subscription-manager",
+            "subscription-manager-plugin-ostree",
+            "insights-client",
+            "ansible-core"
+        ],
+        "payload_repositories": [],
+        "subscription": {
+            "organization": ${ORG_ID_NUMBER},
+            "activation-key": "${ACTIVATION_KEY}",
+            "base-url": "https://cdn.redhat.com/",
+            "server-url": "subscription.rhsm.redhat.com",
+            "insights": true,
+            "rhc": true
+        }
+    },
+    "distribution": "rhel-9.6",
+    "image_requests": [
+        {
+            "architecture": "x86_64",
+            "image_type": "rhel-edge-commit",
+            "ostree": {
+                "url": "${URL_TO_PARENT_OSTREE_REPO}",
+                "ref": "rhel/9/x86_64/edge"
+            },
+            "upload_request": {
+                "options": {},
+                "type": "aws.s3"
+            }
+        }
+    ]
+}

--- a/examples/example_request_installer.json
+++ b/examples/example_request_installer.json
@@ -1,0 +1,45 @@
+{
+    "image_name": "${IMAGE_NAME}",
+    "customizations": {
+        "installer": {
+            "sudo-nopasswd": [
+                "%wheel"
+            ],
+            "unattended": true
+        },
+        "packages": [],
+        "users": [
+            {
+                "groups": [
+                    "wheel"
+                ],
+                "name": "${ADMIN_USERNAME}",
+                "ssh_key": "${PUBLIC_SSH_KEY}"
+            }
+        ],
+        "subscription": {
+            "organization": ${ORG_ID_NUMBER},
+            "activation-key": "${ACTIVATION_KEY}",
+            "base-url": "https://cdn.redhat.com/",
+            "server-url": "subscription.rhsm.redhat.com",
+            "insights": true,
+            "rhc": true
+        }
+    },
+    "distribution": "rhel-9.6",
+    "image_requests": [
+        {
+            "architecture": "x86_64",
+            "image_type": "rhel-edge-installer",
+            "ostree": {
+                "url": "${OSTREE_REPO_URL}",
+                "contenturl": "${OSTREE_REPO_URL}",
+                "ref": ""
+            },
+            "upload_request": {
+                "options": {},
+                "type": "aws.s3"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
# Description
Providing image build templates for create commit, update commit, and ISO create

JSON formatting error can be ignored. It is expecting a number where there is a variable.

FIXES: HMS-8996

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Tests update
- [ ] Refactor

<!--
# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I run `make pre-commit` to check fmt/vet/lint/test-no-fdo
-->

## Summary by Sourcery

Add example JSON blueprints for image compose creation, compose update, and installer ISO requests

Documentation:
- Include example_request_compose_create.json as a template for compose creation requests
- Include example_request_compose_update.json as a template for compose update requests
- Include example_request_installer.json as a template for installer ISO requests